### PR TITLE
feat: 添加 GLM(智谱AI) 和 WhatAI API 供应商支持

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# AstrBot Gemini 图像生成插件 v1.7.5
+# AstrBot Gemini 图像生成插件 v2.0.0
 
 <div align="center">
 
-![Version](https://img.shields.io/badge/Version-v1.7.5-blue)
+![Version](https://img.shields.io/badge/Version-v2.0.0-blue)
 ![License](https://img.shields.io/badge/License-MIT-orange)
 
 </div>
@@ -10,6 +10,27 @@
 **🎨 强大的 Gemini 图像生成插件，支持智能头像参考和智能表情包切分**
 
 </div>
+
+## 🆕 v2.0.0 更新内容
+
+### 新增 API 供应商支持
+- **GLM（智谱AI CogView）**: 支持智谱 AI 的 CogView-4 系列图像生成模型
+- **WhatAI**: 支持 WhatAI 图像编辑接口（multipart/form-data 格式）
+
+### 自定义 API 配置
+- 现在可以不选择 AstrBot 提供商，直接手动配置 API
+- 新增 `custom_api_base` 配置项：自定义 API 端点地址
+- 新增 `custom_api_key` 配置项：自定义 API 密钥（支持多个，逗号分隔）
+
+### 支持的 API 类型
+| API 类型 | 说明 |
+|---------|------|
+| `google` | Google Gemini 官方 API |
+| `openai` | OpenAI 兼容格式 API |
+| `zai` | Zai 兼容参数传递 |
+| `grok2api` | Grok2API（支持相对路径图片） |
+| `glm` | 智谱 AI CogView 接口 |
+| `whatai` | WhatAI 图像编辑接口 |
 
 ## ✨ 特性
 
@@ -98,9 +119,17 @@
 ### 配置项详解
 
 **api_settings**
-- `provider_id`：必填，从 AstrBot 提供商中选择生图模型。
-- `api_type`：可选，覆盖提供商类型（google/openai/zai/grok2api）。选择 `zai` 时启用 Zai 兼容参数传递（顶层分辨率/比例 + generation_config）；选择 `grok2api` 时支持相对路径图片与临时缓存图片的自动下载落盘。
+- `provider_id`：可选，从 AstrBot 提供商中选择生图模型。若不选择，可使用下方自定义配置。
+- `api_type`：必选，API 类型（google/openai/zai/grok2api/glm/whatai）。
+  - `google`：Google Gemini 官方 API
+  - `openai`：OpenAI 兼容格式 API
+  - `zai`：启用 Zai 兼容参数传递
+  - `grok2api`：支持相对路径图片与临时缓存图片的自动下载
+  - `glm`：智谱 AI CogView 图像生成接口
+  - `whatai`：WhatAI 图像编辑接口（multipart/form-data）
 - `model`：可选，覆盖提供商模型名称。
+- `custom_api_base`：可选，自定义 API 端点地址（不选择提供商时使用）。
+- `custom_api_key`：可选，自定义 API 密钥，支持多个密钥用逗号分隔（不选择提供商时使用）。
 - `vision_provider_id`：可选，切图前调用视觉模型识别网格行列；留空则跳过 AI 识别。
 
 **image_generation_settings**

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -5,28 +5,42 @@
     "hint": "配置 API 端点和相关设置",
     "items": {
       "provider_id": {
-        "description": "生图模型提供商（必选）",
+        "description": "生图模型提供商（可选）",
         "type": "string",
-        "hint": "从 AstrBot 提供商列表中选择，插件自动读取模型/密钥/端点；不选将无法调用",
+        "hint": "从 AstrBot 提供商列表中选择，插件自动读取模型/密钥/端点；若不选择，可在下方手动配置自定义 API",
         "_special": "select_provider",
         "default": ""
       },
       "api_type": {
         "description": "API 类型（必选）",
         "type": "string",
-        "hint": "必须选择 API 类型（google/openai/zai/grok2api）。选择 zai 时使用 Zai 兼容参数传递；选择 grok2api 时启用图片相对路径/临时缓存兼容",
+        "hint": "必须选择 API 类型（google/openai/zai/grok2api/glm/whatai）。选择 zai 时使用 Zai 兼容参数传递；选择 grok2api 时启用图片相对路径/临时缓存兼容；选择 glm 时使用智谱 AI CogView 接口；选择 whatai 时使用 WhatAI 图像编辑接口",
         "default": "openai",
         "options": [
           "google",
           "openai",
           "zai",
-          "grok2api"
+          "grok2api",
+          "glm",
+          "whatai"
         ]
       },
       "model": {
         "description": "模型名称（可选）",
         "type": "string",
         "hint": "如需覆盖 AstrBot 提供商的模型，可在此填写。例如 gemini-3-pro-image-preview 或 OpenAI 兼容模型名。留空使用提供商默认模型",
+        "default": ""
+      },
+      "custom_api_base": {
+        "description": "自定义 API Base URL（可选）",
+        "type": "string",
+        "hint": "当不选择提供商时，需手动填写 API 端点地址。例如 https://api.openai.com/v1 或 https://open.bigmodel.cn/api/paas/v4 或 https://api.whatai.cc/v1（无需填写完整路径，插件会自动补全）",
+        "default": ""
+      },
+      "custom_api_key": {
+        "description": "自定义 API Key（可选）",
+        "type": "string",
+        "hint": "当不选择提供商时，需手动填写 API 密钥。支持填写多个密钥，用英文逗号分隔",
         "default": ""
       },
       "vision_provider_id": {

--- a/tl/api/base.py
+++ b/tl/api/base.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Protocol
 
 import aiohttp
@@ -18,6 +18,10 @@ class ProviderRequest:
     url: str
     headers: dict[str, str]
     payload: dict[str, Any]
+    # 请求类型：json（默认）或 multipart
+    request_type: str = "json"
+    # multipart 请求时使用的 FormData（仅当 request_type == "multipart" 时有效）
+    form_data: aiohttp.FormData | None = None
 
 
 class ApiProvider(Protocol):

--- a/tl/api/glm.py
+++ b/tl/api/glm.py
@@ -1,0 +1,197 @@
+"""GLM（智谱AI）CogView 图像生成供应商实现。
+
+用于调用智谱 AI 的 CogView 系列模型进行图像生成。
+API 文档: https://open.bigmodel.cn/dev/api/image/cogview
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import aiohttp
+
+from astrbot.api import logger
+
+from ..api_types import APIError, ApiRequestConfig
+from ..tl_utils import save_base64_image
+from .base import ProviderRequest
+
+
+class GLMProvider:
+    """GLM（智谱AI）CogView 图像生成供应商。
+
+    支持 CogView-4 等系列模型，采用智谱 AI 专有 API 格式。
+    """
+
+    name = "glm"
+
+    # GLM CogView API 默认端点
+    GLM_API_BASE = "https://open.bigmodel.cn/api/paas/v4"
+    DEFAULT_MODEL = "cogView-4-250304"
+
+    # 尺寸映射：将通用尺寸映射到 GLM 支持的格式
+    SIZE_MAPPING = {
+        # 1:1 比例
+        "1K": "1024x1024",
+        "1024x1024": "1024x1024",
+        "512x512": "512x512",
+        "768x768": "768x768",
+        # 16:9 比例
+        "1920x1080": "1920x1080",
+        "1280x720": "1280x720",
+        # 9:16 比例
+        "1080x1920": "1080x1920",
+        "720x1280": "720x1280",
+        # 4:3 比例
+        "1024x768": "1024x768",
+        # 3:4 比例
+        "768x1024": "768x1024",
+        # 其他常见尺寸
+        "2K": "2048x2048",
+        "2048x2048": "2048x2048",
+    }
+
+    # 长宽比到尺寸的映射
+    ASPECT_RATIO_MAPPING = {
+        "1:1": "1024x1024",
+        "16:9": "1920x1080",
+        "9:16": "1080x1920",
+        "4:3": "1024x768",
+        "3:4": "768x1024",
+        "3:2": "1536x1024",
+        "2:3": "1024x1536",
+    }
+
+    async def build_request(
+        self, *, client: Any, config: ApiRequestConfig
+    ) -> ProviderRequest:  # noqa: ANN401
+        """构建 GLM CogView API 请求。"""
+        api_base = (config.api_base or "").rstrip("/")
+        if not api_base:
+            api_base = self.GLM_API_BASE
+
+        url = f"{api_base}/images/generations"
+        logger.debug(f"GLM CogView API URL: {url}")
+
+        # 确定模型
+        model = config.model or self.DEFAULT_MODEL
+
+        # 确定尺寸
+        size = self._resolve_size(config)
+
+        # 构建请求体
+        payload: dict[str, Any] = {
+            "model": model,
+            "prompt": config.prompt,
+        }
+
+        if size:
+            payload["size"] = size
+
+        # 构建请求头
+        headers = {
+            "Authorization": f"Bearer {config.api_key}",
+            "Content-Type": "application/json",
+        }
+
+        logger.debug(f"GLM CogView 请求 payload: model={model}, size={size}")
+        return ProviderRequest(url=url, headers=headers, payload=payload)
+
+    def _resolve_size(self, config: ApiRequestConfig) -> str | None:
+        """解析并映射图像尺寸。"""
+        # 优先使用 resolution
+        if config.resolution:
+            resolution = config.resolution.strip()
+            if resolution in self.SIZE_MAPPING:
+                return self.SIZE_MAPPING[resolution]
+            # 如果是有效的 WxH 格式，直接使用
+            if "x" in resolution.lower():
+                return resolution.lower()
+            logger.debug(f"未知分辨率 '{resolution}'，使用默认 1024x1024")
+            return "1024x1024"
+
+        # 其次使用 aspect_ratio
+        if config.aspect_ratio:
+            aspect = config.aspect_ratio.strip()
+            if aspect in self.ASPECT_RATIO_MAPPING:
+                return self.ASPECT_RATIO_MAPPING[aspect]
+            logger.debug(f"未知长宽比 '{aspect}'，使用默认 1024x1024")
+            return "1024x1024"
+
+        # 默认尺寸
+        return "1024x1024"
+
+    async def parse_response(
+        self,
+        *,
+        client: Any,
+        response_data: dict[str, Any],
+        session: aiohttp.ClientSession,
+        api_base: str | None = None,
+    ) -> tuple[list[str], list[str], str | None, str | None]:  # noqa: ANN401
+        """解析 GLM CogView API 响应。
+
+        GLM CogView 响应格式:
+        {
+            "created": 1234567890,
+            "data": [
+                {"url": "https://..."}
+            ]
+        }
+
+        返回: (image_urls, image_paths, text_content, finish_reason)
+        """
+        image_urls: list[str] = []
+        image_paths: list[str] = []
+        text_content: str | None = None
+        finish_reason: str | None = None
+
+        # 检查错误响应
+        if "error" in response_data:
+            error_info = response_data["error"]
+            error_msg = error_info.get("message", str(error_info))
+            raise APIError(f"GLM API 错误: {error_msg}")
+
+        # 解析 data 数组
+        data_list = response_data.get("data", [])
+        if not data_list:
+            logger.warning("GLM CogView 响应中没有图像数据")
+            return image_urls, image_paths, text_content, finish_reason
+
+        for idx, item in enumerate(data_list):
+            # 处理 URL 格式
+            if "url" in item:
+                url = item["url"]
+                if url:
+                    image_urls.append(url)
+                    logger.debug(f"GLM CogView 图像 URL [{idx}]: {url[:80]}...")
+
+                    # 下载图像
+                    try:
+                        _, image_path = await client._download_image(
+                            url, session, use_cache=True
+                        )
+                        if image_path:
+                            image_paths.append(image_path)
+                            logger.debug(f"GLM CogView 图像已下载: {image_path}")
+                    except Exception as e:
+                        logger.warning(f"GLM CogView 图像下载失败: {e}")
+
+            # 处理 base64 格式（如果有）
+            elif "b64_json" in item:
+                b64_data = item["b64_json"]
+                if b64_data:
+                    try:
+                        image_path = await save_base64_image(b64_data, "png")
+                        if image_path:
+                            image_paths.append(image_path)
+                            logger.debug(f"GLM CogView base64 图像已保存: {image_path}")
+                    except Exception as e:
+                        logger.warning(f"GLM CogView base64 图像保存失败: {e}")
+
+        # 检查 revised_prompt（如果有）
+        if data_list and "revised_prompt" in data_list[0]:
+            text_content = data_list[0]["revised_prompt"]
+
+        return image_urls, image_paths, text_content, finish_reason

--- a/tl/api/registry.py
+++ b/tl/api/registry.py
@@ -8,14 +8,18 @@ from __future__ import annotations
 from typing import Final
 
 from .base import ApiProvider
+from .glm import GLMProvider
 from .google import GoogleProvider
 from .grok2api import Grok2ApiProvider
 from .openai_compat import OpenAICompatProvider
+from .whatai import WhatAIProvider
 from .zai import ZaiProvider
 
+_GLM: Final[GLMProvider] = GLMProvider()
 _GOOGLE: Final[GoogleProvider] = GoogleProvider()
 _GROK2API: Final[Grok2ApiProvider] = Grok2ApiProvider()
 _OPENAI: Final[OpenAICompatProvider] = OpenAICompatProvider()
+_WHATAI: Final[WhatAIProvider] = WhatAIProvider()
 _ZAI: Final[ZaiProvider] = ZaiProvider()
 
 
@@ -30,6 +34,14 @@ def get_api_provider(api_type: str | None) -> ApiProvider:
     """
     normalized_raw = (api_type or "").strip().lower()
     normalized = normalized_raw.replace("-", "_")
+
+    # GLM（智谱AI）供应商
+    if normalized in {"glm", "zhipu", "cogview", "bigmodel"}:
+        return _GLM
+
+    # WhatAI 供应商
+    if normalized in {"whatai", "what_ai"}:
+        return _WHATAI
 
     # Zai 独立供应商
     if normalized == "zai" or normalized.startswith("zai_"):

--- a/tl/api/whatai.py
+++ b/tl/api/whatai.py
@@ -1,0 +1,249 @@
+"""WhatAI 图像编辑供应商实现。
+
+用于调用 WhatAI 的图像编辑 API（multipart/form-data 格式）。
+API 端点: https://api.whatai.cc/v1/images/edits
+"""
+
+from __future__ import annotations
+
+import mimetypes
+import os
+from typing import Any
+
+import aiohttp
+
+from astrbot.api import logger
+
+from ..api_types import APIError, ApiRequestConfig
+from ..tl_utils import (
+    save_base64_image,
+    resolve_image_source_to_path,
+)
+from .base import ProviderRequest
+
+
+class WhatAIProvider:
+    """WhatAI 图像编辑供应商。
+
+    使用 multipart/form-data 格式发送请求，支持多张参考图片。
+    """
+
+    name = "whatai"
+
+    # WhatAI API 默认端点
+    WHATAI_API_BASE = "https://api.whatai.cc/v1"
+    DEFAULT_MODEL = "nano-banana"
+
+    # 尺寸映射
+    SIZE_MAPPING = {
+        "1K": "1K",
+        "2K": "2K",
+        "4K": "4K",
+        "1024x1024": "1K",
+        "2048x2048": "2K",
+        "4096x4096": "4K",
+    }
+
+    async def build_request(
+        self, *, client: Any, config: ApiRequestConfig
+    ) -> ProviderRequest:  # noqa: ANN401
+        """构建 WhatAI multipart/form-data 请求。"""
+        api_base = (config.api_base or "").rstrip("/")
+        if not api_base:
+            api_base = self.WHATAI_API_BASE
+
+        # 智能构建 URL：如果用户已经填写了完整路径（包含 /images/edits），则不再追加
+        if api_base.endswith("/images/edits"):
+            url = api_base
+        elif "/images/edits" in api_base:
+            # 用户可能填写了类似 https://api.whatai.cc/v1/images/edits 的完整路径
+            url = api_base
+        else:
+            url = f"{api_base}/images/edits"
+        logger.debug(f"WhatAI API URL: {url}")
+
+        # 确定模型
+        model = config.model or self.DEFAULT_MODEL
+
+        # 创建 FormData
+        form_data = aiohttp.FormData()
+
+        # 添加模型
+        form_data.add_field("model", model)
+
+        # 添加提示词
+        form_data.add_field("prompt", config.prompt)
+
+        # 添加参考图片
+        if config.reference_images:
+            for idx, image_input in enumerate(config.reference_images):
+                image_str = str(image_input).strip()
+                if not image_str:
+                    continue
+
+                try:
+                    # 尝试解析图片路径
+                    image_path = await self._resolve_image_path(client, image_str)
+                    if image_path and os.path.exists(image_path):
+                        # 获取 MIME 类型
+                        mime_type = mimetypes.guess_type(image_path)[0] or "application/octet-stream"
+                        filename = os.path.basename(image_path)
+
+                        # 读取文件内容
+                        with open(image_path, "rb") as f:
+                            image_data = f.read()
+
+                        form_data.add_field(
+                            "image",
+                            image_data,
+                            filename=filename,
+                            content_type=mime_type,
+                        )
+                        logger.debug(f"WhatAI 添加参考图片 [{idx}]: {filename}")
+                    else:
+                        logger.warning(f"WhatAI 无法解析参考图片 [{idx}]: {image_str[:50]}...")
+                except Exception as e:
+                    logger.warning(f"WhatAI 处理参考图片 [{idx}] 失败: {e}")
+
+        # 响应格式
+        form_data.add_field("response_format", "url")
+
+        # 图像尺寸
+        image_size = self._resolve_size(config)
+        if image_size:
+            form_data.add_field("image_size", image_size)
+
+        # 长宽比（如果有）
+        if config.aspect_ratio:
+            form_data.add_field("aspect_ratio", config.aspect_ratio)
+
+        # 构建请求头（不包含 Content-Type，aiohttp 会自动处理 multipart）
+        headers = {
+            "Authorization": f"Bearer {config.api_key}",
+        }
+
+        logger.debug(f"WhatAI 请求: model={model}, image_size={image_size}")
+
+        # 返回 multipart 类型的请求
+        return ProviderRequest(
+            url=url,
+            headers=headers,
+            payload={},  # multipart 请求不使用 JSON payload
+            request_type="multipart",
+            form_data=form_data,
+        )
+
+    async def _resolve_image_path(self, client: Any, image_input: str) -> str | None:
+        """解析图片输入为本地文件路径。"""
+        try:
+            # 如果已经是本地路径
+            if os.path.exists(image_input):
+                return image_input
+
+            # 尝试使用通用解析函数
+            result = await resolve_image_source_to_path(image_input)
+            if result:
+                return result
+
+            # 如果是 URL，尝试下载
+            if image_input.startswith(("http://", "https://")):
+                session = await client._get_session()
+                _, image_path = await client._download_image(
+                    image_input, session, use_cache=True
+                )
+                return image_path
+
+            return None
+        except Exception as e:
+            logger.debug(f"解析图片路径失败: {e}")
+            return None
+
+    def _resolve_size(self, config: ApiRequestConfig) -> str | None:
+        """解析并映射图像尺寸。"""
+        if config.resolution:
+            resolution = config.resolution.strip().upper()
+            if resolution in self.SIZE_MAPPING:
+                return self.SIZE_MAPPING[resolution]
+            # 如果是有效的尺寸格式，直接使用
+            if resolution in {"1K", "2K", "4K"}:
+                return resolution
+            logger.debug(f"未知分辨率 '{resolution}'，使用默认 1K")
+            return "1K"
+        return "1K"
+
+    async def parse_response(
+        self,
+        *,
+        client: Any,
+        response_data: dict[str, Any],
+        session: aiohttp.ClientSession,
+        api_base: str | None = None,
+    ) -> tuple[list[str], list[str], str | None, str | None]:  # noqa: ANN401
+        """解析 WhatAI API 响应。
+
+        WhatAI 响应格式:
+        {
+            "created": 1234567890,
+            "data": [
+                {"url": "https://..."}
+            ]
+        }
+
+        返回: (image_urls, image_paths, text_content, finish_reason)
+        """
+        image_urls: list[str] = []
+        image_paths: list[str] = []
+        text_content: str | None = None
+        finish_reason: str | None = None
+
+        # 检查错误响应
+        if "error" in response_data:
+            error_info = response_data["error"]
+            if isinstance(error_info, dict):
+                error_msg = error_info.get("message", str(error_info))
+            else:
+                error_msg = str(error_info)
+            raise APIError(f"WhatAI API 错误: {error_msg}")
+
+        # 解析 data 数组
+        data_list = response_data.get("data", [])
+        if not data_list:
+            logger.warning("WhatAI 响应中没有图像数据")
+            return image_urls, image_paths, text_content, finish_reason
+
+        for idx, item in enumerate(data_list):
+            # 处理 URL 格式
+            if "url" in item:
+                url = item["url"]
+                if url:
+                    image_urls.append(url)
+                    logger.debug(f"WhatAI 图像 URL [{idx}]: {url[:80]}...")
+
+                    # 下载图像
+                    try:
+                        _, image_path = await client._download_image(
+                            url, session, use_cache=True
+                        )
+                        if image_path:
+                            image_paths.append(image_path)
+                            logger.debug(f"WhatAI 图像已下载: {image_path}")
+                    except Exception as e:
+                        logger.warning(f"WhatAI 图像下载失败: {e}")
+
+            # 处理 base64 格式（如果有）
+            elif "b64_json" in item:
+                b64_data = item["b64_json"]
+                if b64_data:
+                    try:
+                        image_path = await save_base64_image(b64_data, "png")
+                        if image_path:
+                            image_paths.append(image_path)
+                            logger.debug(f"WhatAI base64 图像已保存: {image_path}")
+                    except Exception as e:
+                        logger.warning(f"WhatAI base64 图像保存失败: {e}")
+
+        # 检查 revised_prompt（如果有）
+        if data_list and "revised_prompt" in data_list[0]:
+            text_content = data_list[0]["revised_prompt"]
+
+        return image_urls, image_paths, text_content, finish_reason


### PR DESCRIPTION
- 新增 GLM (智谱AI CogView) 图像生成供应商
- 新增 WhatAI 图像编辑供应商 (multipart/form-data 格式)
- 支持自定义 API 配置 (custom_api_base, custom_api_key)
- 更新 README 文档至 v2.0.0

## Summary by Sourcery

Add new GLM (Zhipu AI CogView) and WhatAI image providers, support multipart/form-data requests, and enable fully custom API configuration including base and keys, while updating documentation for v2.0.0.

New Features:
- Introduce GLM (Zhipu AI CogView) image generation provider with dedicated request and response handling.
- Add WhatAI image editing provider using multipart/form-data uploads with support for multiple reference images.
- Allow using custom API base and API keys without selecting an AstrBot provider, including support for multiple keys.

Enhancements:
- Extend the core API client to support both JSON and multipart/form-data request types via a unified request pipeline.
- Refactor HTTP response handling into a shared helper to centralize parsing, error handling, and vendor-specific response processing.

Documentation:
- Update README to version 2.0.0 with new providers, custom API configuration options, and expanded supported API type list.