### PR TITLE
refactor: 清理无效参数和调试日志

### DIFF
--- a/tl/tl_api.py
+++ b/tl/tl_api.py
@@ -898,9 +898,6 @@ class GeminiAPIClient:
                         image_paths.append(image_path)
 
         if image_urls or image_paths:
-            logger.info(f"[grok2api 调试] API 返回图片数量: paths={len(image_paths)}, urls={len(image_urls)}")
-            logger.info(f"[grok2api 调试] image_urls = {image_urls}")
-            logger.info(f"[grok2api 调试] image_paths = {image_paths}")
             logger.debug(
                 f"🖼️ OpenAI 收集到 {len(image_paths) or len(image_urls)} 张图片"
             )


### PR DESCRIPTION
## 修改内容

- 移除 OpenAI 兼容 API 中的 `"n": 1` 参数
- 移除 grok2api 调试日志 (logger.info)

## 问题说明

### n=1 参数无效
- `/chat/completions` 端点的 `n` 参数控制的是**文本回复选项数量** (choices)
- 默认值就是 1，与图片生成数量完全无关
- 图片数量由模型自己决定，不是通过 API 参数控制

### grok2api 调试日志
- 原代码使用 `logger.info` 输出调试信息，在生产环境会产生大量日志
- 已改用 `logger.debug` 或直接删除

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)