### PR TITLE
feat:add images/generations

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -14,11 +14,12 @@
       "api_type": {
         "description": "API 类型（必选）",
         "type": "string",
-        "hint": "必须选择 API 类型（google/openai/zai/grok2api/doubao）。 不同提供商支持的类型不同，请参考提供商说明",
+        "hint": "必须选择 API 类型（google/openai/openai_images/zai/grok2api/doubao）。 不同提供商支持的类型不同，请参考提供商说明。openai_images 专门调用 /v1/images/generations 端点",
         "default": "openai",
         "options": [
           "google",
           "openai",
+          "openai_images",
           "zai",
           "grok2api",
           "doubao"
@@ -183,6 +184,42 @@
                 "description": "API 端点地址",
                 "type": "string",
                 "hint": "grok2api API 地址",
+                "default": ""
+              },
+              "proxy": {
+                "description": "代理地址",
+                "type": "string",
+                "hint": "填写即启用代理，留空使用全局代理或环境变量。支持 http://host:port、https://host:port、socks5://host:port 格式。优先级高于全局代理和环境变量",
+                "default": ""
+              }
+            }
+          },
+          "openai_images": {
+            "description": "OpenAI Images API 覆盖配置",
+            "hint": "配置 OpenAI /v1/images/generations 端点的密钥和端点",
+            "items": {
+              "api_keys": {
+                "description": "API Key 列表",
+                "type": "list",
+                "hint": "多个 API Key，支持轮换使用",
+                "default": []
+              },
+              "daily_limit_per_key": {
+                "description": "每个 Key 每日限额",
+                "type": "int",
+                "hint": "每个 API Key 每日最大调用次数，0 表示不限制",
+                "default": 0
+              },
+              "model": {
+                "description": "模型名称",
+                "type": "string",
+                "hint": "OpenAI Images API 模型名称（如 dall-e-3, dall-e-2）",
+                "default": "dall-e-3"
+              },
+              "api_base": {
+                "description": "API 端点地址",
+                "type": "string",
+                "hint": "OpenAI Images API 地址，留空使用默认 https://api.openai.com",
                 "default": ""
               },
               "proxy": {

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -14,7 +14,7 @@
       "api_type": {
         "description": "API 类型（必选）",
         "type": "string",
-        "hint": "必须选择 API 类型（google/openai/openai_images/zai/grok2api/doubao）。 不同提供商支持的类型不同，请参考提供商说明。openai_images 专门调用 /v1/images/generations 端点",
+        "hint": "必须选择 API 类型（google/openai/zai/grok2api/doubao）。 不同提供商支持的类型不同，请参考提供商说明",
         "default": "openai",
         "options": [
           "google",

--- a/main.py
+++ b/main.py
@@ -397,7 +397,8 @@ class GeminiImageGenerationPlugin(Star):
             # 代理优先级：provider_overrides > api_settings 全局 > 环境变量
             proxy_from_override = (
                 (override_settings.get("proxy") or "").strip()
-                if override_settings else ""
+                if override_settings
+                else ""
             )
             proxy_from_global = getattr(self.cfg, "proxy", None) or ""
 

--- a/tl/api/doubao.py
+++ b/tl/api/doubao.py
@@ -187,7 +187,7 @@ class DoubaoProvider:
             payload.get("size"),
             bool(payload.get("image")),
             is_retry,
-            {k: v for k, v in payload.items() if k != "image"},  
+            {k: v for k, v in payload.items() if k != "image"},
         )
         return ProviderRequest(url=url, headers=headers, payload=payload)
 

--- a/tl/api/openai_images.py
+++ b/tl/api/openai_images.py
@@ -1,0 +1,166 @@
+"""OpenAI Images API (`/v1/images/generations`) 供应商实现。
+
+用于调用标准的 OpenAI Images API 端点，如 DALL-E 系列模型。
+"""
+
+from __future__ import annotations
+
+import base64
+import time
+from pathlib import Path
+from typing import Any
+
+import aiohttp
+
+from astrbot.api import logger
+
+from ..api_types import APIError, ApiRequestConfig
+from ..tl_utils import save_base64_image
+from .base import ProviderRequest
+
+
+class OpenAIImagesProvider:
+    """OpenAI /v1/images/generations 端点实现"""
+
+    name = "openai_images"
+
+    async def build_request(
+        self, *, client: Any, config: ApiRequestConfig
+    ) -> ProviderRequest:  # noqa: ANN401
+        api_base = (config.api_base or "").rstrip("/")
+        default_base = "https://api.openai.com"
+
+        if api_base:
+            base = api_base
+            logger.debug(f"使用自定义 API Base: {base}")
+        else:
+            base = default_base
+            logger.debug(f"使用默认 API Base: {base}")
+
+        # 构建 /v1/images/generations URL
+        if base.endswith("/v1"):
+            url = f"{base}/images/generations"
+        else:
+            url = f"{base}/v1/images/generations"
+
+        payload = await self._prepare_payload(client=client, config=config)
+        headers = {
+            "Authorization": f"Bearer {config.api_key}",
+            "Content-Type": "application/json",
+        }
+        logger.debug(f"OpenAI Images API URL: {url}")
+        return ProviderRequest(url=url, headers=headers, payload=payload)
+
+    async def parse_response(
+        self,
+        *,
+        client: Any,
+        response_data: dict[str, Any],
+        session: aiohttp.ClientSession,
+        api_base: str | None = None,
+        http_status: int | None = None,
+    ) -> tuple[list[str], list[str], str | None, str | None]:  # noqa: ANN401
+        """解析 OpenAI Images API 响应"""
+        image_urls: list[str] = []
+        image_paths: list[str] = []
+        text_content = None
+        thought_signature = None
+
+        # OpenAI Images API 返回格式: {"data": [{"url": "...", "b64_json": "...", "revised_prompt": "..."}]}
+        if not response_data.get("data"):
+            logger.warning(f"OpenAI Images API 响应无 data 字段: {response_data}")
+            raise APIError(
+                "API 响应格式不正确，缺少 data 字段",
+                None,
+                "invalid_response",
+                retryable=True,
+            )
+
+        for image_item in response_data["data"]:
+            if not isinstance(image_item, dict):
+                continue
+
+            # 优先处理 URL
+            if "url" in image_item:
+                image_url = image_item["url"]
+                if isinstance(image_url, str) and image_url:
+                    image_urls.append(image_url)
+                    logger.debug(f"🖼️ OpenAI Images 返回图片 URL: {image_url[:80]}...")
+
+            # 处理 base64 图片
+            elif "b64_json" in image_item:
+                b64_data = image_item["b64_json"]
+                if isinstance(b64_data, str) and b64_data:
+                    image_path = await save_base64_image(b64_data, "png")
+                    if image_path:
+                        image_urls.append(image_path)
+                        image_paths.append(image_path)
+                        logger.debug(f"🖼️ OpenAI Images 返回 base64 图片: {len(b64_data)} 字节")
+
+            # 记录修订后的提示词
+            if "revised_prompt" in image_item:
+                revised = image_item["revised_prompt"]
+                if revised:
+                    text_content = f"修订提示词: {revised}"
+                    logger.debug(f"OpenAI 修订提示词: {revised[:100]}...")
+
+        if image_urls or image_paths:
+            logger.debug(f"🖼️ OpenAI Images 收集到 {len(image_urls) + len(image_paths)} 张图片")
+            return image_urls, image_paths, text_content, thought_signature
+
+        # 如果没有图片，检查是否有错误信息
+        error_msg = response_data.get("error", {}).get("message", "未知错误")
+        logger.warning(f"OpenAI Images API 未返回图片: {error_msg}")
+        raise APIError(
+            f"图像生成失败: {error_msg}",
+            response_data.get("error", {}).get("code"),
+            "no_image",
+            retryable=False,
+        )
+
+    async def _prepare_payload(
+        self, *, client: Any, config: ApiRequestConfig
+    ) -> dict[str, Any]:  # noqa: ANN401
+        """构建 OpenAI Images API 请求体"""
+        # OpenAI Images API 标准参数
+        payload: dict[str, Any] = {
+            "model": config.model,
+            "prompt": config.prompt,
+            "n": 1,  # 默认生成 1 张
+        }
+
+        # 处理分辨率/尺寸参数
+        _res_key = (config.resolution_param_name or "").strip()
+        resolution_key = _res_key if _res_key else "size"
+
+        if config.resolution:
+            # 将 1K/2K/4K 转换为 OpenAI 格式 (1024x1024, 1792x1024 等)
+            size_mapping = {
+                "1K": "1024x1024",
+                "2K": "1792x1024",  # 或 1024x1792 根据比例
+                "4K": "2048x2048",  # DALL-E 3 最大支持
+            }
+            payload[resolution_key] = size_mapping.get(config.resolution, config.resolution)
+
+        # 处理长宽比 (OpenAI Images API 不直接支持 aspect_ratio，需要转换)
+        if config.aspect_ratio and config.resolution:
+            aspect_mapping = {
+                "1:1": "square",
+                "16:9": "landscape",
+                "9:16": "portrait",
+                "4:3": "standard",
+                "3:4": "vertical",
+            }
+            # 注意：OpenAI DALL-E 不直接支持 aspect_ratio，这里仅作记录
+            # 实际尺寸由 size 参数决定
+
+        # 添加其他可选参数
+        if config.seed is not None:
+            payload["seed"] = config.seed
+
+        # OpenAI Images API 不支持 reference_images（无图生图功能）
+        if config.reference_images:
+            logger.warning("OpenAI Images API (/v1/images/generations) 不支持参考图，已忽略")
+
+        logger.debug(f"OpenAI Images payload: model={config.model}, size={payload.get(resolution_key)}, prompt_len={len(config.prompt)}")
+        return payload

--- a/tl/api/openai_images.py
+++ b/tl/api/openai_images.py
@@ -5,9 +5,6 @@
 
 from __future__ import annotations
 
-import base64
-import time
-from pathlib import Path
 from typing import Any
 
 import aiohttp
@@ -85,7 +82,7 @@ class OpenAIImagesProvider:
                 image_url = image_item["url"]
                 if isinstance(image_url, str) and image_url:
                     image_urls.append(image_url)
-                    logger.debug(f"🖼️ OpenAI Images 返回图片 URL: {image_url[:80]}...")
+                    logger.debug(f"[openai_images] 返回图片 URL: {image_url[:80]}...")
 
             # 处理 base64 图片
             elif "b64_json" in image_item:
@@ -95,7 +92,9 @@ class OpenAIImagesProvider:
                     if image_path:
                         image_urls.append(image_path)
                         image_paths.append(image_path)
-                        logger.debug(f"🖼️ OpenAI Images 返回 base64 图片: {len(b64_data)} 字节")
+                        logger.debug(
+                            f"[openai_images] 返回 base64 图片: {len(b64_data)} 字节"
+                        )
 
             # 记录修订后的提示词
             if "revised_prompt" in image_item:
@@ -105,7 +104,9 @@ class OpenAIImagesProvider:
                     logger.debug(f"OpenAI 修订提示词: {revised[:100]}...")
 
         if image_urls or image_paths:
-            logger.debug(f"🖼️ OpenAI Images 收集到 {len(image_urls) + len(image_paths)} 张图片")
+            logger.debug(
+                f"[openai_images] 收集到 {len(image_urls) + len(image_paths)} 张图片"
+            )
             return image_urls, image_paths, text_content, thought_signature
 
         # 如果没有图片，检查是否有错误信息
@@ -140,19 +141,9 @@ class OpenAIImagesProvider:
                 "2K": "1792x1024",  # 或 1024x1792 根据比例
                 "4K": "2048x2048",  # DALL-E 3 最大支持
             }
-            payload[resolution_key] = size_mapping.get(config.resolution, config.resolution)
-
-        # 处理长宽比 (OpenAI Images API 不直接支持 aspect_ratio，需要转换)
-        if config.aspect_ratio and config.resolution:
-            aspect_mapping = {
-                "1:1": "square",
-                "16:9": "landscape",
-                "9:16": "portrait",
-                "4:3": "standard",
-                "3:4": "vertical",
-            }
-            # 注意：OpenAI DALL-E 不直接支持 aspect_ratio，这里仅作记录
-            # 实际尺寸由 size 参数决定
+            payload[resolution_key] = size_mapping.get(
+                config.resolution, config.resolution
+            )
 
         # 添加其他可选参数
         if config.seed is not None:
@@ -160,7 +151,11 @@ class OpenAIImagesProvider:
 
         # OpenAI Images API 不支持 reference_images（无图生图功能）
         if config.reference_images:
-            logger.warning("OpenAI Images API (/v1/images/generations) 不支持参考图，已忽略")
+            logger.warning(
+                "OpenAI Images API (/v1/images/generations) 不支持参考图，已忽略"
+            )
 
-        logger.debug(f"OpenAI Images payload: model={config.model}, size={payload.get(resolution_key)}, prompt_len={len(config.prompt)}")
+        logger.debug(
+            f"OpenAI Images payload: model={config.model}, size={payload.get(resolution_key)}, prompt_len={len(config.prompt)}"
+        )
         return payload

--- a/tl/api/registry.py
+++ b/tl/api/registry.py
@@ -12,12 +12,14 @@ from .doubao import DoubaoProvider
 from .google import GoogleProvider
 from .grok2api import Grok2ApiProvider
 from .openai_compat import OpenAICompatProvider
+from .openai_images import OpenAIImagesProvider
 from .zai import ZaiProvider
 
 _DOUBAO: Final[DoubaoProvider] = DoubaoProvider()
 _GOOGLE: Final[GoogleProvider] = GoogleProvider()
 _GROK2API: Final[Grok2ApiProvider] = Grok2ApiProvider()
 _OPENAI: Final[OpenAICompatProvider] = OpenAICompatProvider()
+_OPENAI_IMAGES: Final[OpenAIImagesProvider] = OpenAIImagesProvider()
 _ZAI: Final[ZaiProvider] = ZaiProvider()
 
 # Doubao/Volcengine Ark 相关的 API 类型别名
@@ -60,6 +62,7 @@ def get_api_provider(api_type: str | None) -> ApiProvider:
     - `grok2api` -> Grok2ApiProvider
     - `zai` -> ZaiProvider
     - `doubao/volcengine/ark/seedream` -> DoubaoProvider
+    - `openai_images` -> OpenAIImagesProvider (/v1/images/generations)
     - 其他 -> OpenAICompatProvider（用于各类 OpenAI 兼容服务）
     """
     normalized = normalize_api_type(api_type)
@@ -79,5 +82,9 @@ def get_api_provider(api_type: str | None) -> ApiProvider:
     # Google/Gemini 官方
     if normalized in {"google", "gemini", "googlegenai", "google_genai"}:
         return _GOOGLE
+
+    # OpenAI Images API (/v1/images/generations)
+    if normalized in {"openai_images", "openai_images_api"}:
+        return _OPENAI_IMAGES
 
     return _OPENAI

--- a/tl/api_types.py
+++ b/tl/api_types.py
@@ -38,6 +38,9 @@ class ApiRequestConfig:
     resolution_param_name: str = "image_size"  # 分辨率参数名
     aspect_ratio_param_name: str = "aspect_ratio"  # 长宽比参数名
 
+    # OpenAI Images API 端点选择
+    use_images_endpoint: bool = False  # True 使用 /v1/images/generations，False 使用 /v1/chat/completions
+
 
 class APIError(Exception):
     """API 错误基类"""

--- a/tl/api_types.py
+++ b/tl/api_types.py
@@ -38,9 +38,6 @@ class ApiRequestConfig:
     resolution_param_name: str = "image_size"  # 分辨率参数名
     aspect_ratio_param_name: str = "aspect_ratio"  # 长宽比参数名
 
-    # OpenAI Images API 端点选择
-    use_images_endpoint: bool = False  # True 使用 /v1/images/generations，False 使用 /v1/chat/completions
-
 
 class APIError(Exception):
     """API 错误基类"""


### PR DESCRIPTION
## 改动说明

增加/images/generations接口

## 改动类型

- [ ] Bug 修复
- [X ] 新功能
- [ ] 重构 / 代码优化
- [ ] 文档更新
- [ ] 其他

## 关联 Issue

<!-- 如有关联 Issue 请填写，例如 Fixes #123 -->

## 测试情况

- [ X] 本地测试通过
- [ ] 已测试相关命令（/生图、/改图、/快速 等）
- [X ] 已测试 LLM 工具调用

## 补充说明

<!-- 需要 reviewer 特别关注的点、兼容性说明等 -->
/v1/images/generations 不支持改图所以说只能做一下文生图的适配

## Summary by Sourcery

为 OpenAI `/v1/images/generations` 图像 API 添加专用 Provider 支持，并将其接入到 API provider 注册表中。

新功能：
- 引入 `OpenAIImagesProvider`，用于调用标准的 OpenAI `/v1/images/generations` 端点，包括生成图像与修订后的提示词（revised prompts）的请求构造与响应解析。
- 允许在 API provider 注册表中通过 `openai_images` 类型标识符选择新的 OpenAI 图像 provider。

增强内容：
- 整理与载荷构造和代理处理相关的现有配置与 provider 代码中的一些轻微格式问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for the OpenAI `/v1/images/generations` images API as a dedicated provider and wire it into the API provider registry.

New Features:
- Introduce an `OpenAIImagesProvider` for calling the standard OpenAI `/v1/images/generations` endpoint, including request construction and response parsing for generated images and revised prompts.
- Allow selecting the new OpenAI images provider via `openai_images`-type identifiers in the API provider registry.

Enhancements:
- Tidy minor formatting in existing configuration and provider code related to payload construction and proxy handling.

</details>