### PR TITLE
fix: 修复参考图未加入请求但仍然发送的问题

### DIFF
--- a/tl/api/google.py
+++ b/tl/api/google.py
@@ -83,6 +83,10 @@ class GoogleProvider:
 
         added_refs = 0
         fail_reasons: list[str] = []
+        ref_count = len(config.reference_images or [])
+        if ref_count > 0:
+            logger.info(f"📎 开始处理 {ref_count} 张参考图片...")
+
         if config.reference_images:
             for idx, image_input in enumerate(config.reference_images[:14]):
                 image_str = str(image_input).strip()
@@ -139,6 +143,10 @@ class GoogleProvider:
                     continue
 
                 mime_type = client._ensure_mime_type(mime_type)
+                size_kb = len(validated_data) // 1024 if validated_data else 0
+                logger.info(
+                    f"📎 图片 {idx + 1}/{ref_count} 已加入发送请求 ({mime_type}, {size_kb}KB)"
+                )
                 logger.debug(
                     "[google] 成功处理参考图 idx=%s mime=%s size=%s",
                     idx,
@@ -150,6 +158,17 @@ class GoogleProvider:
                     {"inlineData": {"mimeType": mime_type, "data": validated_data}}
                 )
                 added_refs += 1
+
+        # 输出最终统计
+        if ref_count > 0:
+            if added_refs > 0:
+                logger.info(
+                    f"📎 参考图片处理完成：{added_refs}/{ref_count} 张已成功加入发送请求"
+                )
+            else:
+                logger.info(
+                    f"📎 参考图片处理完成：0/{ref_count} 张成功，全部未能加入发送请求"
+                )
 
         if config.reference_images and added_refs == 0:
             raise APIError(
@@ -337,8 +356,10 @@ class GoogleProvider:
                             )
 
                             if saved_path:
-                                image_paths.append(saved_path)
-                                image_urls.append(saved_path)
+                                if saved_path not in image_paths:
+                                    image_paths.append(saved_path)
+                                if saved_path not in image_urls:
+                                    pass  # 本地路径不加到urls
                             else:
                                 try:
                                     with tempfile.NamedTemporaryFile(
@@ -354,8 +375,11 @@ class GoogleProvider:
                                             )
                                         raw = base64.b64decode(cleaned, validate=False)
                                         tmp_file.write(raw)
-                                    image_paths.append(str(tmp_path))
-                                    image_urls.append(str(tmp_path))
+                                    tmp_path_str = str(tmp_path)
+                                    if tmp_path_str not in image_paths:
+                                        image_paths.append(tmp_path_str)
+                                    if tmp_path_str not in image_urls:
+                                        pass  # 本地路径不加到urls
                                     logger.debug(
                                         "⚠️ save_base64_image 失败，已使用宽松解码写入临时文件: %s",
                                         tmp_path,
@@ -382,7 +406,8 @@ class GoogleProvider:
                         f"处理候选 {idx} 的第 {i} 个part时出错: {e}", exc_info=True
                     )
 
-        logger.debug(f"🖼️ 共找到 {len(image_paths)} 张图片")
+        unique_count = len(set(image_urls) | set(image_paths))
+        logger.debug(f"🖼️ 共找到 {unique_count} 张图片 (urls={len(image_urls)}, paths={len(image_paths)})")
 
         if text_chunks:
             extracted_urls: list[str] = []
@@ -394,8 +419,12 @@ class GoogleProvider:
                 extracted_paths.extend(paths2)
 
             if extracted_urls or extracted_paths:
-                image_urls.extend(extracted_urls)
-                image_paths.extend(extracted_paths)
+                for url in extracted_urls:
+                    if url and url not in image_urls:
+                        image_urls.append(url)
+                for path in extracted_paths:
+                    if path and path not in image_paths:
+                        image_paths.append(path)
 
         text_content = (
             " ".join(chunk for chunk in text_chunks if chunk).strip()

--- a/tl/api/openai_compat.py
+++ b/tl/api/openai_compat.py
@@ -118,6 +118,8 @@ class OpenAICompatProvider:
         if config.reference_images:
             processed_cache: dict[str, dict[str, Any]] = {}
             total_start = time.perf_counter()
+            ref_count = len(config.reference_images)
+            logger.info(f"📎 开始处理 {ref_count} 张参考图片...")
 
             for idx, image_input in enumerate(config.reference_images[:6]):
                 per_start = time.perf_counter()
@@ -156,6 +158,9 @@ class OpenAICompatProvider:
                             "type": "image_url",
                             "image_url": {"url": image_str},
                         }
