### PR TITLE
feat: 新增 xAI (Grok) 图像生成供应商

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,20 @@
 
 </details>
 
+## [1.9.11] - 2026-04-16
+
+### Added
+
+- 新增 `xai` API 类型，原生支持 xAI 官方 `/v1/images/generations` 和 `/v1/images/edits` JSON 图像接口
+- 新增 `tl/api/xai.py` 供应商实现，支持将参考图统一转为 `data URI` 内联发送，兼容单图编辑和最多 5 张参考图的多图编辑
+- 新增 `provider_overrides[xai]` 配置模板，支持多 Key、每日限额、`response_format`、`n`、代理等参数
+
+### Changed
+
+- `main.py` 增加 `xai_settings` 绑定逻辑，确保 provider override 能注入到 API client
+- `tl/tl_api.py` 现在会让 `xai/grok/grok_image` 走供应商自定义响应解析，正确处理 `data[].url` 和 `data[].b64_json`
+- `README.md` 更新多 API 支持列表和 `xai` 配置说明
+
 ## [1.9.10] - 2026-04-16
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 ### Changed
 
 - `main.py` 增加 `xai_settings` 绑定逻辑，确保 provider override 能注入到 API client
-- `tl/tl_api.py` 现在会让 `xai/grok/grok_image` 走供应商自定义响应解析，正确处理 `data[].url` 和 `data[].b64_json`
+- `tl/tl_api.py` 现在会让 `xai` 走供应商自定义响应解析，正确处理 `data[].url` 和 `data[].b64_json`
 - `README.md` 更新多 API 支持列表和 `xai` 配置说明
 
 ## [1.9.10] - 2026-04-16

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-![Version](https://img.shields.io/badge/Version-v1.9.10-blue)
+![Version](https://img.shields.io/badge/Version-v1.9.11-blue)
 ![License](https://img.shields.io/badge/License-AGPL--3.0-orange)
 
 **🎨 强大的 Gemini 图像生成插件，支持智能头像参考和智能表情包切分**
@@ -19,7 +19,7 @@
 - **智能头像**: 自动获取用户头像和@对象头像作为参考
 - **表情包切分**: SmartMemeSplitter v4 算法自动切割表情包网格
 - **LLM 工具**: 支持自然语言触发生图，前台返回 `CallToolResult` 结构化图片，超时自动转后台
-- **多 API 支持**: Google 官方、OpenAI 兼容、OpenAI Images、Zai、grok2api、豆包（Doubao）
+- **多 API 支持**: Google 官方、OpenAI 兼容、OpenAI Images、xAI Images、Zai、grok2api、豆包（Doubao）
 - **多格式支持**: PNG、JPEG、WEBP、HEIC/HEIF、GIF
 
 ### 🛡️ 限制/限流
@@ -62,7 +62,7 @@
 | 配置项 | 说明 |
 |--------|------|
 | `api_settings.provider_id` | 生图模型提供商（从 AstrBot 提供商列表选择；doubao 无需填写） |
-| `api_settings.api_type` | API 类型：`google`/`openai`/`openai_images`/`zai`/`grok2api`/`doubao` |
+| `api_settings.api_type` | API 类型：`google`/`openai`/`openai_images`/`xai`/`zai`/`grok2api`/`doubao` |
 
 ### 配置项详解
 
@@ -160,6 +160,23 @@
 | `output_compression` | `0` | 输出压缩率滑动条 0-100，0 表示不传（使用服务端默认），仅 GPT image + jpeg/webp |
 | `moderation` | - | 审核模式，仅 GPT image（如 low） |
 | `generations_only` | `false` | 开启后强制只用文生图端点，不走 /v1/images/edits |
+
+**xai_settings**（xAI Images API 专用配置）
+| 配置项 | 默认值 | 说明 |
+|--------|--------|------|
+| `api_keys` | `[]` | API Key 列表，支持多 Key 轮换 |
+| `model` | `grok-imagine-image` | xAI 图像模型名称 |
+| `api_base` | `https://api.x.ai` | API 端点地址 |
+| `response_format` | `url` | 响应格式（`url`/`b64_json`） |
+| `quality` | - | 透传给 xAI 图片接口，留空不传；建议仅在确认接口支持时使用 |
+| `n` | `1` | 单次请求生成数量，当前最多 `10` |
+| `proxy` | - | 独立代理地址 |
+
+> `xai` 供应商会自动走 xAI 官方 JSON 图像接口：
+> - 文生图：`/v1/images/generations`
+> - 改图：`/v1/images/edits`
+>
+> 改图请求会把参考图统一内联为 `data URI`，不使用 `multipart/form-data`。xAI 官方文档当前说明单次编辑最多支持 `5` 张参考图，分辨率支持 `1k/2k`，单图编辑时输出比例默认跟随输入图。
 
 ## 🎯 使用指南
 

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -14,12 +14,13 @@
       "api_type": {
         "description": "API 类型（必选）",
         "type": "string",
-        "hint": "必须选择 API 类型（google/openai/zai/grok2api/doubao）。 不同提供商支持的类型不同，请参考提供商说明",
+        "hint": "必须选择 API 类型（google/openai/openai_images/xai/zai/grok2api/doubao）。 不同提供商支持的类型不同，请参考提供商说明",
         "default": "openai",
         "options": [
           "google",
           "openai",
           "openai_images",
+          "xai",
           "zai",
           "grok2api",
           "doubao"
@@ -185,6 +186,62 @@
                 "type": "string",
                 "hint": "grok2api API 地址",
                 "default": ""
+              },
+              "proxy": {
+                "description": "代理地址",
+                "type": "string",
+                "hint": "填写即启用代理，留空使用全局代理或环境变量。支持 http://host:port、https://host:port、socks5://host:port 格式。优先级高于全局代理和环境变量",
+                "default": ""
+              }
+            }
+          },
+          "xai": {
+            "description": "xAI Images API 覆盖配置",
+            "hint": "配置 xAI /v1/images/generations 和 /v1/images/edits 端点的密钥和参数",
+            "items": {
+              "api_keys": {
+                "description": "API Key 列表",
+                "type": "list",
+                "hint": "多个 API Key，支持轮换使用",
+                "default": []
+              },
+              "daily_limit_per_key": {
+                "description": "每个 Key 每日限额",
+                "type": "int",
+                "hint": "每个 API Key 每日最大调用次数，0 表示不限制",
+                "default": 0
+              },
+              "model": {
+                "description": "模型名称",
+                "type": "string",
+                "hint": "xAI 图像模型名称",
+                "default": "grok-imagine-image"
+              },
+              "api_base": {
+                "description": "API 端点地址",
+                "type": "string",
+                "hint": "xAI API 地址，留空使用默认 https://api.x.ai",
+                "default": "https://api.x.ai"
+              },
+              "response_format": {
+                "description": "响应格式",
+                "type": "string",
+                "hint": "url 返回临时链接，b64_json 返回 base64 编码。",
+                "default": "url",
+                "options": ["url", "b64_json"]
+              },
+              "quality": {
+                "description": "图像质量",
+                "type": "string",
+                "hint": "透传给 xAI 图片接口，留空不传。建议仅在已确认接口支持时使用。",
+                "default": "",
+                "options": ["", "low", "medium", "high"]
+              },
+              "n": {
+                "description": "生成数量",
+                "type": "int",
+                "hint": "单次请求生成的图片数量，xAI 当前单次最多 10 张",
+                "default": 1
               },
               "proxy": {
                 "description": "代理地址",

--- a/main.py
+++ b/main.py
@@ -293,7 +293,7 @@ class GeminiImageGenerationPlugin(Star):
         elif not self.cfg.api_type:
             if not quiet:
                 logger.error(
-                    "✗ 未配置 api_settings.api_type（google/openai/zai/grok2api/doubao），无法初始化 API 客户端"
+                    "✗ 未配置 api_settings.api_type（google/openai/openai_images/xai/zai/grok2api/doubao），无法初始化 API 客户端"
                 )
             return
 
@@ -374,6 +374,8 @@ class GeminiImageGenerationPlugin(Star):
             # 绑定完整 settings 供适配器使用
             if api_type_norm == "doubao":
                 self.cfg.doubao_settings = override_settings
+            elif api_type_norm == "xai":
+                self.cfg.xai_settings = override_settings
             elif api_type_norm == "openai_images":
                 self.cfg.openai_images_settings = override_settings
 
@@ -392,6 +394,13 @@ class GeminiImageGenerationPlugin(Star):
                     )
                 except Exception as e:
                     logger.debug(f"绑定 doubao_settings 到 API client 失败: {e}")
+            elif api_type_norm == "xai":
+                try:
+                    self.api_client.xai_settings = (
+                        getattr(self.cfg, "xai_settings", None) or {}
+                    )
+                except Exception as e:
+                    logger.debug(f"绑定 xai_settings 到 API client 失败: {e}")
             elif api_type_norm == "openai_images":
                 try:
                     self.api_client.openai_images_settings = (

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,7 +1,7 @@
 name: astrbot_plugin_gemini_image_generation
 desc: Gemini图像生成插件，支持生图和改图，支持自动获取头像作为参考
 display_name: Gemini 图像生成
-version: v1.9.10
+version: v1.9.11
 author: piexian
 repo: https://github.com/piexian/astrbot_plugin_gemini_image_generation
 astrbot_version: ">=4.10.4"

--- a/tl/api/registry.py
+++ b/tl/api/registry.py
@@ -13,6 +13,7 @@ from .google import GoogleProvider
 from .grok2api import Grok2ApiProvider
 from .openai_compat import OpenAICompatProvider
 from .openai_images import OpenAIImagesProvider
+from .xai import XAIProvider
 from .zai import ZaiProvider
 
 _DOUBAO: Final[DoubaoProvider] = DoubaoProvider()
@@ -20,6 +21,7 @@ _GOOGLE: Final[GoogleProvider] = GoogleProvider()
 _GROK2API: Final[Grok2ApiProvider] = Grok2ApiProvider()
 _OPENAI: Final[OpenAICompatProvider] = OpenAICompatProvider()
 _OPENAI_IMAGES: Final[OpenAIImagesProvider] = OpenAIImagesProvider()
+_XAI: Final[XAIProvider] = XAIProvider()
 _ZAI: Final[ZaiProvider] = ZaiProvider()
 
 # Doubao/Volcengine Ark 相关的 API 类型别名
@@ -60,6 +62,7 @@ def get_api_provider(api_type: str | None) -> ApiProvider:
     当前映射：
     - `google/gemini/...` -> GoogleProvider
     - `grok2api` -> Grok2ApiProvider
+    - `xai/grok/grok_image` -> XAIProvider
     - `zai` -> ZaiProvider
     - `doubao/volcengine/ark/seedream` -> DoubaoProvider
     - `openai_images` -> OpenAIImagesProvider (/v1/images/generations + /v1/images/edits)
@@ -78,6 +81,10 @@ def get_api_provider(api_type: str | None) -> ApiProvider:
     # grok2api 独立供应商
     if normalized in {"grok2api", "grok2_api"} or normalized.startswith("grok2api_"):
         return _GROK2API
+
+    # xAI 官方图像 API
+    if normalized in {"xai", "grok", "grok_image"} or normalized.startswith("xai_"):
+        return _XAI
 
     # Google/Gemini 官方
     if normalized in {"google", "gemini", "googlegenai", "google_genai"}:

--- a/tl/api/registry.py
+++ b/tl/api/registry.py
@@ -62,7 +62,7 @@ def get_api_provider(api_type: str | None) -> ApiProvider:
     当前映射：
     - `google/gemini/...` -> GoogleProvider
     - `grok2api` -> Grok2ApiProvider
-    - `xai/grok/grok_image` -> XAIProvider
+    - `xai` -> XAIProvider
     - `zai` -> ZaiProvider
     - `doubao/volcengine/ark/seedream` -> DoubaoProvider
     - `openai_images` -> OpenAIImagesProvider (/v1/images/generations + /v1/images/edits)
@@ -83,7 +83,7 @@ def get_api_provider(api_type: str | None) -> ApiProvider:
         return _GROK2API
 
     # xAI 官方图像 API
-    if normalized in {"xai", "grok", "grok_image"} or normalized.startswith("xai_"):
+    if normalized == "xai":
         return _XAI
 
     # Google/Gemini 官方

--- a/tl/api/xai.py
+++ b/tl/api/xai.py
@@ -1,0 +1,402 @@
+"""xAI Images API 供应商实现。
+
+支持：
+- /v1/images/generations  文生图（JSON 请求）
+- /v1/images/edits        图像编辑（JSON 请求）
+
+xAI 的图像编辑端点要求 `application/json`，不支持 OpenAI SDK `images.edit()`
+使用的 `multipart/form-data`。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import aiohttp
+
+from astrbot.api import logger
+
+from ..api_types import APIError, ApiRequestConfig
+from ..tl_utils import save_base64_image
+from .base import ProviderRequest
+
+_SUPPORTED_RESOLUTIONS: frozenset[str] = frozenset({"1k", "2k"})
+_SUPPORTED_RESPONSE_FORMATS: frozenset[str] = frozenset({"url", "b64_json"})
+_MAX_EDIT_IMAGES = 5
+_MAX_BATCH_IMAGES = 10
+
+
+class XAIProvider:
+    """xAI `/v1/images/*` 端点实现。"""
+
+    name = "xai"
+
+    async def build_request(
+        self, *, client: Any, config: ApiRequestConfig
+    ) -> ProviderRequest:  # noqa: ANN401
+        settings: dict[str, Any] = getattr(client, "xai_settings", None) or {}
+        api_base = (config.api_base or settings.get("api_base") or "").rstrip("/")
+        base = api_base or "https://api.x.ai"
+
+        has_ref_images = bool(config.reference_images)
+        endpoint = "images/edits" if has_ref_images else "images/generations"
+        url = f"{base}/{endpoint}" if base.endswith("/v1") else f"{base}/v1/{endpoint}"
+
+        if has_ref_images:
+            payload = await self._prepare_edits_payload(
+                client=client,
+                config=config,
+                settings=settings,
+            )
+        else:
+            payload = await self._prepare_generations_payload(
+                config=config,
+                settings=settings,
+            )
+
+        logger.debug("[xai] URL: %s (edits=%s)", url, has_ref_images)
+        return ProviderRequest(
+            url=url,
+            headers={
+                "Authorization": f"Bearer {config.api_key}",
+                "Content-Type": "application/json",
+            },
+            payload=payload,
+        )
+
+    async def parse_response(
+        self,
+        *,
+        client: Any,
+        response_data: dict[str, Any],
+        session: aiohttp.ClientSession,
+        api_base: str | None = None,
+        http_status: int | None = None,
+    ) -> tuple[list[str], list[str], str | None, str | None]:  # noqa: ANN401
+        image_urls: list[str] = []
+        image_paths: list[str] = []
+        text_content = None
+        thought_signature = None
+
+        usage = response_data.get("usage")
+        if isinstance(usage, dict):
+            in_tok = usage.get("input_tokens", 0)
+            out_tok = usage.get("output_tokens", 0)
+            total_tok = usage.get("total_tokens", in_tok + out_tok)
+            logger.info(
+                "[xai] Token 用量: input=%s output=%s total=%s",
+                in_tok,
+                out_tok,
+                total_tok,
+            )
+
+        moderation_states: list[bool] = []
+        respect_moderation = response_data.get("respect_moderation")
+        if isinstance(respect_moderation, bool):
+            moderation_states.append(respect_moderation)
+
+        resp_output_format = response_data.get("output_format") or ""
+        default_save_ext = (
+            resp_output_format
+            if resp_output_format in {"png", "jpeg", "webp"}
+            else "png"
+        )
+
+        if not response_data.get("data"):
+            error_obj = response_data.get("error")
+            if error_obj:
+                error_msg = (
+                    error_obj.get("message", "未知错误")
+                    if isinstance(error_obj, dict)
+                    else str(error_obj)
+                )
+                logger.warning("[xai] API 返回错误: %s", error_msg)
+                raise APIError(
+                    f"图像生成失败: {error_msg}",
+                    http_status,
+                    "api_error",
+                    error_obj.get("code") if isinstance(error_obj, dict) else None,
+                    retryable=False,
+                )
+            logger.warning("[xai] 响应无 data 字段: %s", response_data)
+            raise APIError(
+                "API 响应格式不正确，缺少 data 字段",
+                None,
+                "invalid_response",
+                retryable=True,
+            )
+
+        for image_item in response_data["data"]:
+            if not isinstance(image_item, dict):
+                continue
+
+            item_moderation = image_item.get("respect_moderation")
+            if isinstance(item_moderation, bool):
+                moderation_states.append(item_moderation)
+
+            if "url" in image_item:
+                image_url = image_item["url"]
+                if isinstance(image_url, str) and image_url:
+                    image_urls.append(image_url)
+                    logger.debug("[xai] 图片 URL: %s...", image_url[:80])
+            elif "b64_json" in image_item:
+                b64_data = image_item["b64_json"]
+                if isinstance(b64_data, str) and b64_data:
+                    item_save_ext = self._extension_from_mime_type(
+                        image_item.get("mime_type")
+                    )
+                    image_path = await save_base64_image(
+                        b64_data, item_save_ext or default_save_ext
+                    )
+                    if image_path:
+                        image_urls.append(image_path)
+                        image_paths.append(image_path)
+                        logger.debug(
+                            "[xai] base64 图片 (%s): %s 字节",
+                            item_save_ext or default_save_ext,
+                            len(b64_data),
+                        )
+
+            revised = image_item.get("revised_prompt")
+            if revised:
+                text_content = f"修订提示词: {revised}"
+                logger.debug("[xai] 修订提示词: %s...", revised[:100])
+
+        if moderation_states:
+            logger.info("[xai] respect_moderation=%s", all(moderation_states))
+
+        if image_urls or image_paths:
+            logger.debug("[xai] 共 %s 张图片", len(image_urls))
+            return image_urls, image_paths, text_content, thought_signature
+
+        error_obj = response_data.get("error") or {}
+        error_msg = (
+            error_obj.get("message", "未知错误")
+            if isinstance(error_obj, dict)
+            else str(error_obj)
+        )
+        logger.warning("[xai] 未返回图片: %s", error_msg)
+        raise APIError(
+            f"图像生成失败: {error_msg}",
+            http_status,
+            "no_image",
+            error_obj.get("code") if isinstance(error_obj, dict) else None,
+            retryable=False,
+        )
+
+    async def _prepare_generations_payload(
+        self,
+        *,
+        config: ApiRequestConfig,
+        settings: dict[str, Any],
+    ) -> dict[str, Any]:
+        model = str(
+            settings.get("model") or config.model or "grok-imagine-image"
+        ).strip()
+        payload: dict[str, Any] = {
+            "model": model,
+            "prompt": config.prompt,
+            "n": self._coerce_image_count(settings.get("n")),
+        }
+
+        aspect_ratio = self._normalize_aspect_ratio(config.aspect_ratio)
+        if aspect_ratio:
+            payload["aspect_ratio"] = aspect_ratio
+
+        resolution = self._normalize_resolution(config.resolution)
+        if resolution:
+            payload["resolution"] = resolution
+
+        response_format = self._normalize_response_format(
+            settings.get("response_format")
+        )
+        if response_format:
+            payload["response_format"] = response_format
+
+        quality = self._normalize_quality(settings.get("quality"))
+        if quality:
+            payload["quality"] = quality
+
+        logger.debug(
+            "[xai] generations payload: model=%s n=%s aspect_ratio=%s resolution=%s "
+            "response_format=%s quality=%s prompt_len=%s",
+            model,
+            payload.get("n"),
+            payload.get("aspect_ratio"),
+            payload.get("resolution"),
+            payload.get("response_format"),
+            payload.get("quality"),
+            len(config.prompt),
+        )
+        return payload
+
+    async def _prepare_edits_payload(
+        self,
+        *,
+        client: Any,
+        config: ApiRequestConfig,
+        settings: dict[str, Any],
+    ) -> dict[str, Any]:
+        ref_images = config.reference_images or []
+        if not ref_images:
+            raise APIError(
+                "/v1/images/edits 需要至少一张参考图",
+                None,
+                "missing_image",
+                retryable=False,
+            )
+        if len(ref_images) > _MAX_EDIT_IMAGES:
+            raise APIError(
+                f"xAI /v1/images/edits 最多支持 {_MAX_EDIT_IMAGES} 张参考图",
+                None,
+                "too_many_images",
+                retryable=False,
+            )
+
+        model = str(
+            settings.get("model") or config.model or "grok-imagine-image"
+        ).strip()
+        payload: dict[str, Any] = {
+            "model": model,
+            "prompt": config.prompt,
+            "n": self._coerce_image_count(settings.get("n")),
+        }
+
+        image_items = [
+            {"type": "image_url", "url": await self._to_image_url(client, config, ref)}
+            for ref in ref_images
+        ]
+        if len(image_items) == 1:
+            payload["image"] = image_items[0]
+        else:
+            payload["images"] = image_items
+
+        if len(image_items) > 1:
+            aspect_ratio = self._normalize_aspect_ratio(config.aspect_ratio)
+            if aspect_ratio:
+                payload["aspect_ratio"] = aspect_ratio
+        elif config.aspect_ratio:
+            logger.debug("[xai] 单图 edits 忽略 aspect_ratio，输出比例跟随输入图")
+
+        resolution = self._normalize_resolution(config.resolution)
+        if resolution:
+            payload["resolution"] = resolution
+
+        response_format = self._normalize_response_format(
+            settings.get("response_format")
+        )
+        if response_format:
+            payload["response_format"] = response_format
+
+        quality = self._normalize_quality(settings.get("quality"))
+        if quality:
+            payload["quality"] = quality
+
+        logger.debug(
+            "[xai] edits payload: model=%s n=%s ref_images=%s aspect_ratio=%s resolution=%s "
+            "response_format=%s quality=%s prompt_len=%s",
+            model,
+            payload.get("n"),
+            len(image_items),
+            payload.get("aspect_ratio"),
+            payload.get("resolution"),
+            payload.get("response_format"),
+            payload.get("quality"),
+            len(config.prompt),
+        )
+        return payload
+
+    async def _to_image_url(
+        self, client: Any, config: ApiRequestConfig, image_input: str
+    ) -> str:  # noqa: ANN401
+        image_str = str(image_input or "").strip()
+        if not image_str:
+            raise APIError(
+                "参考图为空",
+                None,
+                "invalid_image",
+                retryable=False,
+            )
+
+        if image_str.startswith("data:image/") and ";base64," in image_str:
+            return image_str
+
+        mime_type, b64_data = await client._normalize_image_input(
+            image_str,
+            image_input_mode=getattr(config, "image_input_mode", "force_base64"),
+        )
+        if not b64_data:
+            raise APIError(
+                "无法将参考图转换为 xAI 所需的 data URI",
+                None,
+                "invalid_image",
+                retryable=False,
+            )
+
+        mime = mime_type or "image/png"
+        return f"data:{mime};base64,{b64_data}"
+
+    @staticmethod
+    def _coerce_image_count(value: Any) -> int:
+        try:
+            count = int(value)
+        except (TypeError, ValueError):
+            count = 1
+        if count < 1:
+            return 1
+        if count > _MAX_BATCH_IMAGES:
+            logger.warning(
+                "[xai] n=%s 超出上限，已自动降级到 %s",
+                count,
+                _MAX_BATCH_IMAGES,
+            )
+            return _MAX_BATCH_IMAGES
+        return count
+
+    @staticmethod
+    def _normalize_aspect_ratio(value: Any) -> str | None:
+        aspect_ratio = str(value or "").strip()
+        return aspect_ratio or None
+
+    @staticmethod
+    def _normalize_resolution(value: Any) -> str | None:
+        resolution = str(value or "").strip().lower()
+        if not resolution:
+            return None
+        if resolution in _SUPPORTED_RESOLUTIONS:
+            return resolution
+        if resolution == "4k":
+            logger.warning("[xai] 4K 不受支持，已自动降级为 2k")
+            return "2k"
+        logger.warning("[xai] 忽略不支持的 resolution=%s，仅支持 1k/2k", value)
+        return None
+
+    @staticmethod
+    def _normalize_response_format(value: Any) -> str | None:
+        response_format = str(value or "").strip().lower()
+        if not response_format:
+            return None
+        if response_format in _SUPPORTED_RESPONSE_FORMATS:
+            return response_format
+        logger.warning(
+            "[xai] 忽略不支持的 response_format=%s，仅支持 url/b64_json",
+            value,
+        )
+        return None
+
+    @staticmethod
+    def _normalize_quality(value: Any) -> str | None:
+        quality = str(value or "").strip().lower()
+        return quality or None
+
+    @staticmethod
+    def _extension_from_mime_type(value: Any) -> str | None:
+        mime_type = str(value or "").strip().lower()
+        if not mime_type.startswith("image/"):
+            return None
+        ext = mime_type.split("/", 1)[1]
+        if ext == "jpg":
+            return "jpeg"
+        if ext in {"jpeg", "png", "webp"}:
+            return ext
+        return None

--- a/tl/api/xai.py
+++ b/tl/api/xai.py
@@ -11,6 +11,7 @@ xAI 的图像编辑端点要求 `application/json`，不支持 OpenAI SDK `image
 from __future__ import annotations
 
 from typing import Any
+import urllib.parse
 
 import aiohttp
 
@@ -35,8 +36,8 @@ class XAIProvider:
         self, *, client: Any, config: ApiRequestConfig
     ) -> ProviderRequest:  # noqa: ANN401
         settings: dict[str, Any] = getattr(client, "xai_settings", None) or {}
-        api_base = (config.api_base or settings.get("api_base") or "").rstrip("/")
-        base = api_base or "https://api.x.ai"
+        raw_api_base = config.api_base or settings.get("api_base") or ""
+        base = self._normalize_api_base(raw_api_base) or "https://api.x.ai"
 
         has_ref_images = bool(config.reference_images)
         endpoint = "images/edits" if has_ref_images else "images/generations"
@@ -196,7 +197,7 @@ class XAIProvider:
         payload: dict[str, Any] = {
             "model": model,
             "prompt": config.prompt,
-            "n": self._coerce_image_count(settings.get("n")),
+            "n": self._get_requested_image_count(config, settings),
         }
 
         aspect_ratio = self._normalize_aspect_ratio(config.aspect_ratio)
@@ -259,7 +260,7 @@ class XAIProvider:
         payload: dict[str, Any] = {
             "model": model,
             "prompt": config.prompt,
-            "n": self._coerce_image_count(settings.get("n")),
+            "n": self._get_requested_image_count(config, settings),
         }
 
         image_items = [
@@ -354,6 +355,38 @@ class XAIProvider:
         return count
 
     @staticmethod
+    def _get_requested_image_count(
+        config: ApiRequestConfig, settings: dict[str, Any]
+    ) -> int:
+        config_n = getattr(config, "n", None)
+        return XAIProvider._coerce_image_count(
+            config_n if config_n is not None else settings.get("n")
+        )
+
+    @staticmethod
+    def _normalize_api_base(value: Any) -> str | None:
+        raw_api_base = str(value or "").strip().rstrip("/")
+        if not raw_api_base:
+            return None
+
+        parsed = urllib.parse.urlsplit(raw_api_base)
+        if parsed.scheme and parsed.netloc:
+            path = parsed.path.rstrip("/")
+            normalized_path = "/v1" if path.startswith("/v1") else ""
+            normalized = urllib.parse.urlunsplit(
+                (parsed.scheme, parsed.netloc, normalized_path, "", "")
+            )
+            if normalized != raw_api_base:
+                logger.debug(
+                    "[xai] 规范化 api_base: %s -> %s",
+                    raw_api_base,
+                    normalized,
+                )
+            return normalized
+
+        return raw_api_base
+
+    @staticmethod
     def _normalize_aspect_ratio(value: Any) -> str | None:
         aspect_ratio = str(value or "").strip()
         return aspect_ratio or None
@@ -394,7 +427,7 @@ class XAIProvider:
         mime_type = str(value or "").strip().lower()
         if not mime_type.startswith("image/"):
             return None
-        ext = mime_type.split("/", 1)[1]
+        ext = mime_type.split(";", 1)[0].split("/")[-1]
         if ext == "jpg":
             return "jpeg"
         if ext in {"jpeg", "png", "webp"}:

--- a/tl/tl_api.py
+++ b/tl/tl_api.py
@@ -909,8 +909,6 @@ class GeminiAPIClient:
                         "openai_images",
                         "openai_images_api",
                         "xai",
-                        "grok",
-                        "grok_image",
                     }:
                         provider = get_api_provider(api_type)
                         return await provider.parse_response(

--- a/tl/tl_api.py
+++ b/tl/tl_api.py
@@ -904,10 +904,13 @@ class GeminiAPIClient:
                             response.status,
                             is_retry=is_retry,
                         )
-                    # openai_images 使用 provider 自身的解析方法
+                    # OpenAI Images / xAI Images 使用 provider 自身的解析方法
                     if normalize_api_type(api_type) in {
                         "openai_images",
                         "openai_images_api",
+                        "xai",
+                        "grok",
+                        "grok_image",
                     }:
                         provider = get_api_provider(api_type)
                         return await provider.parse_response(


### PR DESCRIPTION
## 改动说明

- 新增 tl/api/xai.py，原生支持 xAI 官方 /v1/images/generations（文生图） 和 /v1/images/edits（改图）JSON 接口，参考图统一转为 data URI 内联发送
- 注册 xai/grok/grok_image 类型别名，支持单图和多图（最多 5 张）编辑
- _conf_schema.json 新增 xai provider override 模板（api_keys/model/ response_format/quality/n/proxy）
- main.py 增加 xai_settings 绑定逻辑
- tl/tl_api.py 让 xai 类型走供应商自定义响应解析
- 版本升级至 v1.9.11

<!-- 简要描述本次 PR 的改动内容和目的 -->

## 改动类型

- [ ] Bug 修复
- [x] 新功能
- [ ] 重构 / 代码优化
- [x] 文档更新
- [ ] 其他

## 关联 Issue

<!-- 如有关联 Issue 请填写，例如 Fixes #123 -->

## 测试情况

- [ ] 本地测试通过
- [ ] 已测试相关命令（/生图、/改图、/快速 等）
- [ ] 已测试 LLM 工具调用

## 补充说明

<!-- 需要 reviewer 特别关注的点、兼容性说明等 -->

## Summary by Sourcery

为原生 xAI（Grok）图像 API 提供支持，并将其接入到 provider 注册表和配置系统中。

新功能：
- 引入一个 xAI 图像 provider，实现 `/v1/images/generations` 和 `/v1/images/edits`，支持 URL 和 base64 输出、多个参考图像，以及 data URI 内联。

增强：
- 将 xAI 图像 provider 注册为 `xai/grok/grok_image` 类型，并通过 provider 特定的响应解析路径进行处理。
- 将来自 provider 覆盖（overrides）的 `xai_settings` 绑定到运行时配置和 API 客户端中，以便使用 xAI 专属选项。

构建：
- 在元数据中将插件版本从 `v1.9.10` 提升到 `v1.9.11`。

文档：
- 更新 README 和配置 schema，加入 `xai` API 类型、`xai_settings` 选项，以及 xAI 图像生成与编辑的使用说明。
- 添加一条变更日志记录，描述新的 xAI 图像 provider 及其相关配置接线（wiring）。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add native xAI (Grok) image API support and wire it into the provider registry and config system.

New Features:
- Introduce an xAI image provider implementing /v1/images/generations and /v1/images/edits with support for URL and base64 outputs, multiple reference images, and data URI inlining.

Enhancements:
- Register the xAI image provider under xai/grok/grok_image types and route these through provider-specific response parsing.
- Bind xai_settings from provider overrides into the runtime configuration and API client so xAI-specific options can be used.

Build:
- Bump plugin version from v1.9.10 to v1.9.11 in metadata.

Documentation:
- Update README and configuration schema with xai API type, xai_settings options, and usage notes for xAI image generation and editing.
- Add a changelog entry describing the new xAI image provider and related configuration wiring.

</details>