### PR TITLE
feat(openai_images): 新增自定义尺寸模式与 LLM 工具动态参数

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,30 @@
 
 </details>
 
+## [1.9.13] - 2026-04-23
+
+### Added
+
+- `openai_images` 新增 `size_mode` / `custom_size` 配置，支持在 provider override 条目内显式切换预设尺寸模式与自定义尺寸模式
+- 新增 `tl/openai_image_size.py`，统一处理 OpenAI 官方自定义尺寸约束校验与归一化
+
+### Changed
+
+- `openai_images` 默认模型调整为 `gpt-image-1`
+- LLM 生图工具会根据当前 provider 配置动态切换参数定义
+  - `openai_images + size_mode=custom` 时仅暴露 `size`
+  - 其他模式继续使用 `resolution` / `aspect_ratio`
+- README 补充 OpenAI 官方文档链接，并更新项目结构说明以反映当前仓库模块布局
+
+### Fixed
+
+- 配置保存后插件重载场景下，`openai_images` 自定义尺寸模式现在会随配置动态刷新工具注册信息
+- 修复 LLM 工具在非法 `resolution` / `aspect_ratio` / `size` 输入下静默回退默认值的问题，改为直接报错并要求模型修正参数后重试
+- 当 `openai_images + size_mode=custom` 且本次未显式传入 `size` 时：
+  - 使用配置文件中的 `custom_size`
+  - 输出警告级别日志
+  - 在工具返回结果中提醒 LLM 本次使用了配置值
+
 ## [1.9.12] - 2026-04-21
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-![Version](https://img.shields.io/badge/Version-v1.9.12-blue)
+![Version](https://img.shields.io/badge/Version-v1.9.13-blue)
 ![License](https://img.shields.io/badge/License-AGPL--3.0-orange)
 
 **🎨 强大的 Gemini 图像生成插件，支持智能头像参考和智能表情包切分**
@@ -151,16 +151,26 @@
 | 配置项 | 默认值 | 说明 |
 |--------|--------|------|
 | `api_keys` | `[]` | API Key 列表，支持多 Key 轮换 |
-| `model` | `dall-e-3` | 模型名称（dall-e-2/dall-e-3/gpt-image-1 等） |
+| `model` | `gpt-image-1` | 模型名称（dall-e-2/dall-e-3/gpt-image-1 等） |
 | `api_base` | - | API 端点地址，留空使用 OpenAI 官方 |
 | `quality` | - | 图像质量（GPT image: auto/high/medium/low；dall-e-3: hd/standard） |
 | `response_format` | `b64_json` | 响应格式（b64_json/url） |
+| `size_mode` | `preset` | 尺寸模式：`preset` 使用全局分辨率映射，`custom` 使用 `custom_size` 直接传给 OpenAI |
+| `custom_size` | `1024x1024` | 自定义尺寸示例值。仅 `size_mode=custom` 生效；该模式下此项必填，格式需为 `WxH` |
 | `style` | - | 图像风格，仅 dall-e-3（vivid/natural） |
 | `background` | - | 背景透明度，仅 GPT image（auto/transparent/opaque） |
 | `output_format` | - | 输出格式，仅 GPT image（png/jpeg/webp） |
 | `output_compression` | `0` | 输出压缩率滑动条 0-100，0 表示不传（使用服务端默认），仅 GPT image + jpeg/webp |
 | `moderation` | - | 审核模式，仅 GPT image（如 low） |
 | `generations_only` | `false` | 开启后强制只用文生图端点，不走 /v1/images/edits |
+
+> `size_mode=custom` 时，插件会在发送请求前校验 `custom_size` 是否满足 OpenAI 官方限制：
+> 最大边 `<= 3840`、宽高均为 `16` 的倍数、长短边比 `<= 3:1`、总像素在 `655360-8294400` 之间。
+> 官方文档：
+> <https://developers.openai.com/api/docs/guides/image-generation>
+> <https://developers.openai.com/api/docs/models/gpt-image-2>
+
+> **LLM 工具行为**：当 `api_type=openai_images` 且 `size_mode=custom` 时，LLM 工具参数会从 `resolution`/`aspect_ratio` 切换为仅暴露 `size`。若 LLM 未显式传入 `size`，插件会自动使用配置中的 `custom_size` 值，并在返回结果中提示模型。
 
 **xai_settings**（xAI Images API 专用配置）
 | 配置项 | 默认值 | 说明 |
@@ -234,6 +244,10 @@
 
 **混合触发模式**：LLM 工具会根据当前 `tool_call_timeout` 和 `llm_tool_timeout_reserve_percent` 自动计算前台等待窗口；如果图片在窗口内生成完成，以 `CallToolResult`（含 `ImageContent`）结构化返回给框架，由模型决定后续操作。若超过等待窗口，则自动切到后台继续生成，完成后通过 `event.send()` 直接发送给用户。代理模式下前台和后台均通过代理下载远程图片，确保全链路可用。
 
+**参数动态切换**：当使用 `openai_images` 供应商且启用 `size_mode=custom` 时，LLM 工具仅接受 `size` 参数（格式 `WxH`），不再接受 `resolution` 和 `aspect_ratio`。其他供应商/模式继续使用 `resolution`/`aspect_ratio`。
+
+**参数校验**：LLM 传入非法的 `resolution`、`aspect_ratio` 或 `size` 时，工具会直接返回错误并要求模型修正后重试，不再静默回退到默认值。
+
 **Gemini 思维签名处理**：插件会把 Gemini 返回的 `thought_signature` 视为仅限协议层使用的 opaque 元数据，不会再把它拼进 Tool 文本结果或用户可见内容。这样可以避免部分 Gemini / NewAPI 网关把超大签名重新塞回上下文，导致 `413` 或“输入 Tokens 数量超过系统限制”。
 
 **论坛发帖模式**：当用户要求将图片发到论坛/AstrBook 时，AI 会设置 `for_forum=true`，此时工具同步等待生成完成并返回图片路径/URL，AI 可自动调用 `upload_image` 上传图床后完成全自动发帖流程。
@@ -288,9 +302,11 @@ astrbot_plugin_gemini_image_generation/
     ├── image_splitter.py   # 图像切分（SmartMemeSplitter v4 算法）
     ├── llm_tools.py        # LLM 工具定义（触发器模式实现）
     ├── message_sender.py   # 消息格式化和发送（合并转发、ZIP 打包）
+    ├── openai_image_size.py # OpenAI Images 自定义尺寸校验与归一化
     ├── plugin_config.py    # 配置加载和管理（PluginConfig 类）
     ├── rate_limiter.py     # 限流和群限制（KV 持久化）
     ├── sticker_cutter.py   # 主体+附件吸附分割（兜底算法）
+    ├── thought_signature.py # Gemini thought signature 安全处理
     ├── tl_api.py           # API 客户端（请求发送、重试、图片下载）
     ├── tl_utils.py         # 工具函数（错误格式化、路径处理）
     ├── vision_handler.py   # 视觉 LLM 操作（网格行列识别）
@@ -301,7 +317,9 @@ astrbot_plugin_gemini_image_generation/
         ├── google.py       # Google/Gemini 官方 API
         ├── grok2api.py     # grok2api 适配
         ├── openai_compat.py # OpenAI 兼容格式
+        ├── openai_images.py # OpenAI Images 原生端点适配
         ├── registry.py     # 供应商注册表
+        ├── xai.py          # xAI Images 原生端点适配
         └── zai.py          # Zai.is 适配
 ```
 

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -271,7 +271,7 @@
                 "description": "模型名称",
                 "type": "string",
                 "hint": "OpenAI Images API 模型名称",
-                "default": "dall-e-3"
+                "default": "gpt-image-1"
               },
               "api_base": {
                 "description": "API 端点地址",
@@ -292,6 +292,20 @@
                 "hint": "url 返回临时链接（60分钟有效），b64_json 返回 base64 编码。",
                 "default": "b64_json",
                 "options": ["b64_json", "url"]
+              },
+              "size_mode": {
+                "description": "尺寸模式",
+                "type": "string",
+                "hint": "preset 使用全局分辨率映射；custom 使用下方 custom_size 直接透传到 OpenAI Images API",
+                "default": "preset",
+                "options": ["preset", "custom"]
+              },
+              "custom_size": {
+                "description": "自定义尺寸",
+                "type": "string",
+                "hint": "仅在 size_mode=custom 时生效。默认值仅作示例，可编辑或删除；但 custom 模式下此项必须非空，格式为 WxH，如 1024x1024，且需满足官方限制：最大边<=3840、宽高均为16倍数、长短边比<=3:1、总像素 655360-8294400",
+                "default": "1024x1024",
+                "condition": {"size_mode": "custom"}
               },
               "style": {
                 "description": "图像风格（仅 dall-e-3）",

--- a/main.py
+++ b/main.py
@@ -74,6 +74,7 @@ class GeminiImageGenerationPlugin(Star):
         # 初始化状态
         self.api_client: APIClient | None = None
         self._cleanup_task: asyncio.Task | None = None
+        self.llm_image_tool: GeminiImageGenerationTool | None = None
 
         # 获取插件数据目录
         self._plugin_data_dir = os.path.join(
@@ -87,14 +88,14 @@ class GeminiImageGenerationPlugin(Star):
         # 初始化各功能模块
         self._init_modules()
 
+        # 尝试加载 API 客户端（支持插件重载场景）
+        self._load_provider_from_context(quiet=True)
+
         # 注册 LLM 工具
         self._register_llm_tools()
 
         # 启动定时清理任务
         self._start_cleanup_task()
-
-        # 尝试加载 API 客户端（支持插件重载场景）
-        self._load_provider_from_context(quiet=True)
 
     def _load_version(self) -> str:
         """从 metadata.yaml 读取版本号"""
@@ -198,6 +199,8 @@ class GeminiImageGenerationPlugin(Star):
         """注册 LLM 工具到 Context"""
         try:
             tool = GeminiImageGenerationTool(plugin=self)
+            tool.refresh_from_plugin()
+            self.llm_image_tool = tool
             self.context.add_llm_tools(tool)
             logger.debug("已注册 GeminiImageGenerationTool 到 LLM 工具列表")
         except Exception as e:
@@ -455,11 +458,15 @@ class GeminiImageGenerationPlugin(Star):
         """AstrBot 完成初始化后加载提供商"""
         # 初始化时尝试加载
         self._load_provider_from_context(quiet=True)
+        if self.llm_image_tool:
+            self.llm_image_tool.refresh_from_plugin()
         if self.cfg.help_render_mode == "local":
             asyncio.create_task(self._ensure_font_for_local_mode())
 
         if not self.api_client:
             self._load_provider_from_context()
+            if self.llm_image_tool:
+                self.llm_image_tool.refresh_from_plugin()
 
         if self.api_client:
             logger.info("Gemini 图像生成插件已加载")

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,7 +1,7 @@
 name: astrbot_plugin_gemini_image_generation
 desc: Gemini图像生成插件，支持生图和改图，支持自动获取头像作为参考
 display_name: Gemini 图像生成
-version: v1.9.12
+version: v1.9.13
 author: piexian
 repo: https://github.com/piexian/astrbot_plugin_gemini_image_generation
 astrbot_version: ">=4.10.4"

--- a/tl/api/openai_images.py
+++ b/tl/api/openai_images.py
@@ -10,6 +10,7 @@
 from __future__ import annotations
 
 import base64
+import re
 from typing import Any
 
 import aiohttp
@@ -17,6 +18,7 @@ import aiohttp
 from astrbot.api import logger
 
 from ..api_types import APIError, ApiRequestConfig
+from ..openai_image_size import normalize_size_mode, validate_custom_size
 from ..tl_utils import save_base64_image
 from .base import ProviderRequest
 
@@ -56,6 +58,32 @@ def _get_size_mapping(model: str) -> dict[str, str]:
         return _SIZE_MAP_DALLE2
     # dall-e-3 及其他未知模型使用 dall-e-3 映射
     return _SIZE_MAP_DALLE3
+
+
+def _resolve_size_value(
+    model: str, resolution: str | None, settings: dict[str, Any]
+) -> str | None:
+    """根据配置和请求参数决定最终传给 OpenAI Images API 的 size。"""
+    try:
+        size_mode = normalize_size_mode(settings.get("size_mode"))
+    except ValueError as e:
+        raise APIError(str(e), None, "invalid_size_mode", retryable=False) from e
+
+    if size_mode == "custom":
+        if resolution and re.fullmatch(r"\s*\d+\s*[xX]\s*\d+\s*", resolution):
+            try:
+                return validate_custom_size(resolution, field_name="size")
+            except ValueError as e:
+                raise APIError(str(e), None, "invalid_size", retryable=False) from e
+        try:
+            return validate_custom_size(settings.get("custom_size"))
+        except ValueError as e:
+            raise APIError(str(e), None, "invalid_size", retryable=False) from e
+
+    if resolution:
+        size_map = _get_size_mapping(model)
+        return size_map.get(resolution, resolution)
+    return None
 
 
 class OpenAIImagesProvider:
@@ -247,16 +275,16 @@ class OpenAIImagesProvider:
         settings: dict[str, Any],
     ) -> dict[str, Any]:  # noqa: ANN401
         """构建 /v1/images/generations 请求体"""
-        model = config.model or "dall-e-3"
+        model = config.model or "gpt-image-1"
         payload: dict[str, Any] = {
             "model": model,
             "prompt": config.prompt,
         }
 
         # ---- size ----
-        if config.resolution:
-            size_map = _get_size_mapping(model)
-            payload["size"] = size_map.get(config.resolution, config.resolution)
+        size_value = _resolve_size_value(model, config.resolution, settings)
+        if size_value:
+            payload["size"] = size_value
 
         # ---- quality ----
         quality = str(settings.get("quality") or "").strip()
@@ -322,7 +350,7 @@ class OpenAIImagesProvider:
         返回 payload dict 中包含 ``_multipart`` 标记和 ``_form_data`` 对象，
         由 tl_api._perform_request 识别并切换为 FormData 发送。
         """
-        model = config.model or "dall-e-3"
+        model = config.model or "gpt-image-1"
         form = aiohttp.FormData()
 
         # ---- image (required): 第一张参考图 ----
@@ -369,10 +397,9 @@ class OpenAIImagesProvider:
         form.add_field("model", model)
 
         # ---- size ----
-        if config.resolution:
-            size_map = _get_size_mapping(model)
-            size_val = size_map.get(config.resolution, config.resolution)
-            form.add_field("size", size_val)
+        size_value = _resolve_size_value(model, config.resolution, settings)
+        if size_value:
+            form.add_field("size", size_value)
 
         # ---- response_format ----
         response_format = str(settings.get("response_format") or "b64_json").strip()

--- a/tl/llm_tools.py
+++ b/tl/llm_tools.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import math
 import os
+import re
 from typing import TYPE_CHECKING, Any
 
 import mcp.types
@@ -21,6 +22,14 @@ from astrbot.core.agent.run_context import ContextWrapper
 from astrbot.core.agent.tool import FunctionTool, ToolExecResult
 from astrbot.core.astr_agent_context import AstrAgentContext
 
+from .openai_image_size import (
+    CUSTOM_SIZE_DEFAULT,
+    CUSTOM_SIZE_MAX_EDGE,
+    CUSTOM_SIZE_MAX_PIXELS,
+    CUSTOM_SIZE_MIN_PIXELS,
+    normalize_size_mode,
+    validate_custom_size,
+)
 from .thought_signature import log_thought_signature_debug
 from .tl_utils import encode_file_to_base64, format_error_message
 
@@ -29,8 +38,8 @@ if TYPE_CHECKING:
 
 
 # 参数枚举常量（工具定义和验证共用）
-VALID_RESOLUTIONS = {"1K", "2K", "4K"}
-VALID_ASPECT_RATIOS = {
+RESOLUTION_OPTIONS = ("1K", "2K", "4K")
+ASPECT_RATIO_OPTIONS = (
     "1:1",
     "16:9",
     "4:3",
@@ -41,7 +50,186 @@ VALID_ASPECT_RATIOS = {
     "21:9",
     "3:4",
     "2:3",
-}
+)
+VALID_RESOLUTIONS = set(RESOLUTION_OPTIONS)
+VALID_ASPECT_RATIOS = set(ASPECT_RATIO_OPTIONS)
+
+
+def _get_openai_images_settings(plugin: Any) -> dict[str, Any]:
+    if not plugin or not getattr(plugin, "cfg", None):
+        return {}
+
+    settings = getattr(plugin.cfg, "openai_images_settings", None)
+    if isinstance(settings, dict) and settings:
+        return settings
+
+    overrides = getattr(plugin.cfg, "provider_overrides", None) or {}
+    candidate = overrides.get("openai_images", {})
+    return candidate if isinstance(candidate, dict) else {}
+
+
+def _is_openai_images_custom_size_mode(plugin: Any) -> bool:
+    if not plugin or not getattr(plugin, "cfg", None):
+        return False
+
+    api_type = str(getattr(plugin.cfg, "api_type", "") or "").strip().lower()
+    api_type = api_type.replace("-", "_")
+    if api_type != "openai_images":
+        return False
+
+    try:
+        size_mode = normalize_size_mode(
+            _get_openai_images_settings(plugin).get("size_mode")
+        )
+        return size_mode == "custom"
+    except ValueError as exc:
+        logger.warning(
+            f"[工具定义] openai_images size_mode 非法，回退为预设模式: {exc}"
+        )
+        return False
+
+
+def _custom_size_constraints_text() -> str:
+    return (
+        f"格式必须为 WxH，例如 {CUSTOM_SIZE_DEFAULT} 或 2048x1152；"
+        f"最大边 <= {CUSTOM_SIZE_MAX_EDGE}px，宽高都必须是 16 的倍数，"
+        f"长边与短边之比 <= 3:1，总像素必须在 {CUSTOM_SIZE_MIN_PIXELS} 到 "
+        f"{CUSTOM_SIZE_MAX_PIXELS} 之间。"
+    )
+
+
+def _build_tool_base_properties() -> dict[str, Any]:
+    return {
+        "prompt": {
+            "type": "string",
+            "description": "图像生成或修改的详细描述",
+        },
+        "use_reference_images": {
+            "type": "boolean",
+            "description": (
+                "是否使用上下文中的参考图片。"
+                "当用户意图是修改、变换或基于现有图片时设置为true"
+            ),
+            "default": False,
+        },
+        "include_user_avatar": {
+            "type": "boolean",
+            "description": (
+                "是否包含用户头像作为参考图像。"
+                "当用户说'根据我'、'我的头像'或@某人时设置为true"
+            ),
+            "default": False,
+        },
+    }
+
+
+def _build_forum_property() -> dict[str, Any]:
+    return {
+        "type": "boolean",
+        "description": (
+            "是否用于论坛发帖。当用户明确表示要将生成的图片发到论坛/AstrBook时设置为true。"
+            "设置为true时，工具会等待图片生成完成并返回图片路径，不会自动发送给用户。"
+            "你需要使用返回的路径调用 upload_image 上传到论坛图床。"
+        ),
+        "default": False,
+    }
+
+
+def _build_tool_description(plugin: Any) -> str:
+    prefix = (
+        "使用 Gemini 模型生成或修改图像。"
+        "当用户请求图像生成、绘画、改图、换风格或手办化时调用此函数。"
+        "此工具会先在前台短时间等待结果，若快速完成则直接返回图片；"
+        "若超出等待时间则自动转为后台生成，完成后自动发送给用户。"
+        "判断逻辑：用户说'改成'、'变成'、'基于'、'修改'、'改图'等词时，"
+        "设置 use_reference_images=true；用户说'根据我'、'我的头像'或@某人时，"
+        "设置 use_reference_images=true 和 include_user_avatar=true。"
+    )
+    if _is_openai_images_custom_size_mode(plugin):
+        return (
+            prefix + "当前供应商为 OpenAI Images 且已启用自定义尺寸模式。"
+            "如果用户指定尺寸，设置 size，且不要传 resolution 或 aspect_ratio。"
+            f"size {_custom_size_constraints_text()}"
+            "【重要】当用户明确表示要将生成的图片发到论坛/AstrBook时，设置 for_forum=true。"
+            "此时工具会等待图片生成完成后返回图片路径，你需要使用 upload_image 工具将图片上传到论坛图床获取URL，"
+            "然后在发帖或回复时使用 Markdown 格式 ![描述](URL) 插入图片。"
+        )
+
+    return (
+        prefix
+        + "用户指定分辨率时设置 resolution（仅限 1K/2K/4K 大写）；"
+        + "用户指定比例时设置 aspect_ratio（仅限 1:1/16:9/4:3/3:2/9:16/4:5/5:4/21:9/3:4/2:3）。"
+        + "【重要】当用户明确表示要将生成的图片发到论坛/AstrBook时，设置 for_forum=true。"
+        + "此时工具会等待图片生成完成后返回图片路径，你需要使用 upload_image 工具将图片上传到论坛图床获取URL，"
+        + "然后在发帖或回复时使用 Markdown 格式 ![描述](URL) 插入图片。"
+    )
+
+
+def _build_tool_parameters(plugin: Any) -> dict[str, Any]:
+    properties = _build_tool_base_properties()
+
+    if _is_openai_images_custom_size_mode(plugin):
+        settings = _get_openai_images_settings(plugin)
+        configured_size = (
+            str(settings.get("custom_size") or "").strip() or CUSTOM_SIZE_DEFAULT
+        )
+        properties["size"] = {
+            "type": "string",
+            "description": (
+                "OpenAI Images 自定义尺寸。"
+                "如用户未指定尺寸可省略，省略时使用当前插件配置默认值 "
+                f"{configured_size}。{_custom_size_constraints_text()}"
+            ),
+        }
+    else:
+        properties["resolution"] = {
+            "type": "string",
+            "description": (
+                "图像分辨率，可选参数，留空使用默认配置。"
+                "仅支持：1K、2K、4K（必须大写英文）"
+            ),
+            "enum": list(RESOLUTION_OPTIONS),
+        }
+        properties["aspect_ratio"] = {
+            "type": "string",
+            "description": (
+                "图像长宽比，可选参数，留空使用默认配置。"
+                "仅支持：1:1、16:9、4:3、3:2、9:16、4:5、5:4、21:9、3:4、2:3"
+            ),
+            "enum": list(ASPECT_RATIO_OPTIONS),
+        }
+
+    properties["for_forum"] = _build_forum_property()
+    return {
+        "type": "object",
+        "properties": properties,
+        "required": ["prompt"],
+    }
+
+
+def _build_tool_retry_message(message: str, *, custom_size_mode: bool) -> str:
+    if custom_size_mode:
+        return (
+            f"❌ 参数错误：{message}\n"
+            "当前工具处于 OpenAI Images 自定义尺寸模式，只能传 size，不要传 resolution 或 aspect_ratio。\n"
+            f"size {_custom_size_constraints_text()}\n"
+            "请修正参数后重新调用 gemini_image_generation 工具。"
+        )
+
+    return (
+        f"❌ 参数错误：{message}\n"
+        f"resolution 仅支持：{'/'.join(RESOLUTION_OPTIONS)}；"
+        f"aspect_ratio 仅支持：{'/'.join(ASPECT_RATIO_OPTIONS)}。\n"
+        "请修正参数后重新调用 gemini_image_generation 工具；如果用户没有指定这些参数，可以直接省略。"
+    )
+
+
+def _build_config_size_notice(configured_size: str) -> str:
+    return (
+        "【提醒】本次未显式传入 size，"
+        f"已使用插件配置中的 openai_images.custom_size={configured_size}。"
+        "如果后续需要指定尺寸，请在下次调用工具时显式传入合法的 size。"
+    )
 
 
 def _build_reference_info(ref_count: int, avatar_count: int) -> str:
@@ -60,7 +248,10 @@ def _build_param_info(
 ) -> str:
     parts: list[str] = []
     if resolution:
-        parts.append(f"分辨率 {resolution}")
+        if re.fullmatch(r"\d+[xX]\d+", resolution):
+            parts.append(f"尺寸 {resolution}")
+        else:
+            parts.append(f"分辨率 {resolution}")
     if aspect_ratio:
         parts.append(f"比例 {aspect_ratio}")
     return f"（{', '.join(parts)}）" if parts else ""
@@ -120,6 +311,7 @@ async def _build_call_tool_result(
     text_content: str | None,
     message_sender: Any,
     api_client: Any | None = None,
+    llm_notice: str | None = None,
 ) -> mcp.types.CallToolResult:
     """将图像生成结果转换为 AstrBot 官方 CallToolResult 格式（含 ImageContent）。
 
@@ -210,6 +402,8 @@ async def _build_call_tool_result(
     text_parts: list[str] = []
     if prepared_text:
         text_parts.append(prepared_text)
+    if llm_notice:
+        text_parts.append(llm_notice)
     # thought signature 只能留在 Provider 协议层，绝不能拼进 Tool 文本结果。
     # 否则下游 Runner 会把这类超大 opaque 数据重新塞回上下文。
     if text_parts:
@@ -231,14 +425,18 @@ def _build_background_start_notice(
     avatar_count: int,
     resolution: str | None,
     aspect_ratio: str | None,
+    llm_notice: str | None = None,
 ) -> str:
     ref_info = _build_reference_info(ref_count, avatar_count)
     param_info = _build_param_info(resolution, aspect_ratio)
-    return (
+    message = (
         f"[图像生成任务已启动]{ref_info}{param_info}\n"
         "图片正在后台生成中，通常需要 10-30 秒，高质量生成可能长达几百秒，生成完成后会自动发送给用户。\n"
         "请用你维持原有的人设告诉用户：图片正在生成，请稍等片刻，完成后会自动发送。"
     )
+    if llm_notice:
+        message += f"\n{llm_notice}"
+    return message
 
 
 def _build_background_fallback_notice(
@@ -247,15 +445,19 @@ def _build_background_fallback_notice(
     resolution: str | None,
     aspect_ratio: str | None,
     waited_seconds: int,
+    llm_notice: str | None = None,
 ) -> str:
     ref_info = _build_reference_info(ref_count, avatar_count)
     param_info = _build_param_info(resolution, aspect_ratio)
-    return (
+    message = (
         f"[图像生成任务已转入后台]{ref_info}{param_info}\n"
         f"前台等待 {waited_seconds} 秒后仍未完成，已切换为后台继续生成。\n"
         "图片生成完成后会自动发送给用户。\n"
         "请用你维持原有的人设告诉用户：图片正在生成，请稍等片刻，完成后会自动发送。"
     )
+    if llm_notice:
+        message += f"\n{llm_notice}"
+    return message
 
 
 def _resolve_foreground_wait_seconds(plugin: Any, event: Any) -> int:
@@ -462,76 +664,15 @@ class GeminiImageGenerationTool(FunctionTool[AstrAgentContext]):
 
     name: str = "gemini_image_generation"
     handler_module_path: str = "astrbot_plugin_gemini_image_generation"
-    description: str = (
-        "使用 Gemini 模型生成或修改图像。"
-        "当用户请求图像生成、绘画、改图、换风格或手办化时调用此函数。"
-        "此工具会先在前台短时间等待结果，若快速完成则直接返回图片；"
-        "若超出等待时间则自动转为后台生成，完成后自动发送给用户。"
-        "判断逻辑：用户说'改成'、'变成'、'基于'、'修改'、'改图'等词时，"
-        "设置 use_reference_images=true；用户说'根据我'、'我的头像'或@某人时，"
-        "设置 use_reference_images=true 和 include_user_avatar=true。"
-        "用户指定分辨率时设置 resolution（仅限 1K/2K/4K 大写）；"
-        "用户指定比例时设置 aspect_ratio（仅限 1:1/16:9/4:3/3:2/9:16/4:5/5:4/21:9/3:4/2:3）。"
-        "【重要】当用户明确表示要将生成的图片发到论坛/AstrBook时，设置 for_forum=true。"
-        "此时工具会等待图片生成完成后返回图片路径，你需要使用 upload_image 工具将图片上传到论坛图床获取URL，"
-        "然后在发帖或回复时使用 Markdown 格式 ![描述](URL) 插入图片。"
-    )
-    parameters: dict = Field(
-        default_factory=lambda: {
-            "type": "object",
-            "properties": {
-                "prompt": {
-                    "type": "string",
-                    "description": "图像生成或修改的详细描述",
-                },
-                "use_reference_images": {
-                    "type": "boolean",
-                    "description": (
-                        "是否使用上下文中的参考图片。"
-                        "当用户意图是修改、变换或基于现有图片时设置为true"
-                    ),
-                    "default": False,
-                },
-                "include_user_avatar": {
-                    "type": "boolean",
-                    "description": (
-                        "是否包含用户头像作为参考图像。"
-                        "当用户说'根据我'、'我的头像'或@某人时设置为true"
-                    ),
-                    "default": False,
-                },
-                "resolution": {
-                    "type": "string",
-                    "description": (
-                        "图像分辨率，可选参数，留空使用默认配置。"
-                        "仅支持：1K、2K、4K（必须大写英文）"
-                    ),
-                    "enum": sorted(VALID_RESOLUTIONS),
-                },
-                "aspect_ratio": {
-                    "type": "string",
-                    "description": (
-                        "图像长宽比，可选参数，留空使用默认配置。"
-                        "仅支持：1:1、16:9、4:3、3:2、9:16、4:5、5:4、21:9、3:4、2:3"
-                    ),
-                    "enum": sorted(VALID_ASPECT_RATIOS),
-                },
-                "for_forum": {
-                    "type": "boolean",
-                    "description": (
-                        "是否用于论坛发帖。当用户明确表示要将生成的图片发到论坛/AstrBook时设置为true。"
-                        "设置为true时，工具会等待图片生成完成并返回图片路径，不会自动发送给用户。"
-                        "你需要使用返回的路径调用 upload_image 上传到论坛图床。"
-                    ),
-                    "default": False,
-                },
-            },
-            "required": ["prompt"],
-        }
-    )
+    description: str = Field(default_factory=str)
+    parameters: dict = Field(default_factory=dict)
 
     # 插件实例引用（在创建时设置）
     plugin: Any = Field(default=None, repr=False)
+
+    def refresh_from_plugin(self) -> None:
+        self.description = _build_tool_description(self.plugin)
+        self.parameters = _build_tool_parameters(self.plugin)
 
     async def call(
         self, context: ContextWrapper[AstrAgentContext], **kwargs
@@ -542,12 +683,15 @@ class GeminiImageGenerationTool(FunctionTool[AstrAgentContext]):
         Foreground-first hybrid mode for normal chats.
         When for_forum=True, the tool waits synchronously and returns image paths.
         """
+        self.refresh_from_plugin()
+
         prompt = kwargs.get("prompt") or ""
         if not prompt.strip():
             return "❌ 缺少必填参数：图像描述不能为空"
 
         use_reference_images = kwargs.get("use_reference_images", False)
         include_user_avatar = kwargs.get("include_user_avatar", False)
+        size = kwargs.get("size") or None
         resolution = kwargs.get("resolution") or None
         aspect_ratio = kwargs.get("aspect_ratio") or None
         for_forum = kwargs.get("for_forum", False)
@@ -574,13 +718,69 @@ class GeminiImageGenerationTool(FunctionTool[AstrAgentContext]):
         # 布尔参数已在工具定义中声明为 boolean 类型，直接使用
         include_avatar = bool(include_user_avatar)
         include_ref_images = bool(use_reference_images)
+        config_value_notice: str | None = None
 
-        # 验证分辨率和比例参数，无效值回退到默认配置
-        # 大小写兼容：LLM 有时会输出小写（如 "1k"），统一转换为大写后验证
-        if resolution:
-            resolution = resolution.upper()
-        resolution = resolution if resolution in VALID_RESOLUTIONS else None
-        aspect_ratio = aspect_ratio if aspect_ratio in VALID_ASPECT_RATIOS else None
+        custom_size_mode = _is_openai_images_custom_size_mode(plugin)
+        if custom_size_mode:
+            if resolution is not None:
+                return _build_tool_retry_message(
+                    "当前模式不支持 resolution 参数，请改用 size。",
+                    custom_size_mode=True,
+                )
+            if aspect_ratio is not None:
+                return _build_tool_retry_message(
+                    "当前模式不支持 aspect_ratio 参数，请改用 size。",
+                    custom_size_mode=True,
+                )
+            if size is not None and str(size).strip():
+                try:
+                    resolution = validate_custom_size(size, field_name="size")
+                except ValueError as exc:
+                    return _build_tool_retry_message(
+                        str(exc),
+                        custom_size_mode=True,
+                    )
+            else:
+                settings = _get_openai_images_settings(plugin)
+                try:
+                    resolution = validate_custom_size(
+                        settings.get("custom_size"),
+                        field_name="openai_images.custom_size",
+                    )
+                except ValueError as exc:
+                    return f"❌ 插件配置错误：{exc}"
+                config_value_notice = _build_config_size_notice(resolution)
+                logger.warning(
+                    "[工具调用] OpenAI Images 自定义尺寸模式未显式提供 size，"
+                    f"已使用插件配置中的 openai_images.custom_size={resolution}"
+                )
+            aspect_ratio = None
+        else:
+            if size is not None and str(size).strip():
+                return _build_tool_retry_message(
+                    "当前模式不支持 size 参数，请使用 resolution 和 aspect_ratio，或直接省略。",
+                    custom_size_mode=False,
+                )
+
+            if resolution is not None:
+                resolution = str(resolution).strip().upper()
+                if resolution not in VALID_RESOLUTIONS:
+                    return _build_tool_retry_message(
+                        f"resolution 仅支持 {'/'.join(RESOLUTION_OPTIONS)}，当前值: {kwargs.get('resolution')!r}",
+                        custom_size_mode=False,
+                    )
+            else:
+                resolution = None
+
+            if aspect_ratio is not None:
+                aspect_ratio = str(aspect_ratio).strip()
+                if aspect_ratio not in VALID_ASPECT_RATIOS:
+                    return _build_tool_retry_message(
+                        f"aspect_ratio 仅支持 {'/'.join(ASPECT_RATIO_OPTIONS)}，当前值: {kwargs.get('aspect_ratio')!r}",
+                        custom_size_mode=False,
+                    )
+            else:
+                aspect_ratio = None
 
         # 获取参考图片（需要在启动后台任务前获取，因为 event 可能在之后失效）
         reference_images, avatar_reference = await plugin._fetch_images_from_event(
@@ -600,7 +800,7 @@ class GeminiImageGenerationTool(FunctionTool[AstrAgentContext]):
         logger.info(
             f"[工具调用] 启动图像生成任务："
             f"提示词长度={prompt_len} 参考图={ref_count} 张 头像={avatar_count} 张 "
-            f"分辨率={resolution} 比例={aspect_ratio} 发帖模式={for_forum}"
+            f"尺寸/分辨率={resolution} 比例={aspect_ratio} 发帖模式={for_forum}"
         )
 
         # ========== for_forum 模式：同步等待生成完成 ==========
@@ -681,6 +881,9 @@ class GeminiImageGenerationTool(FunctionTool[AstrAgentContext]):
                         ["", f"【AI 生成的图片描述】{text_content[:200]}..."]
                     )
 
+                if config_value_notice:
+                    result_lines.extend(["", config_value_notice])
+
                 logger.info(
                     f"[后台任务] 图片生成成功，返回 {len(available_images)} 张图片"
                 )
@@ -724,6 +927,7 @@ class GeminiImageGenerationTool(FunctionTool[AstrAgentContext]):
                     avatar_count=avatar_count,
                     resolution=resolution,
                     aspect_ratio=aspect_ratio,
+                    llm_notice=config_value_notice,
                 )
 
             logger.debug(f"[前台等待] 最多等待 {foreground_wait_seconds} 秒。")
@@ -753,6 +957,7 @@ class GeminiImageGenerationTool(FunctionTool[AstrAgentContext]):
                             text_content=text_content,
                             message_sender=plugin.message_sender,
                             api_client=plugin.api_client,
+                            llm_notice=config_value_notice,
                         ),
                         timeout=30,  # 下载最多给 30 秒
                     )
@@ -774,10 +979,13 @@ class GeminiImageGenerationTool(FunctionTool[AstrAgentContext]):
                         generation_task=done_task,
                         scene="后台任务(代理下载超时回退)",
                     )
-                    return (
+                    result_message = (
                         "[图片生成已完成，正在通过代理下载并发送]\n"
                         "由于代理下载耗时较长，已转为后台发送，完成后会自动发给用户。"
                     )
+                    if config_value_notice:
+                        result_message += f"\n{config_value_notice}"
+                    return result_message
             else:
                 error_msg = (
                     result_data if isinstance(result_data, str) else "❌ 图像生成失败"
@@ -798,6 +1006,7 @@ class GeminiImageGenerationTool(FunctionTool[AstrAgentContext]):
                 resolution=resolution,
                 aspect_ratio=aspect_ratio,
                 waited_seconds=foreground_wait_seconds,
+                llm_notice=config_value_notice,
             )
         except Exception as e:
             logger.error(f"[前台等待] 图像生成异常：{e}", exc_info=True)

--- a/tl/openai_image_size.py
+++ b/tl/openai_image_size.py
@@ -25,7 +25,7 @@ def validate_custom_size(
 ) -> str:
     """Validate a custom OpenAI Images size against official constraints."""
     raw_size = str(value or "").strip()
-    normalized = raw_size.replace(" ", "")
+    normalized = re.sub(r"\s+", "", raw_size)
     if not normalized:
         raise ValueError(
             f"{field_name} 不能为空；切换到 custom 模式后必须填写合法尺寸，如 {CUSTOM_SIZE_DEFAULT}"

--- a/tl/openai_image_size.py
+++ b/tl/openai_image_size.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+CUSTOM_SIZE_MAX_EDGE = 3840
+CUSTOM_SIZE_MIN_PIXELS = 655_360
+CUSTOM_SIZE_MAX_PIXELS = 8_294_400
+CUSTOM_SIZE_DEFAULT = "1024x1024"
+VALID_SIZE_MODES = {"preset", "custom"}
+
+
+def normalize_size_mode(
+    value: Any, *, field_name: str = "openai_images.size_mode"
+) -> str:
+    """Normalize and validate the OpenAI Images size mode."""
+    size_mode = str(value or "preset").strip().lower()
+    if size_mode not in VALID_SIZE_MODES:
+        raise ValueError(f"{field_name} 仅支持 preset 或 custom，当前值: {value!r}")
+    return size_mode
+
+
+def validate_custom_size(
+    value: Any, *, field_name: str = "openai_images.custom_size"
+) -> str:
+    """Validate a custom OpenAI Images size against official constraints."""
+    raw_size = str(value or "").strip()
+    normalized = raw_size.replace(" ", "")
+    if not normalized:
+        raise ValueError(
+            f"{field_name} 不能为空；切换到 custom 模式后必须填写合法尺寸，如 {CUSTOM_SIZE_DEFAULT}"
+        )
+
+    match = re.fullmatch(r"(\d+)[xX](\d+)", normalized)
+    if not match:
+        raise ValueError(
+            f"{field_name} 格式无效，必须为 WxH，例如 {CUSTOM_SIZE_DEFAULT}"
+        )
+
+    width = int(match.group(1))
+    height = int(match.group(2))
+    max_edge = max(width, height)
+    min_edge = min(width, height)
+    total_pixels = width * height
+
+    if min_edge <= 0:
+        raise ValueError(f"{field_name} 宽高必须大于 0")
+    if width % 16 != 0 or height % 16 != 0:
+        raise ValueError(f"{field_name} 宽高都必须是 16 的倍数")
+    if max_edge > CUSTOM_SIZE_MAX_EDGE:
+        raise ValueError(f"{field_name} 最大边长不能超过 {CUSTOM_SIZE_MAX_EDGE}px")
+    if max_edge / min_edge > 3:
+        raise ValueError(f"{field_name} 长边与短边之比不能超过 3:1")
+    if not (CUSTOM_SIZE_MIN_PIXELS <= total_pixels <= CUSTOM_SIZE_MAX_PIXELS):
+        raise ValueError(
+            f"{field_name} 总像素必须在 {CUSTOM_SIZE_MIN_PIXELS} 到 {CUSTOM_SIZE_MAX_PIXELS} 之间"
+        )
+
+    return f"{width}x{height}"

--- a/tl/plugin_config.py
+++ b/tl/plugin_config.py
@@ -8,9 +8,23 @@ from typing import Any
 
 from astrbot.api import logger
 
+from .openai_image_size import normalize_size_mode, validate_custom_size
+
 # 豆包组图数量限制常量
 DOUBAO_SEQUENTIAL_IMAGES_MIN = 2
 DOUBAO_SEQUENTIAL_IMAGES_MAX = 15
+
+
+def _validate_openai_images_settings(settings: dict[str, Any]) -> None:
+    """校验 openai_images 覆盖配置。"""
+    size_mode = normalize_size_mode(settings.get("size_mode"))
+    settings["size_mode"] = size_mode
+
+    custom_size = settings.get("custom_size")
+    if size_mode == "custom":
+        settings["custom_size"] = validate_custom_size(custom_size)
+    elif isinstance(custom_size, str):
+        settings["custom_size"] = custom_size.strip()
 
 
 @dataclass
@@ -446,6 +460,8 @@ class ConfigLoader:
                             override_copy["proxy"] = proxy_val.strip() or None
                         else:
                             override_copy["proxy"] = None
+                        if template_key == "openai_images":
+                            _validate_openai_images_settings(override_copy)
                         all_overrides[template_key] = override_copy
         config.provider_overrides = all_overrides
 


### PR DESCRIPTION
## 改动说明

- 新增 size_mode/custom_size 配置，支持在 provider override 内切换预设与自定义尺寸
- 新增 tl/openai_image_size.py，统一处理 OpenAI 官方自定义尺寸约束校验与归一化
- LLM 生图工具根据当前 provider 配置动态切换参数定义： openai_images + size_mode=custom 时仅暴露 size，其他模式使用 resolution/aspect_ratio
- 修复非法 resolution/aspect_ratio/size 输入静默回退默认值的问题，改为直接报错要求重试
- 配置保存后插件重载时自动刷新工具注册信息
- 默认模型调整为 gpt-image-1
- 
## 改动类型

- [ ] Bug 修复
- [x] 新功能
- [ ] 重构 / 代码优化
- [x] 文档更新
- [ ] 其他

## 关联 Issue

Closes #69 

## 测试情况

- [x] 本地测试通过
- [ ] 已测试相关命令（/生图、/改图、/快速 等）
- [ ] 已测试 LLM 工具调用

## 补充说明

## Summary by Sourcery

为 OpenAI Images 添加可配置的自定义尺寸模式，并让 Gemini 图像生成工具能够根据当前的服务提供方配置动态调整其参数和校验逻辑。

新功能：
- 为 `openai_images` provider 引入 `size_mode` 和 `custom_size` 选项，用于在预设分辨率映射和直接使用自定义尺寸之间切换。
- 暴露新的 `tl/openai_image_size` 模块，用于集中处理 OpenAI Images 自定义尺寸的归一化和约束校验。
- 让 Gemini 图像生成 LLM 工具能够根据当前启用的 provider 和 `size_mode` 配置，在公开参数中动态切换 `size` 与 `resolution`/`aspect_ratio`。

错误修复：
- 当向 LLM 工具提供无效的 `resolution`、`aspect_ratio` 或 `size` 时，不再静默回退到默认值，而是返回明确的错误信息。
- 确保在配置变更和插件重载后，LLM 工具的注册信息（描述和参数）会被刷新，从而使 `openai_images` 的自定义尺寸模式与设置保持同步。

增强：
- 将 OpenAI Images 的默认模型从 `dall-e-3` 更改为 `gpt-image-1`，用于生成与编辑请求。
- 改进面向用户和 LLM 的提示信息，涵盖背景生成、参数使用以及已配置 `custom_size` 值的隐式使用说明。
- 重构 `GeminiImageGenerationTool`，使其能够在运行时基于插件配置构建自身的描述和参数模式，并更好地记录尺寸/分辨率的使用情况。
- 在配置加载时校验与规范化 `openai_images` 的覆盖设置，包括 `size_mode` 和 `custom_size`。

文档：
- 更新 README，包含新的插件版本、`openai_images` 的 `size_mode`/`custom_size` 配置、OpenAI Images 尺寸约束、LLM 工具参数的动态行为以及更新后的模块结构。
- 在 CHANGELOG 中添加 1.9.13 条目，记录自定义尺寸支持、默认模型变更、工具动态行为以及校验修复。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable custom size mode for OpenAI Images and make the Gemini image generation tool dynamically adapt its parameters and validation to the current provider configuration.

New Features:
- Introduce size_mode and custom_size options for the openai_images provider to switch between preset resolution mapping and direct custom size usage.
- Expose a new tl/openai_image_size module to centralize OpenAI Images custom size normalization and constraint validation.
- Make the Gemini image generation LLM tool dynamically switch its public parameters between size and resolution/aspect_ratio based on the active provider and size_mode configuration.

Bug Fixes:
- Stop silently falling back to default values when invalid resolution, aspect_ratio, or size are provided to the LLM tool, returning explicit errors instead.
- Ensure LLM tool registration (description and parameters) is refreshed after configuration changes and plugin reloads so openai_images custom size mode stays in sync with settings.

Enhancements:
- Change the default OpenAI Images model from dall-e-3 to gpt-image-1 for both generations and edits requests.
- Improve user- and LLM-facing notices around background generation, parameter usage, and implicit use of configured custom_size values.
- Refactor GeminiImageGenerationTool to build its description and parameter schema at runtime based on plugin configuration, and to better log size/resolution usage.
- Validate and normalize openai_images override settings at config load time, including size_mode and custom_size.

Documentation:
- Update README with the new plugin version, openai_images size_mode/custom_size configuration, OpenAI Images sizing constraints, dynamic LLM tool parameter behavior, and refreshed module layout.
- Add a 1.9.13 entry to CHANGELOG documenting custom size support, default model change, dynamic tool behavior, and validation fixes.

</details>