### PR TITLE
fix: 改进参考图片处理日志，增加失败检测

### DIFF
--- a/tl/api/google.py
+++ b/tl/api/google.py
@@ -83,6 +83,17 @@ class GoogleProvider:
 
         added_refs = 0
         fail_reasons: list[str] = []
+        total_ref_count = len(config.reference_images or [])
+        # 实际处理的参考图数量受 [:14] 限制
+        processed_ref_count = len((config.reference_images or [])[:14])
+        if total_ref_count > 0:
+            if total_ref_count > processed_ref_count:
+                logger.info(
+                    f"📎 开始处理 {processed_ref_count} 张参考图片 (共配置 {total_ref_count} 张，最多处理 14 张)..."
+                )
+            else:
+                logger.info(f"📎 开始处理 {processed_ref_count} 张参考图片...")
+
         if config.reference_images:
             for idx, image_input in enumerate(config.reference_images[:14]):
                 image_str = str(image_input).strip()
@@ -139,6 +150,10 @@ class GoogleProvider:
                     continue
 
                 mime_type = client._ensure_mime_type(mime_type)
+                size_kb = len(validated_data) // 1024 if validated_data else 0
+                logger.info(
+                    f"📎 图片 {idx + 1}/{processed_ref_count} 已加入发送请求 ({mime_type}, {size_kb}KB)"
+                )
                 logger.debug(
                     "[google] 成功处理参考图 idx=%s mime=%s size=%s",
                     idx,
@@ -150,6 +165,17 @@ class GoogleProvider:
                     {"inlineData": {"mimeType": mime_type, "data": validated_data}}
                 )
                 added_refs += 1
+
+        # 输出最终统计
+        if processed_ref_count > 0:
+            if added_refs > 0:
+                logger.info(
+                    f"📎 参考图片处理完成：{added_refs}/{processed_ref_count} 张已成功加入发送请求"
+                )
+            else:
+                logger.info(
+                    f"📎 参考图片处理完成：0/{processed_ref_count} 张成功，全部未能加入发送请求"
+                )
 
         if config.reference_images and added_refs == 0:
             raise APIError(


### PR DESCRIPTION
## 问题描述

使用 OpenAI 兼容 API 时，如果参考图处理失败（网络超时、格式不支持等），图片会被静默跳过，但请求仍然会发送给 API。这导致：
- 用户以为有参考图，实际没有
- 生成的图像与参考图无关
- 用户无法得知问题所在

## 修复内容

1. 添加明确的参考图片处理日志
2. 参考图全部处理失败时，抛出明确错误
3. 修复参考图数量日志未考虑处理上限的问题
4. 将敏感 URL 日志降为 debug 级别

## 日志示例

成功：
```
📎 开始处理 2 张参考图片...
📎 图片 1/2 已加入发送请求 (URL)
📎 参考图片处理完成：2/2 张已成功加入发送请求
```

失败（现在会正确报错）：
```
📎 开始处理 1 张参考图片...
📎 图片 1/1 未能加入发送请求 - 无法转换
❌ 图像生成失败：参考图全部处理失败...
```

## 影响范围
- tl/api/openai_compat.py - 日志 + 失败检测
- tl/api/google.py - 日志统一

## Summary by Sourcery

Improve reference image handling and result parsing for OpenAI-compatible and Google image generation APIs, with clearer logging, stricter failure detection, and safer URL collection.

Bug Fixes:
- Detect when all reference images fail to process in the OpenAI-compatible API and surface a clear API error instead of silently proceeding.
- Fix reference image count logging to respect configured processing limits in the Google API.
- Avoid adding duplicate or local file paths to the list of returned image URLs in both OpenAI-compatible and Google response parsers.

Enhancements:
- Add structured info-level and debug-level logs around reference image processing for both OpenAI-compatible and Google APIs, including per-image status and final statistics.
- Add size and type metadata to reference image logs for easier troubleshooting.
- Ensure OpenAI-compatible image generation requests explicitly ask for a single returned image and report accurate counts of collected images in logs.
- Reduce the logging level of potentially sensitive URL details to debug while keeping high-level counts at info level.