### PR TITLE
快速模式可配置

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AstrBot Gemini 图像生成插件 v1.7.3
+# AstrBot Gemini 图像生成插件 v1.7.4
 
 <div align="center">
 
@@ -115,6 +115,10 @@
 - `force_resolution`：强制传 `image_size` 参数给模型，默认 false。
 - `resolution_param_name`：**自定义分辨率参数名**，不同 API 可能使用不同字段名（如 `image_size`、`size`、`resolution`），默认 `image_size`。
 - `aspect_ratio_param_name`：**自定义长宽比参数名**，不同 API 可能使用不同字段名（如 `aspect_ratio`、`aspectRatio`、`image_aspect_ratio`），默认 `aspect_ratio`。
+
+**quick_mode_settings**
+- 可选：覆盖 `快速` 指令各模式的默认分辨率/长宽比；默认值即内置默认，可直接修改。
+- 覆盖项（每个模式下都有 `resolution` / `aspect_ratio` 两个字段）：`avatar`/`poster`/`wallpaper`/`card`/`mobile`/`figure`/`sticker`。
 
 **retry_settings**
 - `max_attempts_per_key`：每个密钥的最大重试次数，默认 3。

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -128,6 +128,229 @@
       }
     }
   },
+  "quick_mode_settings": {
+    "description": "快速模式参数覆盖",
+    "type": "object",
+    "hint": "可选：覆盖“快速”指令各模式的默认分辨率/长宽比；默认值即内置默认，可直接修改。",
+    "items": {
+      "avatar": {
+        "description": "头像模式覆盖",
+        "type": "object",
+        "hint": "对应命令：快速 头像",
+        "items": {
+          "resolution": {
+            "description": "分辨率（覆盖）",
+            "type": "string",
+            "hint": "默认即内置默认，可按需修改",
+            "default": "1K",
+            "options": [
+              "1K",
+              "2K",
+              "4K"
+            ]
+          },
+          "aspect_ratio": {
+            "description": "长宽比（覆盖）",
+            "type": "string",
+            "hint": "默认即内置默认，可按需修改",
+            "default": "1:1",
+            "options": [
+              "1:1",
+              "16:9",
+              "4:3",
+              "3:2",
+              "9:16",
+              "4:5",
+              "5:4",
+              "21:9",
+              "3:4",
+              "2:3"
+            ]
+          }
+        }
+      },
+      "poster": {
+        "description": "海报模式覆盖",
+        "type": "object",
+        "hint": "对应命令：快速 海报",
+        "items": {
+          "resolution": {
+            "description": "分辨率（覆盖）",
+            "type": "string",
+            "hint": "默认即内置默认，可按需修改",
+            "default": "2K",
+            "options": [
+              "1K",
+              "2K",
+              "4K"
+            ]
+          },
+          "aspect_ratio": {
+            "description": "长宽比（覆盖）",
+            "type": "string",
+            "hint": "默认即内置默认，可按需修改",
+            "default": "16:9",
+            "options": [
+              "1:1",
+              "16:9",
+              "4:3",
+              "3:2",
+              "9:16",
+              "4:5",
+              "5:4",
+              "21:9",
+              "3:4",
+              "2:3"
+            ]
+          }
+        }
+      },
+      "wallpaper": {
+        "description": "壁纸模式覆盖",
+        "type": "object",
+        "hint": "对应命令：快速 壁纸",
+        "items": {
+          "resolution": {
+            "description": "分辨率（覆盖）",
+            "type": "string",
+            "hint": "默认即内置默认，可按需修改",
+            "default": "4K",
+            "options": [
+              "1K",
+              "2K",
+              "4K"
+            ]
+          },
+          "aspect_ratio": {
+            "description": "长宽比（覆盖）",
+            "type": "string",
+            "hint": "默认即内置默认，可按需修改",
+            "default": "16:9",
+            "options": [
+              "1:1",
+              "16:9",
+              "4:3",
+              "3:2",
+              "9:16",
+              "4:5",
+              "5:4",
+              "21:9",
+              "3:4",
+              "2:3"
+            ]
+          }
+        }
+      },
+      "card": {
+        "description": "卡片模式覆盖",
+        "type": "object",
+        "hint": "对应命令：快速 卡片",
+        "items": {
+          "resolution": {
+            "description": "分辨率（覆盖）",
+            "type": "string",
+            "hint": "默认即内置默认，可按需修改",
+            "default": "1K",
+            "options": [
+              "1K",
+              "2K",
+              "4K"
+            ]
+          },
+          "aspect_ratio": {
+            "description": "长宽比（覆盖）",
+            "type": "string",
+            "hint": "默认即内置默认，可按需修改",
+            "default": "3:2",
+            "options": [
+              "1:1",
+              "16:9",
+              "4:3",
+              "3:2",
+              "9:16",
+              "4:5",
+              "5:4",
+              "21:9",
+              "3:4",
+              "2:3"
+            ]
+          }
+        }
+      },
+      "mobile": {
+        "description": "手机模式覆盖",
+        "type": "object",
+        "hint": "对应命令：快速 手机",
+        "items": {
+          "resolution": {
+            "description": "分辨率（覆盖）",
+            "type": "string",
+            "hint": "默认即内置默认，可按需修改",
+            "default": "2K",
+            "options": [
+              "1K",
+              "2K",
+              "4K"
+            ]
+          },
+          "aspect_ratio": {
+            "description": "长宽比（覆盖）",
+            "type": "string",
+            "hint": "默认即内置默认，可按需修改",
+            "default": "9:16",
+            "options": [
+              "1:1",
+              "16:9",
+              "4:3",
+              "3:2",
+              "9:16",
+              "4:5",
+              "5:4",
+              "21:9",
+              "3:4",
+              "2:3"
+            ]
+          }
+        }
+      },
+      "figure": {
+        "description": "手办化模式覆盖",
+        "type": "object",
+        "hint": "对应命令：快速 手办化",
+        "items": {
+          "resolution": {
+            "description": "分辨率（覆盖）",
+            "type": "string",
+            "hint": "默认即内置默认，可按需修改",
+            "default": "2K",
+            "options": [
+              "1K",
+              "2K",
+              "4K"
+            ]
+          },
+          "aspect_ratio": {
+            "description": "长宽比（覆盖）",
+            "type": "string",
+            "hint": "默认即内置默认，可按需修改",
+            "default": "3:2",
+            "options": [
+              "1:1",
+              "16:9",
+              "4:3",
+              "3:2",
+              "9:16",
+              "4:5",
+              "5:4",
+              "21:9",
+              "3:4",
+              "2:3"
+            ]
+          }
+        }
+      }
+    }
+  },
   "retry_settings": {
     "description": "重试设置",
     "type": "object",

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,6 @@
 name: astrbot_plugin_gemini_image_generation
 desc: Gemini图像生成插件，支持生图和改图，支持自动获取头像作为参考
 display_name: Gemini 图像生成
-version: v1.7.3
+version: v1.7.4
 author: piexian
 repo: https://github.com/piexian/astrbot_plugin_gemini_image_generation


### PR DESCRIPTION
## Summary by Sourcery

Make quick image generation modes configurable via the plugin config and bump the plugin version.

New Features:
- Allow overriding default resolution and aspect ratio for each quick mode (avatar, poster, wallpaper, card, mobile, figure, sticker) via quick_mode_settings in the config.

Enhancements:
- Apply configured quick mode overrides when resolving parameters in quick mode handlers.
- Document the new quick_mode_settings configuration section in the README and update the displayed version to v1.7.4.

Build:
- Bump plugin metadata version to v1.7.4.