### PR TITLE
fix:错误透传thought_signature信息到llm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@
 
 </details>
 
+## [1.9.12] - 2026-04-21
+
+### Fixed
+
+- 修复 Gemini 图像工具调用路径错误透传 `thought_signature` 的问题
+  - 不再将 `thought_signature` 拼入 `CallToolResult` 或 Tool 返回文本，避免 AstrBot 将超大签名重新注入 LLM 上下文
+  - 统一将 `thought_signature` 视为仅限协议层/调试使用的 opaque 元数据，默认直接丢弃，不再参与用户可见结果
+  - 调试日志改为仅输出受限预览和长度，避免超长签名污染日志或被后续误用
+- 修复部分 Gemini / NewAPI 网关下 LLM 工具生图成功后，复核阶段因上下文膨胀触发 `413` / `输入Tokens数量超过系统限制` 的问题
+
 ## [1.9.11] - 2026-04-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-![Version](https://img.shields.io/badge/Version-v1.9.11-blue)
+![Version](https://img.shields.io/badge/Version-v1.9.12-blue)
 ![License](https://img.shields.io/badge/License-AGPL--3.0-orange)
 
 **🎨 强大的 Gemini 图像生成插件，支持智能头像参考和智能表情包切分**
@@ -19,6 +19,7 @@
 - **智能头像**: 自动获取用户头像和@对象头像作为参考
 - **表情包切分**: SmartMemeSplitter v4 算法自动切割表情包网格
 - **LLM 工具**: 支持自然语言触发生图，前台返回 `CallToolResult` 结构化图片，超时自动转后台
+- **安全回传**: 自动过滤 Gemini `thought_signature`，避免超大签名误注入工具结果导致上下文膨胀
 - **多 API 支持**: Google 官方、OpenAI 兼容、OpenAI Images、xAI Images、Zai、grok2api、豆包（Doubao）
 - **多格式支持**: PNG、JPEG、WEBP、HEIC/HEIF、GIF
 
@@ -233,6 +234,8 @@
 
 **混合触发模式**：LLM 工具会根据当前 `tool_call_timeout` 和 `llm_tool_timeout_reserve_percent` 自动计算前台等待窗口；如果图片在窗口内生成完成，以 `CallToolResult`（含 `ImageContent`）结构化返回给框架，由模型决定后续操作。若超过等待窗口，则自动切到后台继续生成，完成后通过 `event.send()` 直接发送给用户。代理模式下前台和后台均通过代理下载远程图片，确保全链路可用。
 
+**Gemini 思维签名处理**：插件会把 Gemini 返回的 `thought_signature` 视为仅限协议层使用的 opaque 元数据，不会再把它拼进 Tool 文本结果或用户可见内容。这样可以避免部分 Gemini / NewAPI 网关把超大签名重新塞回上下文，导致 `413` 或“输入 Tokens 数量超过系统限制”。
+
 **论坛发帖模式**：当用户要求将图片发到论坛/AstrBook 时，AI 会设置 `for_forum=true`，此时工具同步等待生成完成并返回图片路径/URL，AI 可自动调用 `upload_image` 上传图床后完成全自动发帖流程。
 
 ### 表情包切分算法
@@ -249,6 +252,7 @@ SmartMemeSplitter v4 特点：
 |------|----------|
 | API 错误 | 检查 API 密钥、模型名称（如 `gemini-3-pro-image-preview`）、api_type 配置 |
 | 生成超时 | 降低分辨率、简化提示词、增加工具超时时间（推荐 100s+） |
+| LLM 工具生图后报 `413` / 上下文爆炸 | 升级到 `v1.9.12+`；该版本已过滤 `thought_signature`，不再把超大签名回灌到 Tool 结果 |
 | 无法获取头像 | 确认使用 NapCat 平台 |
 | 切图效果不佳 | 手动指定网格 `/切图 4 4` 或配置视觉提供商 |
 | 中文乱码 (local 模式) | 等待字体自动下载或手动放置 `.ttf` 字体到 `tl/` 目录 |

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,7 +1,7 @@
 name: astrbot_plugin_gemini_image_generation
 desc: Gemini图像生成插件，支持生图和改图，支持自动获取头像作为参考
 display_name: Gemini 图像生成
-version: v1.9.11
+version: v1.9.12
 author: piexian
 repo: https://github.com/piexian/astrbot_plugin_gemini_image_generation
 astrbot_version: ">=4.10.4"

--- a/tl/api/google.py
+++ b/tl/api/google.py
@@ -12,6 +12,7 @@ import aiohttp
 from astrbot.api import logger
 
 from ..api_types import APIError, ApiRequestConfig
+from ..thought_signature import log_thought_signature_debug
 from ..tl_utils import get_temp_dir, save_base64_image
 from .base import ProviderRequest
 
@@ -327,8 +328,12 @@ class GoogleProvider:
                     logger.debug(f"检查候选 {idx} 的第 {i} 个part: {list(part.keys())}")
 
                     if "thoughtSignature" in part and not thought_signature:
+                        # 这里只保留原始签名供 Provider 协议层续传，不能把它当普通文本使用。
                         thought_signature = part["thoughtSignature"]
-                        logger.debug(f"找到思维签名: {thought_signature[:50]}...")
+                        log_thought_signature_debug(
+                            thought_signature,
+                            scene=f"Google候选{idx}",
+                        )
 
                     if "text" in part and isinstance(part.get("text"), str):
                         text_chunks.append(part.get("text", ""))

--- a/tl/image_generator.py
+++ b/tl/image_generator.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 from astrbot.api import logger
 
+from .thought_signature import log_thought_signature_debug
 from .tl_api import APIError, ApiRequestConfig
 from .tl_utils import send_file
 
@@ -227,8 +228,7 @@ The last {final_avatar_count} image(s) provided are User Avatars (marked as opti
                 f"🖼️ API 返回图片数量: {len(image_paths)}, URL 数量: {len(image_urls)}"
             )
 
-            if thought_signature:
-                logger.debug(f"思维签名: {thought_signature[:50]}...")
+            log_thought_signature_debug(thought_signature, scene="图像生成完成")
 
             resolved_paths: list[str] = []
             for idx, img_path in enumerate(image_paths):

--- a/tl/llm_tools.py
+++ b/tl/llm_tools.py
@@ -21,6 +21,7 @@ from astrbot.core.agent.run_context import ContextWrapper
 from astrbot.core.agent.tool import FunctionTool, ToolExecResult
 from astrbot.core.astr_agent_context import AstrAgentContext
 
+from .thought_signature import log_thought_signature_debug
 from .tl_utils import encode_file_to_base64, format_error_message
 
 if TYPE_CHECKING:
@@ -86,7 +87,9 @@ def _image_to_base64_content(image_ref: str) -> mcp.types.ImageContent | None:
         try:
             header, b64_data = image_ref.split(";base64,", 1)
             mime_type = header.replace("data:", "")
-            return mcp.types.ImageContent(type="image", data=b64_data, mimeType=mime_type)
+            return mcp.types.ImageContent(
+                type="image", data=b64_data, mimeType=mime_type
+            )
         except Exception:
             return None
 
@@ -100,7 +103,9 @@ def _image_to_base64_content(image_ref: str) -> mcp.types.ImageContent | None:
             ext = os.path.splitext(fs_candidate)[1].lower()
             mime_type = _MIME_TYPE_MAP.get(ext, "image/png")
             b64_data = encode_file_to_base64(fs_candidate)
-            return mcp.types.ImageContent(type="image", data=b64_data, mimeType=mime_type)
+            return mcp.types.ImageContent(
+                type="image", data=b64_data, mimeType=mime_type
+            )
         except Exception as e:
             logger.warning(f"[CallToolResult] 编码图片失败: {e}")
             return None
@@ -113,7 +118,6 @@ async def _build_call_tool_result(
     image_urls: list[str] | None,
     image_paths: list[str] | None,
     text_content: str | None,
-    thought_signature: str | None,
     message_sender: Any,
     api_client: Any | None = None,
 ) -> mcp.types.CallToolResult:
@@ -187,8 +191,7 @@ async def _build_call_tool_result(
 
     if remaining_urls:
         url_lines = [
-            f"Image URL ({i + 1}): {url}"
-            for i, url in enumerate(remaining_urls)
+            f"Image URL ({i + 1}): {url}" for i, url in enumerate(remaining_urls)
         ]
         contents.append(
             mcp.types.TextContent(
@@ -207,12 +210,10 @@ async def _build_call_tool_result(
     text_parts: list[str] = []
     if prepared_text:
         text_parts.append(prepared_text)
-    if thought_signature:
-        text_parts.append(thought_signature)
+    # thought signature 只能留在 Provider 协议层，绝不能拼进 Tool 文本结果。
+    # 否则下游 Runner 会把这类超大 opaque 数据重新塞回上下文。
     if text_parts:
-        contents.append(
-            mcp.types.TextContent(type="text", text="\n".join(text_parts))
-        )
+        contents.append(mcp.types.TextContent(type="text", text="\n".join(text_parts)))
 
     if not contents:
         contents.append(
@@ -750,7 +751,6 @@ class GeminiImageGenerationTool(FunctionTool[AstrAgentContext]):
                             image_urls=image_urls,
                             image_paths=image_paths,
                             text_content=text_content,
-                            thought_signature=thought_signature,
                             message_sender=plugin.message_sender,
                             api_client=plugin.api_client,
                         ),
@@ -780,9 +780,7 @@ class GeminiImageGenerationTool(FunctionTool[AstrAgentContext]):
                     )
             else:
                 error_msg = (
-                    result_data
-                    if isinstance(result_data, str)
-                    else "❌ 图像生成失败"
+                    result_data if isinstance(result_data, str) else "❌ 图像生成失败"
                 )
                 return error_msg
         except asyncio.TimeoutError:
@@ -913,8 +911,9 @@ async def execute_image_generation_tool(
         results: list[Any] = []
         if text_content:
             results.append(text_content)
-        if thought_signature:
-            results.append(thought_signature)
+        # thought signature 只允许作为内部调试/协议层元数据存在，不能返回给
+        # Tool 调用方，更不能让 Agent 把它当成普通文本继续消费。
+        log_thought_signature_debug(thought_signature, scene="Tool结果已丢弃")
 
         # 添加图片
         for img_path in image_paths or []:

--- a/tl/message_sender.py
+++ b/tl/message_sender.py
@@ -12,6 +12,7 @@ from astrbot.api import logger
 from astrbot.api.message_components import Image as AstrImage
 from astrbot.api.message_components import Node, Plain
 
+from .thought_signature import log_thought_signature_debug
 from .tl_utils import encode_file_to_base64
 from .tl_utils import is_valid_base64_image_str as util_is_valid_base64_image_str
 
@@ -361,8 +362,7 @@ class MessageSender:
                         event, event.image_result(available_images[0])
                     ):
                         yield res
-            if thought_signature:
-                logger.debug(f"思维签名: {thought_signature[:50]}...")
+            log_thought_signature_debug(thought_signature, scene=f"{scene}/单图发送")
             return
 
         # AIOCQHTTP 逐图发送（base64）
@@ -391,8 +391,7 @@ class MessageSender:
                 ):
                     yield res
 
-            if thought_signature:
-                logger.debug(f"思维签名: {thought_signature[:50]}...")
+            log_thought_signature_debug(thought_signature, scene=f"{scene}/逐图发送")
             return
 
         # 短链富媒体发送
@@ -406,8 +405,7 @@ class MessageSender:
             if chain:
                 async for res in self.safe_send(event, event.chain_result(chain)):
                     yield res
-            if thought_signature:
-                logger.debug(f"思维签名: {thought_signature[:50]}...")
+            log_thought_signature_debug(thought_signature, scene=f"{scene}/短链发送")
             return
 
         # 合并转发
@@ -440,5 +438,4 @@ class MessageSender:
         async for res in self.safe_send(event, event.chain_result([node])):
             yield res
 
-        if thought_signature:
-            logger.debug(f"思维签名: {thought_signature[:50]}...")
+        log_thought_signature_debug(thought_signature, scene=f"{scene}/合并转发")

--- a/tl/thought_signature.py
+++ b/tl/thought_signature.py
@@ -1,0 +1,31 @@
+"""安全处理 thought signature 的辅助函数。"""
+
+from __future__ import annotations
+
+from astrbot.api import logger
+
+THOUGHT_SIGNATURE_DEBUG_PREVIEW_CHARS = 80
+
+
+def log_thought_signature_debug(
+    thought_signature: str | None,
+    *,
+    scene: str,
+) -> None:
+    """仅输出受限预览，禁止将 thought signature 当普通文本透传。
+
+    thought signature 是上游模型返回的 opaque 元数据，只能用于调试或在
+    Provider 协议层按原样续传，不能拼进用户可见文本、Tool 结果或 LLM 上下文。
+    某些模型会返回超大签名，误透传会直接导致上下文爆炸。
+    """
+    if not thought_signature:
+        return
+
+    preview = thought_signature[:THOUGHT_SIGNATURE_DEBUG_PREVIEW_CHARS]
+    suffix = (
+        "..." if len(thought_signature) > THOUGHT_SIGNATURE_DEBUG_PREVIEW_CHARS else ""
+    )
+    logger.debug(
+        f"[{scene}] 思维签名仅调试预览: "
+        f"length={len(thought_signature)} preview={preview}{suffix}"
+    )


### PR DESCRIPTION
## 改动说明

- 修复 Gemini 图像 LLM 工具路径错误透传 `thought_signature` 到 Tool 文本结果和下游 LLM 上下文的问题
- 将 `thought_signature` 收口为仅限协议层 / 调试使用的 opaque 元数据，默认不再透传给用户可见结果或 Agent 文本输入
- 调试日志改为仅输出受限预览和长度，避免超长签名污染日志，并在代码中补充注释防止后续误操作
- 同步更新 `CHANGELOG.md`、`README.md` 和 `metadata.yaml`，将版本提升到 `v1.9.12`

## 改动类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 重构 / 代码优化
- [x] 文档更新
- [ ] 其他

## 关联 Issue

Fixes #65

## 测试情况

- [x] 本地测试通过
- [x] 已测试相关命令（/生图、/改图、/快速 等）
- [x] 已测试 LLM 工具调用

已执行：
- `uv run ruff format tl/thought_signature.py tl/llm_tools.py tl/image_generator.py tl/message_sender.py tl/api/google.py`
- `uv run ruff check tl/thought_signature.py tl/llm_tools.py tl/image_generator.py tl/message_sender.py tl/api/google.py`

## 补充说明

- 仓库默认主分支为 `master`，本 PR 目标分支已设置为 `master`
- 本次修复依据 issue #65 附件日志定位：工具生图成功后，`thought_signature` 被拼入结果并在复核阶段重新注入上下文，最终触发 `413` / `输入Tokens数量超过系统限制`
- 当前未在完整 AstrBot 运行时中做端到端回归，仅完成静态检查与代码路径修复

## Summary by Sourcery

防止 Gemini 的 `thought_signature` 元数据泄漏到工具结果或下游 LLM 上下文中，并相应更新版本化文档。

Bug 修复：
- 不再在 `CallToolResult` 和工具文本输出中包含 Gemini `thought_signature`，以避免膨胀下游 LLM 上下文并触发 413/令牌上限错误。
- 将 `thought_signature` 严格视为不透明的提供方/调试元数据，从用户可见结果中丢弃。

增强功能：
- 新增集中式辅助函数，用于安全地记录 `thought_signature` 调试日志，并对预览内容进行截断，避免生成过大的日志记录。

文档：
- 在 README、故障排除部分和更新日志中记录新的 `thought_signature` 处理行为和使用指南，并将插件版本提升至 `v1.9.12`。

杂项：
- 更新 `metadata.yaml` 和 README 徽章以反映版本 `v1.9.12`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent Gemini thought_signature metadata from leaking into tool results or downstream LLM context and update versioned docs accordingly.

Bug Fixes:
- Stop including Gemini thought_signature in CallToolResult and tool text outputs to avoid inflating downstream LLM context and triggering 413/token limit errors.
- Treat thought_signature strictly as opaque provider/debug metadata that is dropped from user-visible results.

Enhancements:
- Add a centralized helper for safe thought_signature debug logging with truncated previews to avoid oversized log entries.

Documentation:
- Document the new thought_signature handling behavior and guidance in README, troubleshooting section, and changelog, and bump plugin version to v1.9.12.

Chores:
- Update metadata.yaml and README badges to reflect version v1.9.12.

</details>