### PR TITLE
feat: 添加图像生成和图像编辑专用端点

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,20 @@
 
 </details>
 
+## [1.9.8] - 2026-04-11
+
+### Added
+
+- 新增 `openai_images` API 类型，支持 OpenAI `/v1/images/generations`（文生图）和 `/v1/images/edits`（图像编辑）专用端点
+- 支持 GPT image 系列模型（gpt-image-1 / gpt-image-1-mini / gpt-image-1.5）和 DALL·E 系列的完整参数配置
+- 新增 `output_compression`（输出压缩率，滑动条 0-100）和 `moderation`（审核模式）配置项
+- 新增 `generations_only` 配置项，可强制只使用文生图端点
+- 支持 multipart/form-data 请求，用于图像编辑端点的二进制图片上传
+- GPT image 模型支持多张参考图同时上传
+- 解析并记录 API 返回的 Token 用量信息（input/output/total）
+
+
+
 ## [1.9.7] - 2026-03-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-![Version](https://img.shields.io/badge/Version-v1.9.7-blue)
+![Version](https://img.shields.io/badge/Version-v1.9.8-blue)
 ![License](https://img.shields.io/badge/License-AGPL--3.0-orange)
 
 **🎨 强大的 Gemini 图像生成插件，支持智能头像参考和智能表情包切分**
@@ -19,7 +19,7 @@
 - **智能头像**: 自动获取用户头像和@对象头像作为参考
 - **表情包切分**: SmartMemeSplitter v4 算法自动切割表情包网格
 - **LLM 工具**: 支持自然语言触发生图，优先前台短等待，超时自动转后台
-- **多 API 支持**: Google 官方、OpenAI 兼容、Zai、grok2api、豆包（Doubao）
+- **多 API 支持**: Google 官方、OpenAI 兼容、OpenAI Images、Zai、grok2api、豆包（Doubao）
 - **多格式支持**: PNG、JPEG、WEBP、HEIC/HEIF、GIF
 
 ### 🛡️ 限制/限流
@@ -62,7 +62,7 @@
 | 配置项 | 说明 |
 |--------|------|
 | `api_settings.provider_id` | 生图模型提供商（从 AstrBot 提供商列表选择；doubao 无需填写） |
-| `api_settings.api_type` | API 类型：`google`/`openai`/`zai`/`grok2api`/`doubao` |
+| `api_settings.api_type` | API 类型：`google`/`openai`/`openai_images`/`zai`/`grok2api`/`doubao` |
 
 ### 配置项详解
 
@@ -145,6 +145,21 @@
 | `optimize_prompt_mode` | `standard` | 提示词优化模式（standard/fast） |
 | `sequential_image_generation` | `disabled` | 组图生成模式（disabled/auto），[官方文档](https://www.volcengine.com/docs/82379/1824121?lang=zh#fc9f85e4) |
 | `sequential_max_images` | `4` | 组图最大数量（2-15） |
+
+**openai_images_settings**（OpenAI Images API 专用配置）
+| 配置项 | 默认值 | 说明 |
+|--------|--------|------|
+| `api_keys` | `[]` | API Key 列表，支持多 Key 轮换 |
+| `model` | `dall-e-3` | 模型名称（dall-e-2/dall-e-3/gpt-image-1 等） |
+| `api_base` | - | API 端点地址，留空使用 OpenAI 官方 |
+| `quality` | - | 图像质量（GPT image: auto/high/medium/low；dall-e-3: hd/standard） |
+| `response_format` | `b64_json` | 响应格式（b64_json/url） |
+| `style` | - | 图像风格，仅 dall-e-3（vivid/natural） |
+| `background` | - | 背景透明度，仅 GPT image（auto/transparent/opaque） |
+| `output_format` | - | 输出格式，仅 GPT image（png/jpeg/webp） |
+| `output_compression` | `0` | 输出压缩率滑动条 0-100，0 表示不传（使用服务端默认），仅 GPT image + jpeg/webp |
+| `moderation` | - | 审核模式，仅 GPT image（如 low） |
+| `generations_only` | `false` | 开启后强制只用文生图端点，不走 /v1/images/edits |
 
 ## 🎯 使用指南
 

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -257,10 +257,24 @@
                 "default": "",
                 "options": ["", "png", "jpeg", "webp"]
               },
+              "output_compression": {
+                "description": "输出压缩率（仅 GPT image 模型）",
+                "type": "int",
+                "hint": "仅在 output_format 为 jpeg 或 webp 时有效。0 表示不传（使用服务端默认值），1-100 为自定义压缩率",
+                "default": 0,
+                "slider": {"min": 0, "max": 100, "step": 1}
+              },
+              "moderation": {
+                "description": "审核模式（仅 GPT image 模型）",
+                "type": "string",
+                "hint": "审核策略配置，如 low。仅 GPT image 模型支持，留空不传",
+                "default": "",
+                "options": ["", "low"]
+              },
               "generations_only": {
                 "description": "仅使用文生图",
                 "type": "bool",
-                "hint": "edits 接口的兼容端点",
+                "hint": "开启后丢去所有参考图仅输入文本提示词进行生成。",
                 "default": false
               },
               "proxy": {

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -196,7 +196,7 @@
           },
           "openai_images": {
             "description": "OpenAI Images API 覆盖配置",
-            "hint": "配置 OpenAI /v1/images/generations 端点的密钥和端点",
+            "hint": "配置 OpenAI /v1/images/generations 和 /v1/images/edits 端点的密钥和参数",
             "items": {
               "api_keys": {
                 "description": "API Key 列表",
@@ -213,7 +213,7 @@
               "model": {
                 "description": "模型名称",
                 "type": "string",
-                "hint": "OpenAI Images API 模型名称（如 dall-e-3, dall-e-2）",
+                "hint": "OpenAI Images API 模型名称",
                 "default": "dall-e-3"
               },
               "api_base": {
@@ -221,6 +221,47 @@
                 "type": "string",
                 "hint": "OpenAI Images API 地址，留空使用默认 https://api.openai.com",
                 "default": ""
+              },
+              "quality": {
+                "description": "图像质量",
+                "type": "string",
+                "hint": "GPT image 模型: auto/high/medium/low；dall-e-3: hd/standard；dall-e-2: standard。留空使用默认值",
+                "default": "",
+                "options": ["", "auto", "high", "medium", "low", "hd", "standard"]
+              },
+              "response_format": {
+                "description": "响应格式",
+                "type": "string",
+                "hint": "url 返回临时链接（60分钟有效），b64_json 返回 base64 编码。",
+                "default": "b64_json",
+                "options": ["b64_json", "url"]
+              },
+              "style": {
+                "description": "图像风格（仅 dall-e-3）",
+                "type": "string",
+                "hint": "vivid 生成超现实戏剧性图像，natural 生成更自然的图像。仅 dall-e-3 支持，留空不传",
+                "default": "",
+                "options": ["", "vivid", "natural"]
+              },
+              "background": {
+                "description": "背景透明度（仅 GPT image 模型）",
+                "type": "string",
+                "hint": "transparent 透明背景，opaque 不透明，auto 自动。仅 GPT image 模型支持，留空不传",
+                "default": "",
+                "options": ["", "auto", "transparent", "opaque"]
+              },
+              "output_format": {
+                "description": "输出图像格式（仅 GPT image 模型）",
+                "type": "string",
+                "hint": "png 支持透明背景，jpeg 文件更小，webp 兼顾两者。仅 GPT image 模型支持，留空不传",
+                "default": "",
+                "options": ["", "png", "jpeg", "webp"]
+              },
+              "generations_only": {
+                "description": "仅使用文生图",
+                "type": "bool",
+                "hint": "edits 接口的兼容端点",
+                "default": false
               },
               "proxy": {
                 "description": "代理地址",

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -14,11 +14,12 @@
       "api_type": {
         "description": "API 类型（必选）",
         "type": "string",
-        "hint": "必须选择 API 类型（google/openai/zai/grok2api/doubao）。 不同提供商支持的类型不同，请参考提供商说明",
+        "hint": "必须选择 API 类型（google/openai/openai_images/zai/grok2api/doubao）。 不同提供商支持的类型不同，请参考提供商说明。openai_images 专门调用 /v1/images/generations 端点",
         "default": "openai",
         "options": [
           "google",
           "openai",
+          "openai_images",
           "zai",
           "grok2api",
           "doubao"
@@ -183,6 +184,42 @@
                 "description": "API 端点地址",
                 "type": "string",
                 "hint": "grok2api API 地址",
+                "default": ""
+              },
+              "proxy": {
+                "description": "代理地址",
+                "type": "string",
+                "hint": "填写即启用代理，留空使用全局代理或环境变量。支持 http://host:port、https://host:port、socks5://host:port 格式。优先级高于全局代理和环境变量",
+                "default": ""
+              }
+            }
+          },
+          "openai_images": {
+            "description": "OpenAI Images API 覆盖配置",
+            "hint": "配置 OpenAI /v1/images/generations 端点的密钥和端点",
+            "items": {
+              "api_keys": {
+                "description": "API Key 列表",
+                "type": "list",
+                "hint": "多个 API Key，支持轮换使用",
+                "default": []
+              },
+              "daily_limit_per_key": {
+                "description": "每个 Key 每日限额",
+                "type": "int",
+                "hint": "每个 API Key 每日最大调用次数，0 表示不限制",
+                "default": 0
+              },
+              "model": {
+                "description": "模型名称",
+                "type": "string",
+                "hint": "OpenAI Images API 模型名称（如 dall-e-3, dall-e-2）",
+                "default": "dall-e-3"
+              },
+              "api_base": {
+                "description": "API 端点地址",
+                "type": "string",
+                "hint": "OpenAI Images API 地址，留空使用默认 https://api.openai.com",
                 "default": ""
               },
               "proxy": {

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -14,7 +14,7 @@
       "api_type": {
         "description": "API 类型（必选）",
         "type": "string",
-        "hint": "必须选择 API 类型（google/openai/openai_images/zai/grok2api/doubao）。 不同提供商支持的类型不同，请参考提供商说明。openai_images 专门调用 /v1/images/generations 端点",
+        "hint": "必须选择 API 类型（google/openai/zai/grok2api/doubao）。 不同提供商支持的类型不同，请参考提供商说明",
         "default": "openai",
         "options": [
           "google",

--- a/main.py
+++ b/main.py
@@ -397,7 +397,8 @@ class GeminiImageGenerationPlugin(Star):
             # 代理优先级：provider_overrides > api_settings 全局 > 环境变量
             proxy_from_override = (
                 (override_settings.get("proxy") or "").strip()
-                if override_settings else ""
+                if override_settings
+                else ""
             )
             proxy_from_global = getattr(self.cfg, "proxy", None) or ""
 

--- a/main.py
+++ b/main.py
@@ -371,9 +371,11 @@ class GeminiImageGenerationPlugin(Star):
             if api_base:
                 self.cfg.api_base = api_base
 
-            # doubao 特殊：绑定完整 settings 供适配器使用
+            # 绑定完整 settings 供适配器使用
             if api_type_norm == "doubao":
                 self.cfg.doubao_settings = override_settings
+            elif api_type_norm == "openai_images":
+                self.cfg.openai_images_settings = override_settings
 
             # 日志显示覆盖来源
             logger.info(
@@ -382,7 +384,7 @@ class GeminiImageGenerationPlugin(Star):
 
         if self.cfg.api_keys:
             self.api_client = get_api_client(self.cfg.api_keys)
-            # 绑定 doubao_settings 到 API client，供 DoubaoProvider 读取
+            # 绑定 provider settings 到 API client，供各 Provider 读取
             if api_type_norm == "doubao":
                 try:
                     self.api_client.doubao_settings = (
@@ -390,6 +392,13 @@ class GeminiImageGenerationPlugin(Star):
                     )
                 except Exception as e:
                     logger.debug(f"绑定 doubao_settings 到 API client 失败: {e}")
+            elif api_type_norm == "openai_images":
+                try:
+                    self.api_client.openai_images_settings = (
+                        getattr(self.cfg, "openai_images_settings", None) or {}
+                    )
+                except Exception as e:
+                    logger.debug(f"绑定 openai_images_settings 到 API client 失败: {e}")
             # 绑定 KeyManager 到 API client（支持多 Key 轮换和每日限额）
             if hasattr(self, "key_manager") and self.key_manager:
                 self.api_client.set_key_manager(self.key_manager)

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,7 +1,7 @@
 name: astrbot_plugin_gemini_image_generation
 desc: Gemini图像生成插件，支持生图和改图，支持自动获取头像作为参考
 display_name: Gemini 图像生成
-version: v1.9.7
+version: v1.9.8
 author: piexian
 repo: https://github.com/piexian/astrbot_plugin_gemini_image_generation
 astrbot_version: ">=4.10.4"

--- a/tl/api/doubao.py
+++ b/tl/api/doubao.py
@@ -187,7 +187,7 @@ class DoubaoProvider:
             payload.get("size"),
             bool(payload.get("image")),
             is_retry,
-            {k: v for k, v in payload.items() if k != "image"},  
+            {k: v for k, v in payload.items() if k != "image"},
         )
         return ProviderRequest(url=url, headers=headers, payload=payload)
 

--- a/tl/api/openai_images.py
+++ b/tl/api/openai_images.py
@@ -1,0 +1,166 @@
+"""OpenAI Images API (`/v1/images/generations`) 供应商实现。
+
+用于调用标准的 OpenAI Images API 端点，如 DALL-E 系列模型。
+"""
+
+from __future__ import annotations
+
+import base64
+import time
+from pathlib import Path
+from typing import Any
+
+import aiohttp
+
+from astrbot.api import logger
+
+from ..api_types import APIError, ApiRequestConfig
+from ..tl_utils import save_base64_image
+from .base import ProviderRequest
+
+
+class OpenAIImagesProvider:
+    """OpenAI /v1/images/generations 端点实现"""
+
+    name = "openai_images"
+
+    async def build_request(
+        self, *, client: Any, config: ApiRequestConfig
+    ) -> ProviderRequest:  # noqa: ANN401
+        api_base = (config.api_base or "").rstrip("/")
+        default_base = "https://api.openai.com"
+
+        if api_base:
+            base = api_base
+            logger.debug(f"使用自定义 API Base: {base}")
+        else:
+            base = default_base
+            logger.debug(f"使用默认 API Base: {base}")
+
+        # 构建 /v1/images/generations URL
+        if base.endswith("/v1"):
+            url = f"{base}/images/generations"
+        else:
+            url = f"{base}/v1/images/generations"
+
+        payload = await self._prepare_payload(client=client, config=config)
+        headers = {
+            "Authorization": f"Bearer {config.api_key}",
+            "Content-Type": "application/json",
+        }
+        logger.debug(f"OpenAI Images API URL: {url}")
+        return ProviderRequest(url=url, headers=headers, payload=payload)
+
+    async def parse_response(
+        self,
+        *,
+        client: Any,
+        response_data: dict[str, Any],
+        session: aiohttp.ClientSession,
+        api_base: str | None = None,
+        http_status: int | None = None,
+    ) -> tuple[list[str], list[str], str | None, str | None]:  # noqa: ANN401
+        """解析 OpenAI Images API 响应"""
+        image_urls: list[str] = []
+        image_paths: list[str] = []
+        text_content = None
+        thought_signature = None
+
+        # OpenAI Images API 返回格式: {"data": [{"url": "...", "b64_json": "...", "revised_prompt": "..."}]}
+        if not response_data.get("data"):
+            logger.warning(f"OpenAI Images API 响应无 data 字段: {response_data}")
+            raise APIError(
+                "API 响应格式不正确，缺少 data 字段",
+                None,
+                "invalid_response",
+                retryable=True,
+            )
+
+        for image_item in response_data["data"]:
+            if not isinstance(image_item, dict):
+                continue
+
+            # 优先处理 URL
+            if "url" in image_item:
+                image_url = image_item["url"]
+                if isinstance(image_url, str) and image_url:
+                    image_urls.append(image_url)
+                    logger.debug(f"🖼️ OpenAI Images 返回图片 URL: {image_url[:80]}...")
+
+            # 处理 base64 图片
+            elif "b64_json" in image_item:
+                b64_data = image_item["b64_json"]
+                if isinstance(b64_data, str) and b64_data:
+                    image_path = await save_base64_image(b64_data, "png")
+                    if image_path:
+                        image_urls.append(image_path)
+                        image_paths.append(image_path)
+                        logger.debug(f"🖼️ OpenAI Images 返回 base64 图片: {len(b64_data)} 字节")
+
+            # 记录修订后的提示词
+            if "revised_prompt" in image_item:
+                revised = image_item["revised_prompt"]
+                if revised:
+                    text_content = f"修订提示词: {revised}"
+                    logger.debug(f"OpenAI 修订提示词: {revised[:100]}...")
+
+        if image_urls or image_paths:
+            logger.debug(f"🖼️ OpenAI Images 收集到 {len(image_urls) + len(image_paths)} 张图片")
+            return image_urls, image_paths, text_content, thought_signature
+
+        # 如果没有图片，检查是否有错误信息
+        error_msg = response_data.get("error", {}).get("message", "未知错误")
+        logger.warning(f"OpenAI Images API 未返回图片: {error_msg}")
+        raise APIError(
+            f"图像生成失败: {error_msg}",
+            response_data.get("error", {}).get("code"),
+            "no_image",
+            retryable=False,
+        )
+
+    async def _prepare_payload(
+        self, *, client: Any, config: ApiRequestConfig
+    ) -> dict[str, Any]:  # noqa: ANN401
+        """构建 OpenAI Images API 请求体"""
+        # OpenAI Images API 标准参数
+        payload: dict[str, Any] = {
+            "model": config.model,
+            "prompt": config.prompt,
+            "n": 1,  # 默认生成 1 张
+        }
+
+        # 处理分辨率/尺寸参数
+        _res_key = (config.resolution_param_name or "").strip()
+        resolution_key = _res_key if _res_key else "size"
+
+        if config.resolution:
+            # 将 1K/2K/4K 转换为 OpenAI 格式 (1024x1024, 1792x1024 等)
+            size_mapping = {
+                "1K": "1024x1024",
+                "2K": "1792x1024",  # 或 1024x1792 根据比例
+                "4K": "2048x2048",  # DALL-E 3 最大支持
+            }
+            payload[resolution_key] = size_mapping.get(config.resolution, config.resolution)
+
+        # 处理长宽比 (OpenAI Images API 不直接支持 aspect_ratio，需要转换)
+        if config.aspect_ratio and config.resolution:
+            aspect_mapping = {
+                "1:1": "square",
+                "16:9": "landscape",
+                "9:16": "portrait",
+                "4:3": "standard",
+                "3:4": "vertical",
+            }
+            # 注意：OpenAI DALL-E 不直接支持 aspect_ratio，这里仅作记录
+            # 实际尺寸由 size 参数决定
+
+        # 添加其他可选参数
+        if config.seed is not None:
+            payload["seed"] = config.seed
+
+        # OpenAI Images API 不支持 reference_images（无图生图功能）
+        if config.reference_images:
+            logger.warning("OpenAI Images API (/v1/images/generations) 不支持参考图，已忽略")
+
+        logger.debug(f"OpenAI Images payload: model={config.model}, size={payload.get(resolution_key)}, prompt_len={len(config.prompt)}")
+        return payload

--- a/tl/api/openai_images.py
+++ b/tl/api/openai_images.py
@@ -163,6 +163,22 @@ class OpenAIImagesProvider:
 
         # ---------- 解析图片数据 ----------
         if not response_data.get("data"):
+            # 优先提取 API 返回的错误信息
+            error_obj = response_data.get("error")
+            if error_obj:
+                error_msg = (
+                    error_obj.get("message", "未知错误")
+                    if isinstance(error_obj, dict)
+                    else str(error_obj)
+                )
+                logger.warning(f"[openai_images] API 返回错误: {error_msg}")
+                raise APIError(
+                    f"图像生成失败: {error_msg}",
+                    http_status,
+                    "api_error",
+                    error_obj.get("code") if isinstance(error_obj, dict) else None,
+                    retryable=False,
+                )
             logger.warning(f"[openai_images] 响应无 data 字段: {response_data}")
             raise APIError(
                 "API 响应格式不正确，缺少 data 字段",
@@ -235,7 +251,6 @@ class OpenAIImagesProvider:
         payload: dict[str, Any] = {
             "model": model,
             "prompt": config.prompt,
-            "n": 1,
         }
 
         # ---- size ----
@@ -258,29 +273,26 @@ class OpenAIImagesProvider:
         if style:
             payload["style"] = style
 
-        # ---- background (GPT image only) ----
+        # ---- GPT image 模型专属参数 ----
+        is_gpt = _is_gpt_image_model(model)
+
         background = str(settings.get("background") or "").strip()
-        if background:
+        if background and is_gpt:
             payload["background"] = background
 
-        # ---- output_format (GPT image only) ----
         output_format = str(settings.get("output_format") or "").strip()
-        if output_format:
+        if output_format and is_gpt:
             payload["output_format"] = output_format
 
-        # ---- output_compression (GPT image + jpeg/webp) ----
-        output_compression = settings.get("output_compression")
-        if output_compression is not None:
-            try:
-                payload["output_compression"] = max(
-                    0, min(100, int(output_compression))
-                )
-            except (TypeError, ValueError):
-                pass
+        try:
+            output_compression = int(settings.get("output_compression", 0))
+        except (TypeError, ValueError):
+            output_compression = 0
+        if output_compression > 0 and is_gpt and output_format in {"jpeg", "webp"}:
+            payload["output_compression"] = min(output_compression, 100)
 
-        # ---- moderation (GPT image only) ----
         moderation = str(settings.get("moderation") or "").strip()
-        if moderation:
+        if moderation and is_gpt:
             payload["moderation"] = moderation
 
         # ---- seed ----
@@ -356,9 +368,6 @@ class OpenAIImagesProvider:
         # ---- model ----
         form.add_field("model", model)
 
-        # ---- n ----
-        form.add_field("n", "1")
-
         # ---- size ----
         if config.resolution:
             size_map = _get_size_mapping(model)
@@ -405,7 +414,7 @@ class OpenAIImagesProvider:
                 s = parts[1]
 
         try:
-            return base64.b64decode(s)
+            return base64.b64decode(s, validate=True)
         except Exception:
             logger.debug(f"[openai_images] 无法 base64 解码图片输入 (len={len(s)})")
             return None

--- a/tl/api/openai_images.py
+++ b/tl/api/openai_images.py
@@ -5,9 +5,6 @@
 
 from __future__ import annotations
 
-import base64
-import time
-from pathlib import Path
 from typing import Any
 
 import aiohttp
@@ -85,7 +82,7 @@ class OpenAIImagesProvider:
                 image_url = image_item["url"]
                 if isinstance(image_url, str) and image_url:
                     image_urls.append(image_url)
-                    logger.debug(f"🖼️ OpenAI Images 返回图片 URL: {image_url[:80]}...")
+                    logger.debug(f"[openai_images] 返回图片 URL: {image_url[:80]}...")
 
             # 处理 base64 图片
             elif "b64_json" in image_item:
@@ -95,7 +92,9 @@ class OpenAIImagesProvider:
                     if image_path:
                         image_urls.append(image_path)
                         image_paths.append(image_path)
-                        logger.debug(f"🖼️ OpenAI Images 返回 base64 图片: {len(b64_data)} 字节")
+                        logger.debug(
+                            f"[openai_images] 返回 base64 图片: {len(b64_data)} 字节"
+                        )
 
             # 记录修订后的提示词
             if "revised_prompt" in image_item:
@@ -105,7 +104,9 @@ class OpenAIImagesProvider:
                     logger.debug(f"OpenAI 修订提示词: {revised[:100]}...")
 
         if image_urls or image_paths:
-            logger.debug(f"🖼️ OpenAI Images 收集到 {len(image_urls) + len(image_paths)} 张图片")
+            logger.debug(
+                f"[openai_images] 收集到 {len(image_urls) + len(image_paths)} 张图片"
+            )
             return image_urls, image_paths, text_content, thought_signature
 
         # 如果没有图片，检查是否有错误信息
@@ -140,19 +141,9 @@ class OpenAIImagesProvider:
                 "2K": "1792x1024",  # 或 1024x1792 根据比例
                 "4K": "2048x2048",  # DALL-E 3 最大支持
             }
-            payload[resolution_key] = size_mapping.get(config.resolution, config.resolution)
-
-        # 处理长宽比 (OpenAI Images API 不直接支持 aspect_ratio，需要转换)
-        if config.aspect_ratio and config.resolution:
-            aspect_mapping = {
-                "1:1": "square",
-                "16:9": "landscape",
-                "9:16": "portrait",
-                "4:3": "standard",
-                "3:4": "vertical",
-            }
-            # 注意：OpenAI DALL-E 不直接支持 aspect_ratio，这里仅作记录
-            # 实际尺寸由 size 参数决定
+            payload[resolution_key] = size_mapping.get(
+                config.resolution, config.resolution
+            )
 
         # 添加其他可选参数
         if config.seed is not None:
@@ -160,7 +151,11 @@ class OpenAIImagesProvider:
 
         # OpenAI Images API 不支持 reference_images（无图生图功能）
         if config.reference_images:
-            logger.warning("OpenAI Images API (/v1/images/generations) 不支持参考图，已忽略")
+            logger.warning(
+                "OpenAI Images API (/v1/images/generations) 不支持参考图，已忽略"
+            )
 
-        logger.debug(f"OpenAI Images payload: model={config.model}, size={payload.get(resolution_key)}, prompt_len={len(config.prompt)}")
+        logger.debug(
+            f"OpenAI Images payload: model={config.model}, size={payload.get(resolution_key)}, prompt_len={len(config.prompt)}"
+        )
         return payload

--- a/tl/api/openai_images.py
+++ b/tl/api/openai_images.py
@@ -1,10 +1,15 @@
-"""OpenAI Images API (`/v1/images/generations`) 供应商实现。
+"""OpenAI Images API 供应商实现。
 
-用于调用标准的 OpenAI Images API 端点，如 DALL-E 系列模型。
+支持：
+- /v1/images/generations  文生图（JSON 请求）
+- /v1/images/edits        图像编辑（multipart/form-data 请求）
+
+兼容 OpenAI 官方、NewAPI等 OpenAI Images API 兼容端点。
 """
 
 from __future__ import annotations
 
+import base64
 from typing import Any
 
 import aiohttp
@@ -15,38 +20,113 @@ from ..api_types import APIError, ApiRequestConfig
 from ..tl_utils import save_base64_image
 from .base import ProviderRequest
 
+# ---------- 按模型族分的合法尺寸映射 ----------
+
+_SIZE_MAP_DALLE2: dict[str, str] = {
+    "1K": "1024x1024",
+    "2K": "1024x1024",  # dall-e-2 最大 1024x1024
+    "4K": "1024x1024",
+}
+
+_SIZE_MAP_DALLE3: dict[str, str] = {
+    "1K": "1024x1024",
+    "2K": "1792x1024",
+    "4K": "1024x1792",
+}
+
+_SIZE_MAP_GPT_IMAGE: dict[str, str] = {
+    "1K": "1024x1024",
+    "2K": "1536x1024",
+    "4K": "auto",
+}
+
+
+def _is_gpt_image_model(model: str) -> bool:
+    """判断是否为 GPT image 系列模型（gpt-image-1 / gpt-image-1-mini / gpt-image-1.5 等）"""
+    m = (model or "").lower()
+    return m.startswith("gpt-image") or m == "chatgpt-image-latest"
+
+
+def _get_size_mapping(model: str) -> dict[str, str]:
+    """根据模型名称返回对应的尺寸映射表"""
+    m = (model or "").lower()
+    if _is_gpt_image_model(m):
+        return _SIZE_MAP_GPT_IMAGE
+    if "dall-e-2" in m or "dalle2" in m:
+        return _SIZE_MAP_DALLE2
+    # dall-e-3 及其他未知模型使用 dall-e-3 映射
+    return _SIZE_MAP_DALLE3
+
 
 class OpenAIImagesProvider:
-    """OpenAI /v1/images/generations 端点实现"""
+    """OpenAI /v1/images/generations + /v1/images/edits 端点实现"""
 
     name = "openai_images"
+
+    # ------------------------------------------------------------------
+    # build_request
+    # ------------------------------------------------------------------
 
     async def build_request(
         self, *, client: Any, config: ApiRequestConfig
     ) -> ProviderRequest:  # noqa: ANN401
+        settings: dict[str, Any] = getattr(client, "openai_images_settings", None) or {}
         api_base = (config.api_base or "").rstrip("/")
         default_base = "https://api.openai.com"
 
-        if api_base:
-            base = api_base
-            logger.debug(f"使用自定义 API Base: {base}")
-        else:
-            base = default_base
-            logger.debug(f"使用默认 API Base: {base}")
+        base = api_base if api_base else default_base
+        logger.debug(f"[openai_images] API Base: {base}")
 
-        # 构建 /v1/images/generations URL
-        if base.endswith("/v1"):
-            url = f"{base}/images/generations"
-        else:
-            url = f"{base}/v1/images/generations"
+        # 根据是否有参考图决定走 generations 还是 edits
+        generations_only = bool(settings.get("generations_only", False))
+        has_ref_images = bool(config.reference_images) and not generations_only
 
-        payload = await self._prepare_payload(client=client, config=config)
-        headers = {
-            "Authorization": f"Bearer {config.api_key}",
-            "Content-Type": "application/json",
-        }
-        logger.debug(f"OpenAI Images API URL: {url}")
+        if generations_only and config.reference_images:
+            logger.info(
+                "[openai_images] generations_only 已开启，忽略参考图，仅使用文生图"
+            )
+
+        if has_ref_images:
+            # /v1/images/edits (multipart/form-data)
+            endpoint = "images/edits"
+            if base.endswith("/v1"):
+                url = f"{base}/{endpoint}"
+            else:
+                url = f"{base}/v1/{endpoint}"
+
+            payload = await self._prepare_edits_payload(
+                client=client,
+                config=config,
+                settings=settings,
+            )
+            headers = {
+                "Authorization": f"Bearer {config.api_key}",
+                # Content-Type 由 aiohttp 自动设置 multipart boundary
+            }
+        else:
+            # /v1/images/generations (JSON)
+            endpoint = "images/generations"
+            if base.endswith("/v1"):
+                url = f"{base}/{endpoint}"
+            else:
+                url = f"{base}/v1/{endpoint}"
+
+            payload = await self._prepare_generations_payload(
+                client=client,
+                config=config,
+                settings=settings,
+            )
+            headers = {
+                "Authorization": f"Bearer {config.api_key}",
+                "Content-Type": "application/json",
+            }
+
+        logger.debug(f"[openai_images] URL: {url} (edits={has_ref_images})")
         return ProviderRequest(url=url, headers=headers, payload=payload)
+
+    # ------------------------------------------------------------------
+    # parse_response
+    # ------------------------------------------------------------------
 
     async def parse_response(
         self,
@@ -57,15 +137,33 @@ class OpenAIImagesProvider:
         api_base: str | None = None,
         http_status: int | None = None,
     ) -> tuple[list[str], list[str], str | None, str | None]:  # noqa: ANN401
-        """解析 OpenAI Images API 响应"""
+        """解析 OpenAI Images API 响应（generations / edits 共用）"""
         image_urls: list[str] = []
         image_paths: list[str] = []
         text_content = None
         thought_signature = None
 
-        # OpenAI Images API 返回格式: {"data": [{"url": "...", "b64_json": "...", "revised_prompt": "..."}]}
+        # ---------- 解析 usage ----------
+        usage = response_data.get("usage")
+        if isinstance(usage, dict):
+            in_tok = usage.get("input_tokens", 0)
+            out_tok = usage.get("output_tokens", 0)
+            total_tok = usage.get("total_tokens", in_tok + out_tok)
+            logger.info(
+                f"[openai_images] Token 用量: input={in_tok} output={out_tok} total={total_tok}"
+            )
+
+        # ---------- 推断输出格式 ----------
+        resp_output_format = response_data.get("output_format") or ""
+        save_ext = (
+            resp_output_format
+            if resp_output_format in {"png", "jpeg", "webp"}
+            else "png"
+        )
+
+        # ---------- 解析图片数据 ----------
         if not response_data.get("data"):
-            logger.warning(f"OpenAI Images API 响应无 data 字段: {response_data}")
+            logger.warning(f"[openai_images] 响应无 data 字段: {response_data}")
             raise APIError(
                 "API 响应格式不正确，缺少 data 字段",
                 None,
@@ -82,80 +180,232 @@ class OpenAIImagesProvider:
                 image_url = image_item["url"]
                 if isinstance(image_url, str) and image_url:
                     image_urls.append(image_url)
-                    logger.debug(f"[openai_images] 返回图片 URL: {image_url[:80]}...")
+                    logger.debug(f"[openai_images] 图片 URL: {image_url[:80]}...")
 
             # 处理 base64 图片
             elif "b64_json" in image_item:
                 b64_data = image_item["b64_json"]
                 if isinstance(b64_data, str) and b64_data:
-                    image_path = await save_base64_image(b64_data, "png")
+                    image_path = await save_base64_image(b64_data, save_ext)
                     if image_path:
                         image_urls.append(image_path)
                         image_paths.append(image_path)
                         logger.debug(
-                            f"[openai_images] 返回 base64 图片: {len(b64_data)} 字节"
+                            f"[openai_images] base64 图片 ({save_ext}): {len(b64_data)} 字节"
                         )
 
-            # 记录修订后的提示词
-            if "revised_prompt" in image_item:
-                revised = image_item["revised_prompt"]
-                if revised:
-                    text_content = f"修订提示词: {revised}"
-                    logger.debug(f"OpenAI 修订提示词: {revised[:100]}...")
+            # 记录修订后的提示词（dall-e-3 only）
+            revised = image_item.get("revised_prompt")
+            if revised:
+                text_content = f"修订提示词: {revised}"
+                logger.debug(f"[openai_images] 修订提示词: {revised[:100]}...")
 
         if image_urls or image_paths:
-            logger.debug(
-                f"[openai_images] 收集到 {len(image_urls) + len(image_paths)} 张图片"
-            )
+            logger.debug(f"[openai_images] 共 {len(image_urls)} 张图片")
             return image_urls, image_paths, text_content, thought_signature
 
-        # 如果没有图片，检查是否有错误信息
-        error_msg = response_data.get("error", {}).get("message", "未知错误")
-        logger.warning(f"OpenAI Images API 未返回图片: {error_msg}")
+        # 没有图片 → 提取错误信息
+        error_obj = response_data.get("error") or {}
+        error_msg = (
+            error_obj.get("message", "未知错误")
+            if isinstance(error_obj, dict)
+            else str(error_obj)
+        )
+        logger.warning(f"[openai_images] 未返回图片: {error_msg}")
         raise APIError(
             f"图像生成失败: {error_msg}",
-            response_data.get("error", {}).get("code"),
+            error_obj.get("code") if isinstance(error_obj, dict) else None,
             "no_image",
             retryable=False,
         )
 
-    async def _prepare_payload(
-        self, *, client: Any, config: ApiRequestConfig
+    # ------------------------------------------------------------------
+    # _prepare_generations_payload (文生图 JSON)
+    # ------------------------------------------------------------------
+
+    async def _prepare_generations_payload(
+        self,
+        *,
+        client: Any,
+        config: ApiRequestConfig,
+        settings: dict[str, Any],
     ) -> dict[str, Any]:  # noqa: ANN401
-        """构建 OpenAI Images API 请求体"""
-        # OpenAI Images API 标准参数
+        """构建 /v1/images/generations 请求体"""
+        model = config.model or "dall-e-3"
         payload: dict[str, Any] = {
-            "model": config.model,
+            "model": model,
             "prompt": config.prompt,
-            "n": 1,  # 默认生成 1 张
+            "n": 1,
         }
 
-        # 处理分辨率/尺寸参数
-        _res_key = (config.resolution_param_name or "").strip()
-        resolution_key = _res_key if _res_key else "size"
-
+        # ---- size ----
         if config.resolution:
-            # 将 1K/2K/4K 转换为 OpenAI 格式 (1024x1024, 1792x1024 等)
-            size_mapping = {
-                "1K": "1024x1024",
-                "2K": "1792x1024",  # 或 1024x1792 根据比例
-                "4K": "2048x2048",  # DALL-E 3 最大支持
-            }
-            payload[resolution_key] = size_mapping.get(
-                config.resolution, config.resolution
-            )
+            size_map = _get_size_mapping(model)
+            payload["size"] = size_map.get(config.resolution, config.resolution)
 
-        # 添加其他可选参数
+        # ---- quality ----
+        quality = str(settings.get("quality") or "").strip()
+        if quality:
+            payload["quality"] = quality
+
+        # ---- response_format ----
+        response_format = str(settings.get("response_format") or "").strip()
+        if response_format:
+            payload["response_format"] = response_format
+
+        # ---- style (dall-e-3 only) ----
+        style = str(settings.get("style") or "").strip()
+        if style:
+            payload["style"] = style
+
+        # ---- background (GPT image only) ----
+        background = str(settings.get("background") or "").strip()
+        if background:
+            payload["background"] = background
+
+        # ---- output_format (GPT image only) ----
+        output_format = str(settings.get("output_format") or "").strip()
+        if output_format:
+            payload["output_format"] = output_format
+
+        # ---- output_compression (GPT image + jpeg/webp) ----
+        output_compression = settings.get("output_compression")
+        if output_compression is not None:
+            try:
+                payload["output_compression"] = max(
+                    0, min(100, int(output_compression))
+                )
+            except (TypeError, ValueError):
+                pass
+
+        # ---- moderation (GPT image only) ----
+        moderation = str(settings.get("moderation") or "").strip()
+        if moderation:
+            payload["moderation"] = moderation
+
+        # ---- seed ----
         if config.seed is not None:
             payload["seed"] = config.seed
 
-        # OpenAI Images API 不支持 reference_images（无图生图功能）
-        if config.reference_images:
-            logger.warning(
-                "OpenAI Images API (/v1/images/generations) 不支持参考图，已忽略"
-            )
-
         logger.debug(
-            f"OpenAI Images payload: model={config.model}, size={payload.get(resolution_key)}, prompt_len={len(config.prompt)}"
+            f"[openai_images] generations payload: model={model} size={payload.get('size')} "
+            f"quality={payload.get('quality')} style={payload.get('style')} "
+            f"response_format={payload.get('response_format')} prompt_len={len(config.prompt)}"
         )
         return payload
+
+    # ------------------------------------------------------------------
+    # _prepare_edits_payload (图像编辑 multipart/form-data)
+    # ------------------------------------------------------------------
+
+    async def _prepare_edits_payload(
+        self,
+        *,
+        client: Any,
+        config: ApiRequestConfig,
+        settings: dict[str, Any],
+    ) -> dict[str, Any]:  # noqa: ANN401
+        """构建 /v1/images/edits 请求体（multipart/form-data）
+
+        返回 payload dict 中包含 ``_multipart`` 标记和 ``_form_data`` 对象，
+        由 tl_api._perform_request 识别并切换为 FormData 发送。
+        """
+        model = config.model or "dall-e-3"
+        form = aiohttp.FormData()
+
+        # ---- image (required): 第一张参考图 ----
+        ref_images = config.reference_images or []
+        if not ref_images:
+            raise APIError(
+                "/v1/images/edits 需要至少一张参考图",
+                None,
+                "missing_image",
+                retryable=False,
+            )
+
+        image_data = self._decode_image_input(ref_images[0])
+        if image_data is None:
+            raise APIError(
+                "无法解码参考图为二进制数据",
+                None,
+                "invalid_image",
+                retryable=False,
+            )
+        form.add_field(
+            "image",
+            image_data,
+            filename="image.png",
+            content_type="image/png",
+        )
+
+        # ---- 多图支持 (GPT image 模型支持多张 image) ----
+        if _is_gpt_image_model(model) and len(ref_images) > 1:
+            for idx, extra_ref in enumerate(ref_images[1:], start=2):
+                extra_data = self._decode_image_input(extra_ref)
+                if extra_data:
+                    form.add_field(
+                        "image",
+                        extra_data,
+                        filename=f"image_{idx}.png",
+                        content_type="image/png",
+                    )
+
+        # ---- prompt ----
+        form.add_field("prompt", config.prompt)
+
+        # ---- model ----
+        form.add_field("model", model)
+
+        # ---- n ----
+        form.add_field("n", "1")
+
+        # ---- size ----
+        if config.resolution:
+            size_map = _get_size_mapping(model)
+            size_val = size_map.get(config.resolution, config.resolution)
+            form.add_field("size", size_val)
+
+        # ---- response_format ----
+        response_format = str(settings.get("response_format") or "b64_json").strip()
+        form.add_field("response_format", response_format)
+
+        # ---- quality ----
+        quality = str(settings.get("quality") or "").strip()
+        if quality:
+            form.add_field("quality", quality)
+
+        logger.debug(
+            f"[openai_images] edits payload: model={model} ref_images={len(ref_images)} "
+            f"prompt_len={len(config.prompt)}"
+        )
+
+        # 返回带标记的 payload，tl_api 会检测 _multipart 并使用 _form_data 发送
+        return {
+            "_multipart": True,
+            "_form_data": form,
+            "model": model,
+            "prompt": config.prompt,
+        }
+
+    # ------------------------------------------------------------------
+    # helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _decode_image_input(image_input: str) -> bytes | None:
+        """将 base64 字符串或 data URI 解码为二进制数据"""
+        s = (image_input or "").strip()
+        if not s:
+            return None
+
+        # 处理 data URI: data:image/png;base64,xxxx
+        if s.startswith("data:"):
+            parts = s.split(",", 1)
+            if len(parts) == 2:
+                s = parts[1]
+
+        try:
+            return base64.b64decode(s)
+        except Exception:
+            logger.debug(f"[openai_images] 无法 base64 解码图片输入 (len={len(s)})")
+            return None

--- a/tl/api/registry.py
+++ b/tl/api/registry.py
@@ -62,7 +62,7 @@ def get_api_provider(api_type: str | None) -> ApiProvider:
     - `grok2api` -> Grok2ApiProvider
     - `zai` -> ZaiProvider
     - `doubao/volcengine/ark/seedream` -> DoubaoProvider
-    - `openai_images` -> OpenAIImagesProvider (/v1/images/generations)
+    - `openai_images` -> OpenAIImagesProvider (/v1/images/generations + /v1/images/edits)
     - 其他 -> OpenAICompatProvider（用于各类 OpenAI 兼容服务）
     """
     normalized = normalize_api_type(api_type)

--- a/tl/api/registry.py
+++ b/tl/api/registry.py
@@ -12,12 +12,14 @@ from .doubao import DoubaoProvider
 from .google import GoogleProvider
 from .grok2api import Grok2ApiProvider
 from .openai_compat import OpenAICompatProvider
+from .openai_images import OpenAIImagesProvider
 from .zai import ZaiProvider
 
 _DOUBAO: Final[DoubaoProvider] = DoubaoProvider()
 _GOOGLE: Final[GoogleProvider] = GoogleProvider()
 _GROK2API: Final[Grok2ApiProvider] = Grok2ApiProvider()
 _OPENAI: Final[OpenAICompatProvider] = OpenAICompatProvider()
+_OPENAI_IMAGES: Final[OpenAIImagesProvider] = OpenAIImagesProvider()
 _ZAI: Final[ZaiProvider] = ZaiProvider()
 
 # Doubao/Volcengine Ark 相关的 API 类型别名
@@ -60,6 +62,7 @@ def get_api_provider(api_type: str | None) -> ApiProvider:
     - `grok2api` -> Grok2ApiProvider
     - `zai` -> ZaiProvider
     - `doubao/volcengine/ark/seedream` -> DoubaoProvider
+    - `openai_images` -> OpenAIImagesProvider (/v1/images/generations)
     - 其他 -> OpenAICompatProvider（用于各类 OpenAI 兼容服务）
     """
     normalized = normalize_api_type(api_type)
@@ -79,5 +82,9 @@ def get_api_provider(api_type: str | None) -> ApiProvider:
     # Google/Gemini 官方
     if normalized in {"google", "gemini", "googlegenai", "google_genai"}:
         return _GOOGLE
+
+    # OpenAI Images API (/v1/images/generations)
+    if normalized in {"openai_images", "openai_images_api"}:
+        return _OPENAI_IMAGES
 
     return _OPENAI

--- a/tl/api_types.py
+++ b/tl/api_types.py
@@ -38,6 +38,9 @@ class ApiRequestConfig:
     resolution_param_name: str = "image_size"  # 分辨率参数名
     aspect_ratio_param_name: str = "aspect_ratio"  # 长宽比参数名
 
+    # OpenAI Images API 端点选择
+    use_images_endpoint: bool = False  # True 使用 /v1/images/generations，False 使用 /v1/chat/completions
+
 
 class APIError(Exception):
     """API 错误基类"""

--- a/tl/api_types.py
+++ b/tl/api_types.py
@@ -38,9 +38,6 @@ class ApiRequestConfig:
     resolution_param_name: str = "image_size"  # 分辨率参数名
     aspect_ratio_param_name: str = "aspect_ratio"  # 长宽比参数名
 
-    # OpenAI Images API 端点选择
-    use_images_endpoint: bool = False  # True 使用 /v1/images/generations，False 使用 /v1/chat/completions
-
 
 class APIError(Exception):
     """API 错误基类"""

--- a/tl/tl_api.py
+++ b/tl/tl_api.py
@@ -826,24 +826,38 @@ class GeminiAPIClient:
         api_base: str = None,
     ) -> tuple[list[str], list[str], str | None, str | None]:
         """执行实际的HTTP请求"""
+        # 检测 multipart 标记（由 openai_images edits 等需要 FormData 的 provider 设置）
+        is_multipart = payload.get("_multipart", False)
+        form_data = payload.get("_form_data") if is_multipart else None
+
         # 移除内部标记字段，不发送给 API
         send_payload = {k: v for k, v in payload.items() if not k.startswith("_")}
 
         logger.debug(
-            "发送请求: url=%s api_type=%s model=%s payload_keys=%s",
+            "发送请求: url=%s api_type=%s model=%s payload_keys=%s multipart=%s",
             url[:100],
             api_type,
             model,
             list(send_payload.keys()),
+            is_multipart,
         )
 
-        async with session.post(
-            url,
-            json=send_payload,
-            headers=headers,
-            proxy=self._http_proxy,
-            timeout=timeout,
-        ) as response:
+        # multipart 请求需移除 Content-Type（aiohttp 自动设置 boundary）
+        send_headers = dict(headers)
+        if is_multipart and form_data is not None:
+            send_headers.pop("Content-Type", None)
+
+        post_kwargs: dict[str, Any] = {
+            "headers": send_headers,
+            "proxy": self._http_proxy,
+            "timeout": timeout,
+        }
+        if is_multipart and form_data is not None:
+            post_kwargs["data"] = form_data
+        else:
+            post_kwargs["json"] = send_payload
+
+        async with session.post(url, **post_kwargs) as response:
             logger.debug(f"响应状态: {response.status}")
             response_text = await response.text()
             content_type = response.headers.get("Content-Type", "") or ""

--- a/tl/tl_api.py
+++ b/tl/tl_api.py
@@ -20,7 +20,7 @@ import aiohttp
 
 from astrbot.api import logger
 
-from .api import get_api_provider, is_doubao_api_type
+from .api import get_api_provider, is_doubao_api_type, normalize_api_type
 from .api_types import APIError, ApiRequestConfig
 
 try:
@@ -903,6 +903,19 @@ class GeminiAPIClient:
                             api_base,
                             response.status,
                             is_retry=is_retry,
+                        )
+                    # openai_images 使用 provider 自身的解析方法
+                    if normalize_api_type(api_type) in {
+                        "openai_images",
+                        "openai_images_api",
+                    }:
+                        provider = get_api_provider(api_type)
+                        return await provider.parse_response(
+                            client=self,
+                            response_data=response_data,
+                            session=session,
+                            api_base=api_base,
+                            http_status=response.status,
                         )
                     return await self._parse_openai_response(
                         response_data, session, api_base


### PR DESCRIPTION
## 改动说明

<!-- 简要描述本次 PR 的改动内容和目的 -->

## 改动类型

- [ ] Bug 修复
- [x] 新功能
- [ ] 重构 / 代码优化
- [ ] 文档更新
- [ ] 其他

## 关联 Issue

<!-- 如有关联 Issue 请填写，例如 Fixes #123 -->

## 测试情况

- [x] 本地测试通过
- [x] 已测试相关命令（/生图、/改图、/快速 等）
- [x] 已测试 LLM 工具调用

## 补充说明

<!-- 需要 reviewer 特别关注的点、兼容性说明等 -->

## Summary by Sourcery

新增对专用的、兼容 OpenAI 的图像提供方的支持，包括图像生成和图像编辑两个端点，并在 HTTP 客户端中加入 multipart 处理，同时通过配置和提供方注册表完成相关串联。

新功能：
- 引入 `OpenAIImagesProvider`，支持用于文本转图像的 `/v1/images/generations` 和用于图像编辑的 `/v1/images/edits`，包括针对不同模型的尺寸映射以及响应解析。
- 在共享的 HTTP 请求辅助函数中添加 `multipart/form-data` 处理，以支持在图像编辑请求中上传二进制图像数据。
- 将新的 `openai_images` 提供方设置接入配置和 API 客户端，使与图像相关的选项可以按提供方进行自定义。
- 在提供方注册表中注册 `openai_images` API 类型，使其解析为新的 `OpenAIImagesProvider`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for a dedicated OpenAI-compatible images provider, including both image generation and image editing endpoints, with multipart handling in the HTTP client and wiring through configuration and provider registry.

New Features:
- Introduce an OpenAIImagesProvider that supports /v1/images/generations for text-to-image and /v1/images/edits for image editing, including model-specific size mappings and response parsing.
- Add multipart/form-data handling in the shared HTTP request helper to support image edit requests that upload binary image data.
- Wire new openai_images provider settings into the configuration and API client so that image-related options can be customized per provider.
- Register the openai_images API type in the provider registry so it is resolved to the new OpenAIImagesProvider.

</details>