+                        logger.info(
+                            f"📎 图片 {idx + 1}/{ref_count} 已加入发送请求 (URL)"
+                        )
                         logger.debug(
                             "OpenAI兼容API使用URL参考图: idx=%s ext=%s url=%s",
                             idx,
@@ -188,6 +193,9 @@ class OpenAICompatProvider:
                                 "type": "image_url",
                                 "image_url": {"url": image_str},
                             }
+                            logger.info(
+                                f"📎 图片 {idx + 1}/{ref_count} 已加入发送请求 (data URL, {len(data_part)//1024}KB)"
+                            )
                             logger.debug(
                                 "OpenAI兼容API使用data URL参考图: idx=%s mime=%s",
                                 idx,
@@ -206,6 +214,9 @@ class OpenAICompatProvider:
                                     "invalid_reference_image",
                                 )
                             logger.warning(
+                                f"📎 图片 {idx + 1}/{ref_count} 未能加入发送请求 - 无法转换"
+                            )
+                            logger.debug(
                                 "跳过无法识别/读取的参考图像: idx=%s type=%s",
                                 idx,
                                 type(image_input),
@@ -231,6 +242,10 @@ class OpenAICompatProvider:
                             cleaned = data.strip().replace("\n", "")
                             try:
                                 base64.b64decode(cleaned, validate=True)
+                                b64_kb = len(cleaned) * 3 // 4 // 1024
+                                logger.info(
+                                    f"📎 图片 {idx + 1}/{ref_count} 已加入发送请求 (base64, {b64_kb}KB)"
+                                )
                             except Exception:
                                 raise APIError(
                                     f"参考图 base64 校验失败（force_base64），来源: idx={idx}",
@@ -258,17 +273,27 @@ class OpenAICompatProvider:
                         )
 
                 except Exception as e:
-                    logger.warning("处理参考图像时出现异常: idx=%s err=%s", idx, e)
+                    logger.warning(
+                        f"📎 图片 {idx + 1}/{ref_count} 未能加入发送请求 - {str(e)[:30]}"
+                    )
+                    logger.debug("处理参考图像时出现异常: idx=%s err=%s", idx, e)
                     continue
 
             total_elapsed_ms = (time.perf_counter() - total_start) * 1000
-            if processed_cache:
-                logger.debug(
-                    "参考图像处理统计: 总数=%s 总耗时=%.2fms 平均=%.2fms",
-                    len(processed_cache),
-                    total_elapsed_ms,
-                    total_elapsed_ms / len(processed_cache),
+            # 输出最终统计
+            success_count = len(processed_cache)
+            if success_count > 0:
+                logger.info(
+                    f"📎 参考图片处理完成：{success_count}/{ref_count} 张已成功加入发送请求"
                 )
+            else:
+                # 如果原本有参考图但全部处理失败，抛出错误
+                if config.reference_images:
+                    raise APIError(
+                        "参考图全部处理失败，可能是网络问题或格式不支持。建议：1) 检查图片链接是否可访问；2) 尝试重新发送图片；3) 使用 Google API 格式可能有更好的错误提示。",
+                        None,
+                        "invalid_reference_image",
+                    )
 
         payload: dict[str, Any] = {
             "model": config.model,
@@ -279,6 +304,7 @@ class OpenAICompatProvider:
             else 0.7,
             "modalities": ["image", "text"],
             "stream": False,
+            "n": 1,  # 确保只返回1张图片
         }
 
         _res_key = (config.resolution_param_name or "").strip()
@@ -419,7 +445,8 @@ class OpenAICompatProvider:
                     if cleaned_candidate.startswith(
                         "http://"
                     ) or cleaned_candidate.startswith("https://"):
-                        image_urls.append(cleaned_candidate)
+                        if cleaned_candidate not in image_urls:
+                            image_urls.append(cleaned_candidate)
                         logger.debug(
                             f"🖼️ OpenAI 返回可直接访问的图像链接: {cleaned_candidate}"
                         )
@@ -432,9 +459,11 @@ class OpenAICompatProvider:
                     continue
 
                 if image_url or image_path:
-                    if image_url:
-                        image_urls.append(image_url)
-                    if image_path:
+                    # image_url 可能是下载后的本地路径，只添加 http/https/data: URL
+                    if image_url and image_url not in image_urls:
+                        if image_url.startswith(("http://", "https://", "data:")):
+                            image_urls.append(image_url)
+                    if image_path and image_path not in image_paths:
                         image_paths.append(image_path)
 
             extracted_urls2: list[str] = []
@@ -512,8 +541,8 @@ class OpenAICompatProvider:
                     b64_raw = m.group(2)
                     b64_clean = re.sub(r"\\s+", "", b64_raw)
                     image_path = await save_base64_image(b64_clean, fmt.lower())
-                    if image_path:
-                        image_urls.append(image_path)
+                    if image_path and image_path not in image_paths:
+                        # image_urls.append(image_path)  # 本地路径不加到urls
                         image_paths.append(image_path)
                         logger.debug(
                             "[openai] 松散提取 data URI 成功: fmt=%s len=%s",
@@ -540,19 +569,25 @@ class OpenAICompatProvider:
                     image_url, image_path = await client._download_image(
                         image_item["url"], session, use_cache=False
                     )
-                    if image_url:
-                        image_urls.append(image_url)
-                    if image_path:
+                    # image_url 可能是下载后的本地路径，只添加 http/https/data: URL
+                    if image_url and image_url not in image_urls:
+                        if image_url.startswith(("http://", "https://", "data:")):
+                            image_urls.append(image_url)
+                    if image_path and image_path not in image_paths:
                         image_paths.append(image_path)
                 elif "b64_json" in image_item:
                     image_path = await save_base64_image(image_item["b64_json"], "png")
-                    if image_path:
-                        image_urls.append(image_path)
+                    if image_path and image_path not in image_paths:
+                        # image_urls.append(image_path)  # 本地路径不加到urls
                         image_paths.append(image_path)
-
         if image_urls or image_paths:
+            logger.info(f"🔍 收集的URLs数量: {len(image_urls)}")
+            sources_preview = ", ".join([u[:50] + "..." if len(u) > 50 else u for u in image_urls])
+            logger.info(f"🔍 image_urls来源: {sources_preview}")
+            logger.info(f"🔍 收集的Paths数量: {len(image_paths)}")
+            unique_count = len(set(image_urls) | set(image_paths))
             logger.debug(
-                f"🖼️ OpenAI 收集到 {len(image_paths) or len(image_urls)} 张图片"
+                f"🖼️ OpenAI 收集到 {unique_count} 张图片 (urls={len(image_urls)}, paths={len(image_paths)})"
             )
             return image_urls, image_paths, text_content, thought_signature
 


### PR DESCRIPTION
## 问题描述

使用 OpenAI 兼容 API 时，如果参考图处理失败（网络超时、格式不支持等），图片会被静默跳过，但请求仍然会发送给 API。这导致：

- 用户以为有参考图，实际没有
- 生成的图像与参考图无关
- 用户无法得知问题所在

## 修复内容

1. 添加明确的参考图片处理日志
2. 参考图全部处理失败时，抛出明确错误

## 日志示例

成功：
```
📎 开始处理 2 张参考图片...
📎 图片 1/2 已加入发送请求 (URL)
📎 参考图片处理完成：2/2 张已成功加入发送请求
```

失败（现在会正确报错）：
```
📎 图片 1/1 未能加入发送请求 - 无法转换
❌ 图像生成失败：参考图全部处理失败...
```

## 影响范围
- tl/api/openai_compat.py - 日志 + 失败检测
- tl/api/google.py - 日志统一

## Summary by Sourcery

Improve robustness and observability of reference image handling for OpenAI-compatible and Google image generation APIs, ensuring failed references are surfaced as errors and outputs are de-duplicated.

Bug Fixes:
- Prevent sending OpenAI-compatible image generation requests when all reference images fail processing, instead raising a clear API error.
- Avoid duplicate entries and incorrect inclusion of local file paths in the collected image URL lists for both OpenAI-compatible and Google responses.

Enhancements:
- Add detailed, user-oriented logging around reference image processing for OpenAI-compatible and Google APIs, including per-image status and final statistics.
- Ensure OpenAI-compatible image generation requests explicitly request a single output image via the payload configuration.
- Improve response parsing statistics by logging distinct counts of image URLs and paths for OpenAI-compatible and Google APIs.