### PR TITLE
fix: 改进参考图片处理日志，增加失败检测

### DIFF
--- a/tl/api/google.py
+++ b/tl/api/google.py
@@ -85,7 +85,7 @@ class GoogleProvider:
         fail_reasons: list[str] = []
         total_ref_count = len(config.reference_images or [])
         # 实际处理的参考图数量受 [:14] 限制
-        processed_ref_count = len((config.reference_images or [])[:14])
+        processed_ref_count = min(total_ref_count, 14)
         if total_ref_count > 0:
             if total_ref_count > processed_ref_count:
                 logger.info(

--- a/tl/api/openai_compat.py
+++ b/tl/api/openai_compat.py
@@ -118,8 +118,14 @@ class OpenAICompatProvider:
         if config.reference_images:
             processed_cache: dict[str, dict[str, Any]] = {}
             total_start = time.perf_counter()
-            ref_count = len(config.reference_images)
-            logger.info(f"📎 开始处理 {ref_count} 张参考图片...")
+            total_ref_count = len(config.reference_images)
+            processed_ref_count = min(total_ref_count, 6)
+            if total_ref_count > processed_ref_count:
+                logger.info(
+                    f"📎 开始处理 {processed_ref_count} 张参考图片 (共配置 {total_ref_count} 张，最多处理 6 张)..."
+                )
+            else:
+                logger.info(f"📎 开始处理 {processed_ref_count} 张参考图片...")
 
             for idx, image_input in enumerate(config.reference_images[:6]):
                 per_start = time.perf_counter()
@@ -158,7 +164,7 @@ class OpenAICompatProvider:
                             "type": "image_url",
                             "image_url": {"url": image_str},
                         }
-                        logger.info(f"📎 图片 {idx + 1}/{ref_count} 已加入发送请求 (URL)")
+                        logger.info(f"📎 图片 {idx + 1}/{processed_ref_count} 已加入发送请求 (URL)")
                         logger.debug(
                             "OpenAI兼容API使用URL参考图: idx=%s ext=%s url=%s",
                             idx,
@@ -191,7 +197,7 @@ class OpenAICompatProvider:
                                 "type": "image_url",
                                 "image_url": {"url": image_str},
                             }
-                            logger.info(f"📎 图片 {idx + 1}/{ref_count} 已加入发送请求 (data URL)")
+                            logger.info(f"📎 图片 {idx + 1}/{processed_ref_count} 已加入发送请求 (data URL)")
                             logger.debug(
                                 "OpenAI兼容API使用data URL参考图: idx=%s mime=%s",
                                 idx,
@@ -209,7 +215,7 @@ class OpenAICompatProvider:
                                     None,
                                     "invalid_reference_image",
                                 )
-                            logger.warning(f"📎 图片 {idx + 1}/{ref_count} 未能加入发送请求 - 无法转换")
+                            logger.warning(f"📎 图片 {idx + 1}/{processed_ref_count} 未能加入发送请求 - 无法转换")
                             logger.debug(
                                 "跳过无法识别/读取的参考图像: idx=%s type=%s",
                                 idx,
@@ -237,7 +243,7 @@ class OpenAICompatProvider:
                             try:
                                 base64.b64decode(cleaned, validate=True)
                                 b64_kb = len(cleaned) * 3 // 4 // 1024
-                                logger.info(f"📎 图片 {idx + 1}/{ref_count} 已加入发送请求 (base64, {b64_kb}KB)")
+                                logger.info(f"📎 图片 {idx + 1}/{processed_ref_count} 已加入发送请求 (base64, {b64_kb}KB)")
                             except Exception:
                                 raise APIError(
                                     f"参考图 base64 校验失败（force_base64），来源: idx={idx}",
@@ -265,22 +271,21 @@ class OpenAICompatProvider:
                         )
 
                 except Exception as e:
-                    logger.warning(f"📎 图片 {idx + 1}/{ref_count} 未能加入发送请求 - {str(e)[:30]}")
+                    logger.warning(f"📎 图片 {idx + 1}/{processed_ref_count} 未能加入发送请求 - {str(e)[:30]}")
                     logger.debug("处理参考图像时出现异常: idx=%s err=%s", idx, e)
                     continue
 
             total_elapsed_ms = (time.perf_counter() - total_start) * 1000
             success_count = len(processed_cache)
             if success_count > 0:
-                logger.info(f"📎 参考图片处理完成：{success_count}/{ref_count} 张已成功加入发送请求")
+                logger.info(f"📎 参考图片处理完成：{success_count}/{processed_ref_count} 张已成功加入发送请求")
             else:
-                # 如果原本有参考图但全部处理失败，抛出错误
-                if config.reference_images:
-                    raise APIError(
-                        "参考图全部处理失败，可能是网络问题或格式不支持。建议：1) 检查图片链接是否可访问；2) 尝试重新发送图片；3) 使用 Google API 格式可能有更好的错误提示。",
-                        None,
-                        "invalid_reference_image",
-                    )
+                # 参考图全部处理失败，抛出错误
+                raise APIError(
+                    "参考图全部处理失败，可能是网络问题或格式不支持。建议：1) 检查图片链接是否可访问；2) 尝试重新发送图片；3) 使用 Google API 格式可能有更好的错误提示。",
+                    None,
+                    "invalid_reference_image",
+                )
 
         payload: dict[str, Any] = {
             "model": config.model,


### PR DESCRIPTION
## 问题描述

使用 OpenAI 兼容 API 时，如果参考图处理失败（网络超时、格式不支持等），图片会被静默跳过，但请求仍然会发送给 API。这导致：
- 用户以为有参考图，实际没有
- 生成的图像与参考图无关
- 用户无法得知问题所在

## 修复内容

1. 添加明确的参考图片处理日志
2. 参考图全部处理失败时，抛出明确错误
3. 修复参考图数量日志未考虑处理上限的问题

## 日志示例

成功：
```
📎 开始处理 2 张参考图片...
📎 图片 1/2 已加入发送请求 (URL)
📎 参考图片处理完成：2/2 张已成功加入发送请求
```

失败（现在会正确报错）：
```
📎 开始处理 1 张参考图片...
📎 图片 1/1 未能加入发送请求 - 无法转换
❌ 图像生成失败：参考图全部处理失败...
```

## 影响范围
- tl/api/openai_compat.py - 日志 + 失败检测
- tl/api/google.py - 日志统一

## Summary by Sourcery

Improve reference image handling and error reporting for OpenAI-compatible and Google image generation APIs.

Bug Fixes:
- Detect when all configured reference images fail to process for the OpenAI-compatible API and raise a clear API error instead of silently proceeding without references.

Enhancements:
- Add user-facing, structured logging around the lifecycle of reference image processing, including counts, per-image status, and final summary for both OpenAI-compatible and Google APIs.
- Correct reference image count logging to respect processing limits and report processed versus configured images in Google API handling.
- Include basic size and type information for successfully processed reference images in logs to aid debugging.