### PR TITLE
feat: add NapCat stream send fallback

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -717,17 +717,11 @@
     "type": "object",
     "hint": "配置文件传输等外部服务",
     "items": {
-      "nap_server_address": {
-        "description": "NAP cat 服务地址",
-        "type": "string",
-        "hint": "仅当 NAP 和机器人不在同一服务器时填写，同服务器填写 localhost",
-        "default": "localhost"
-      },
-      "nap_server_port": {
-        "description": "文件传输端口",
-        "type": "int",
-        "hint": "NAP cat 所在服务器接收文件端口，在同一服务器上可以不填",
-        "default": 3658
+      "napcat_stream_threshold_mb": {
+        "description": "NapCat 流式上传阈值（MB）",
+        "type": "float",
+        "hint": "先按现有 max_inline_image_size_mb 规则发送本地图片；若发送失败，且本地文件大小达到该阈值，则复用当前 OneBot/NapCat 连接调用 upload_file_stream 并重试一次。填 0 表示禁用。Docker / docker compose 环境建议保持默认或按图片大小调大",
+        "default": 2.0
       },
       "auto_avatar_reference": {
         "description": "自动头像参考",

--- a/docs/config.md
+++ b/docs/config.md
@@ -38,7 +38,7 @@
 google / openai / zai / grok2api / xai / openai_images / doubao
 ```
 
-下方 `doubao_settings`、`openai_images_settings`、`xai_settings` 章节对应这些模板的专用字段。旧版顶层配置仅作为兼容读取路径，新配置建议统一放在 `api_settings.provider_overrides` 中。
+下方 `doubao_settings`、`openai_images_settings`、`xai_settings` 章节对应这些模板的专用字段。配置时在 `api_settings.provider_overrides` 中选择相应模板。
 
 ## image_generation_settings
 
@@ -79,10 +79,11 @@ avatar / poster / wallpaper / card / mobile / figure / sticker
 
 | 配置项 | 默认值 | 说明 |
 |--------|--------|------|
-| `nap_server_address` | `localhost` | NAP 文件传输地址 |
-| `nap_server_port` | `3658` | NAP 文件传输端口 |
+| `napcat_stream_threshold_mb` | `2.0` | 本地图片原始发送失败后，达到该大小才使用 NapCat Stream API 兜底重试；`0` 表示禁用 |
 | `auto_avatar_reference` | `false` | 自动获取头像作为参考图 |
 | `theme_settings.mode` | `cycle` | 帮助页主题模式 |
+
+NapCat v4.8.115+ 支持 Stream API。插件默认仍先按 `max_inline_image_size_mb` 规则发送本地图片；只有原始发送失败且文件大小达到 `napcat_stream_threshold_mb` 时，才会复用当前 NapCat/OneBot 连接调用 `upload_file_stream` 并重试一次。Docker / docker compose 部署仍建议共享 `AstrBot/data` 目录，以兼容普通本地文件发送路径。
 
 ## help_render_mode
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -79,7 +79,7 @@ LLM 工具会根据当前 `tool_call_timeout` 和 `llm_tool_timeout_reserve_perc
 
 - LLM 工具仅接受 `size` 参数，格式 `WxH`。
 - 不再接受 `resolution` 和 `aspect_ratio`。
-- 未显式传入 `size` 时，使用配置中的 `openai_images.custom_size`。
+- 未显式传入 `size` 时，使用 `api_settings.provider_overrides` 中 `openai_images` 模板的 `custom_size`。
 
 其他供应商或非 custom 模式继续使用 `resolution` / `aspect_ratio`。
 

--- a/main.py
+++ b/main.py
@@ -142,6 +142,7 @@ class GeminiImageGenerationPlugin(Star):
         self.message_sender = MessageSender(
             enable_text_response=self.cfg.enable_text_response,
             max_inline_image_size_mb=self.cfg.max_inline_image_size_mb,
+            napcat_stream_threshold_mb=self.cfg.napcat_stream_threshold_mb,
             log_debug_fn=logger.debug,
         )
 
@@ -174,8 +175,6 @@ class GeminiImageGenerationPlugin(Star):
             max_reference_images=self.cfg.max_reference_images,
             total_timeout=self.cfg.total_timeout,
             max_attempts_per_key=self.cfg.max_attempts_per_key,
-            nap_server_address=self.cfg.nap_server_address,
-            nap_server_port=self.cfg.nap_server_port,
             filter_valid_fn=self.image_handler.filter_valid_reference_images,
             get_tool_timeout_fn=self.get_tool_timeout,
         )
@@ -187,6 +186,11 @@ class GeminiImageGenerationPlugin(Star):
         """更新各模块的 API 客户端和相关配置"""
         if self.api_client:
             self.image_handler.update_config(api_client=self.api_client)
+            self.message_sender.update_config(
+                enable_text_response=self.cfg.enable_text_response,
+                max_inline_image_size_mb=self.cfg.max_inline_image_size_mb,
+                napcat_stream_threshold_mb=self.cfg.napcat_stream_threshold_mb,
+            )
             self.vision_handler.update_config(api_client=self.api_client)
             # 同步更新 ImageGenerator 的全部相关配置
             self.image_generator.update_config(
@@ -620,15 +624,14 @@ class GeminiImageGenerationPlugin(Star):
             api_duration = time.perf_counter() - api_start
 
             send_start = time.perf_counter()
-            async for send_res in self.message_sender.dispatch_send_results(
+            await self.message_sender.send_results_with_stream_retry(
                 event=event,
                 image_urls=image_urls,
                 image_paths=image_paths,
                 text_content=text_content,
                 thought_signature=thought_signature,
                 scene="快捷生成",
-            ):
-                yield send_res
+            )
             send_duration = time.perf_counter() - send_start
 
             async for res in self.message_sender.send_api_duration(
@@ -1447,15 +1450,18 @@ class GeminiImageGenerationPlugin(Star):
         send_start = time.perf_counter()
         if success and result_data:
             image_urls, image_paths, text_content, thought_signature = result_data
-            async for send_res in self.message_sender.dispatch_send_results(
-                event=event,
-                image_urls=image_urls,
-                image_paths=image_paths,
-                text_content=text_content,
-                thought_signature=thought_signature,
-                scene="换风格",
-            ):
-                yield send_res
+            try:
+                await self.message_sender.send_results_with_stream_retry(
+                    event=event,
+                    image_urls=image_urls,
+                    image_paths=image_paths,
+                    text_content=text_content,
+                    thought_signature=thought_signature,
+                    scene="换风格",
+                )
+            except Exception as e:
+                logger.warning(f"换风格结果发送失败: {e}")
+                yield event.plain_result("⚠️ 图像已生成，但发送失败，请查看日志。")
         else:
             yield event.plain_result(result_data)
         send_duration = time.perf_counter() - send_start
@@ -1640,14 +1646,6 @@ class GeminiImageGenerationPlugin(Star):
     @property
     def max_attempts_per_key(self) -> int:
         return self.cfg.max_attempts_per_key
-
-    @property
-    def nap_server_address(self) -> str:
-        return self.cfg.nap_server_address
-
-    @property
-    def nap_server_port(self) -> int:
-        return self.cfg.nap_server_port
 
     @property
     def preserve_reference_image_size(self) -> bool:

--- a/tl/README.md
+++ b/tl/README.md
@@ -10,7 +10,7 @@ main.py
   ├─ GeminiAPIClient -> tl/api/* Provider
   ├─ ImageGenerator -> GeminiAPIClient.generate_image()
   ├─ ImageHandler / AvatarHandler -> 收集参考图
-  ├─ MessageSender -> 发送生成结果
+  ├─ MessageSender -> 发送生成结果和 NapCat Stream 兜底
   ├─ VisionHandler / image_splitter / sticker_cutter -> 表情包切分
   ├─ RateLimiter -> 群限制与限流
   ├─ KeyManager -> provider_overrides 多 Key 轮换
@@ -28,7 +28,8 @@ main.py
 | `ImageGenerator.generate_image_core()` | `image_generator.py` | 指令与 LLM Tool 共用的核心生图逻辑 |
 | `GeminiImageGenerationTool.call()` | `llm_tools.py` | AstrBot FunctionTool 调用入口 |
 | `execute_image_generation_tool()` | `llm_tools.py` | 兼容旧调用方式的工具入口 |
-| `MessageSender.dispatch_send_results()` | `message_sender.py` | 图片、文本、合并转发发送入口 |
+| `MessageSender.dispatch_send_results()` | `message_sender.py` | 图片、文本、合并转发发送结果构造入口 |
+| `MessageSender.send_results_with_stream_retry()` | `message_sender.py` | 直接发送结果；原始发送失败后按阈值尝试 NapCat Stream API 兜底 |
 | `ImageHandler.fetch_images_from_event()` | `image_handler.py` | 从消息事件收集参考图和头像图 |
 | `AvatarHandler.get_avatar_reference()` | `avatar_handler.py` | 获取用户头像参考图 |
 | `split_image()` | `image_splitter.py` | 表情包切图入口 |
@@ -337,8 +338,8 @@ prompt + use_reference_images + include_user_avatar + resolution + aspect_ratio 
 
 | 接口 | 说明 |
 |------|------|
-| `MessageSender(enable_text_response=False, max_inline_image_size_mb=2.0)` | 消息发送处理器 |
-| `update_config(enable_text_response=None, max_inline_image_size_mb=None)` | 热更新发送配置 |
+| `MessageSender(enable_text_response=False, max_inline_image_size_mb=2.0, napcat_stream_threshold_mb=2.0)` | 消息发送处理器 |
+| `update_config(enable_text_response=None, max_inline_image_size_mb=None, napcat_stream_threshold_mb=None)` | 热更新发送配置 |
 | `is_aioqhttp_event(event)` | 判断是否为 aiocqhttp 平台 |
 | `safe_send(event, payload)` | 发送失败时兜底返回错误提示 |
 | `send_api_duration(event, api_duration, send_duration=None)` | 发送耗时统计 |
@@ -348,6 +349,7 @@ prompt + use_reference_images + include_user_avatar + resolution + aspect_ratio 
 | `merge_available_images(image_urls, image_paths)` | URL 与本地路径合并去重，URL 优先 |
 | `build_forward_image_component(image, force_base64=False)` | 构造 AstrBot 图片组件 |
 | `dispatch_send_results(...)` | 按单图、多图、合并转发策略发送结果 |
+| `send_results_with_stream_retry(...)` | 发送失败时筛选达到阈值的本地图片，调用 `upload_file_stream()` 后重试 |
 
 ## 表情包切分与视觉识别
 
@@ -475,7 +477,7 @@ _prepare_foreground()
 | 图片规范化 | `coerce_supported_image_bytes()`、`coerce_supported_image()`、`normalize_image_input()` | 将输入图片统一为 provider 可用格式 |
 | 图片源解析 | `collect_image_sources()`、`resolve_image_source_to_path()` | 从 AstrBot 事件或任意来源解析图片 |
 | QQ 头像 | `download_qq_avatar()`、`AvatarManager`、`download_qq_avatar_legacy()` | 头像下载和缓存管理 |
-| NapCat 文件 | `send_file()` | 向 NAP 文件服务器发送文件 |
+| NapCat Stream | `upload_file_stream()` | 复用当前 NapCat/OneBot 连接上传本地文件并返回可发送路径 |
 | 错误展示 | `format_error_message()` | 统一生图错误提示文案 |
 
 注意事项：
@@ -483,6 +485,7 @@ _prepare_foreground()
 - `normalize_image_input()` 是 API provider 处理参考图时的核心工具。
 - `resolve_image_source_to_path()` 是 `/切图` 将 URL/base64/data URI 转成本地文件的核心工具。
 - `AvatarManager` 管理头像缓存和清理，通常通过 `AvatarHandler` 或 `ImageHandler` 间接使用。
+- `upload_file_stream()` 只作为发送失败后的兜底路径使用，常规图片发送仍由 `MessageSender.dispatch_send_results()` 构造。
 
 ## `tl/api/__init__.py` 与 `tl/__init__.py`
 

--- a/tl/image_generator.py
+++ b/tl/image_generator.py
@@ -10,7 +10,6 @@ from astrbot.api import logger
 
 from .thought_signature import log_thought_signature_debug
 from .tl_api import APIError, ApiRequestConfig
-from .tl_utils import send_file
 
 if TYPE_CHECKING:
     from astrbot.api.event import AstrMessageEvent
@@ -40,8 +39,6 @@ class ImageGenerator:
         max_reference_images: int = 6,
         total_timeout: int = 120,
         max_attempts_per_key: int = 3,
-        nap_server_address: str = "localhost",
-        nap_server_port: int = 3658,
         filter_valid_fn=None,
         get_tool_timeout_fn=None,
     ):
@@ -63,8 +60,6 @@ class ImageGenerator:
             max_reference_images: 最大参考图片数
             total_timeout: 总超时时间
             max_attempts_per_key: 每个密钥最大尝试次数
-            nap_server_address: NAP 服务器地址
-            nap_server_port: NAP 服务器端口
             filter_valid_fn: 过滤有效参考图片的函数
             get_tool_timeout_fn: 获取工具超时的函数
         """
@@ -84,8 +79,6 @@ class ImageGenerator:
         self.max_reference_images = max_reference_images
         self.total_timeout = total_timeout
         self.max_attempts_per_key = max_attempts_per_key
-        self.nap_server_address = nap_server_address
-        self.nap_server_port = nap_server_port
         self._filter_valid_fn = filter_valid_fn
         self._get_tool_timeout_fn = get_tool_timeout_fn
 
@@ -231,32 +224,11 @@ The last {final_avatar_count} image(s) provided are User Avatars (marked as opti
             log_thought_signature_debug(thought_signature, scene="图像生成完成")
 
             resolved_paths: list[str] = []
-            for idx, img_path in enumerate(image_paths):
+            for img_path in image_paths:
                 if not img_path:
                     continue
                 if Path(img_path).exists():
-                    resolved_path = img_path
-                    if (
-                        self.nap_server_address
-                        and self.nap_server_address != "localhost"
-                    ):
-                        logger.debug(f"开始传输第 {idx + 1} 张图片到远程服务器...")
-                        try:
-                            remote_path = await asyncio.wait_for(
-                                send_file(
-                                    img_path,
-                                    host=self.nap_server_address,
-                                    port=self.nap_server_port,
-                                ),
-                                timeout=10.0,
-                            )
-                            if remote_path:
-                                resolved_path = remote_path
-                        except asyncio.TimeoutError:
-                            logger.warning("文件传输超时，使用本地文件")
-                        except Exception as e:
-                            logger.warning(f"文件传输失败: {e}，将使用本地文件")
-                    resolved_paths.append(resolved_path)
+                    resolved_paths.append(img_path)
                 else:
                     logger.warning(f"图像文件不存在或不可访问: {img_path}")
                     resolved_paths.append(img_path)

--- a/tl/llm_tools.py
+++ b/tl/llm_tools.py
@@ -574,20 +574,19 @@ async def _dispatch_generation_result(
             logger.info(
                 f"[{scene}] Text content only contained image references; using fallback text."
             )
-        async for send_res in plugin.message_sender.dispatch_send_results(
-            event=event,
-            image_urls=image_urls,
-            image_paths=image_paths,
-            text_content=content_text,
-            thought_signature=thought_signature,
-            scene=scene,
-            force_text_response=force_text_response,
-            text_content_prepared=True,
-        ):
-            try:
-                await event.send(send_res)
-            except Exception as exc:
-                logger.warning(f"[{scene}] 发送结果失败: {exc}")
+        try:
+            await plugin.message_sender.send_results_with_stream_retry(
+                event=event,
+                image_urls=image_urls,
+                image_paths=image_paths,
+                text_content=content_text,
+                thought_signature=thought_signature,
+                scene=scene,
+                force_text_response=force_text_response,
+                text_content_prepared=True,
+            )
+        except Exception as exc:
+            logger.warning(f"[{scene}] 发送结果失败: {exc}")
         return
 
     error_msg = result_data if isinstance(result_data, str) else "❌ 图像生成失败"

--- a/tl/message_sender.py
+++ b/tl/message_sender.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 import re
 import urllib.parse
@@ -40,6 +41,13 @@ AUTH_LIKE_QUERY_KEYS = {
 }
 
 
+class _DispatchSendError(RuntimeError):
+    def __init__(self, *, sent_count: int, cause: Exception):
+        super().__init__(f"发送第 {sent_count + 1} 条消息失败: {cause}")
+        self.sent_count = sent_count
+        self.cause = cause
+
+
 class MessageSender:
     """消息格式化和发送处理器"""
 
@@ -59,10 +67,18 @@ class MessageSender:
         """
         self.enable_text_response = enable_text_response
         self.max_inline_image_size_bytes = int(max_inline_image_size_mb * 1024 * 1024)
-        self.napcat_stream_threshold_bytes = int(
-            max(float(napcat_stream_threshold_mb or 0), 0.0) * 1024 * 1024
+        self.napcat_stream_threshold_bytes = self._mb_to_bytes(
+            napcat_stream_threshold_mb
         )
         self._log_debug = log_debug_fn or logger.debug
+
+    @staticmethod
+    def _mb_to_bytes(value: float | int | str | None) -> int:
+        try:
+            value_mb = float(value or 0)
+        except (TypeError, ValueError):
+            value_mb = 0.0
+        return int(max(value_mb, 0.0) * 1024 * 1024)
 
     def update_config(
         self,
@@ -78,8 +94,8 @@ class MessageSender:
                 max_inline_image_size_mb * 1024 * 1024
             )
         if napcat_stream_threshold_mb is not None:
-            self.napcat_stream_threshold_bytes = int(
-                max(float(napcat_stream_threshold_mb or 0), 0.0) * 1024 * 1024
+            self.napcat_stream_threshold_bytes = self._mb_to_bytes(
+                napcat_stream_threshold_mb
             )
 
     @staticmethod
@@ -96,6 +112,8 @@ class MessageSender:
         """包装发送，若平台发送失败则提示用户"""
         try:
             yield payload
+        except asyncio.CancelledError:
+            raise
         except Exception as e:
             logger.error(f"发送消息失败: {e}")
             yield event.plain_result("⚠️ 消息发送失败，请稍后重试或检查网络/权限。")
@@ -123,8 +141,9 @@ class MessageSender:
         self,
         event: AstrMessageEvent,
         image_paths: list[str] | None,
-    ) -> list[str] | None:
+    ) -> tuple[list[str], bool, bool]:
         fallback_paths: list[str] = []
+        has_candidate = False
         changed = False
 
         for image in image_paths or []:
@@ -134,6 +153,7 @@ class MessageSender:
                     fallback_paths.append(image)
                 continue
 
+            has_candidate = True
             streamed_path = await upload_file_stream(event, candidate)
             if streamed_path:
                 fallback_paths.append(streamed_path)
@@ -141,7 +161,7 @@ class MessageSender:
             else:
                 fallback_paths.append(image)
 
-        return fallback_paths if changed else None
+        return fallback_paths, has_candidate, changed
 
     async def _send_dispatch_results(
         self,
@@ -158,6 +178,7 @@ class MessageSender:
         if not hasattr(event, "send"):
             raise RuntimeError("当前事件对象不支持直接发送，无法执行 Stream API 兜底")
 
+        sent_count = 0
         async for payload in self.dispatch_send_results(
             event=event,
             image_urls=image_urls,
@@ -168,7 +189,13 @@ class MessageSender:
             force_text_response=force_text_response,
             text_content_prepared=text_content_prepared,
         ):
-            await event.send(payload)
+            try:
+                await event.send(payload)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                raise _DispatchSendError(sent_count=sent_count, cause=exc) from exc
+            sent_count += 1
 
     async def send_results_with_stream_retry(
         self,
@@ -196,22 +223,43 @@ class MessageSender:
                 text_content_prepared=text_content_prepared,
             )
             return
+        except asyncio.CancelledError:
+            raise
+        except _DispatchSendError as exc:
+            if exc.sent_count > 0:
+                logger.warning(
+                    f"[SEND] {scene} 已成功发送 {exc.sent_count} 条消息，"
+                    f"跳过 Stream API 整组兜底以避免重复发送: {exc.cause}"
+                )
+                raise
+            first_error = exc.cause
+            logger.warning(
+                f"[SEND] {scene} 原始发送失败，准备检查 Stream API 兜底: {exc.cause}"
+            )
         except Exception as exc:
             first_error = exc
             logger.warning(
                 f"[SEND] {scene} 原始发送失败，准备检查 Stream API 兜底: {exc}"
             )
 
-        fallback_paths = await self._build_stream_fallback_paths(event, image_paths)
-        if not fallback_paths:
+        (
+            fallback_paths,
+            has_candidate,
+            changed,
+        ) = await self._build_stream_fallback_paths(event, image_paths)
+        if not has_candidate:
             raise RuntimeError(
                 "原始发送失败，且没有可用于 NapCat Stream API 兜底的本地图片"
+            ) from first_error
+        if not changed:
+            raise RuntimeError(
+                "原始发送失败，NapCat Stream API 兜底上传也未成功"
             ) from first_error
 
         logger.warning(f"[SEND] {scene} 已启用 NapCat Stream API 兜底重试")
         await self._send_dispatch_results(
             event=event,
-            image_urls=[],
+            image_urls=image_urls,
             image_paths=fallback_paths,
             text_content=text_content,
             thought_signature=thought_signature,
@@ -241,6 +289,8 @@ class MessageSender:
                 msg = f"⏱️ API响应 {api_duration:.1f}s"
             async for res in self.safe_send(event, event.plain_result(msg)):
                 yield res
+        except asyncio.CancelledError:
+            raise
         except Exception as e:
             # 非关键统计信息发送失败时仅记录日志，避免影响主流程
             logger.error(f"发送耗时统计消息失败: {e}")

--- a/tl/message_sender.py
+++ b/tl/message_sender.py
@@ -42,9 +42,12 @@ AUTH_LIKE_QUERY_KEYS = {
 
 
 class _DispatchSendError(RuntimeError):
-    def __init__(self, *, sent_count: int, cause: Exception):
-        super().__init__(f"发送第 {sent_count + 1} 条消息失败: {cause}")
+    def __init__(self, *, sent_count: int, failed_count: int, cause: Exception):
+        super().__init__(
+            f"发送结果中有 {failed_count} 条消息失败，成功 {sent_count} 条: {cause}"
+        )
         self.sent_count = sent_count
+        self.failed_count = failed_count
         self.cause = cause
 
 
@@ -141,10 +144,11 @@ class MessageSender:
         self,
         event: AstrMessageEvent,
         image_paths: list[str] | None,
-    ) -> tuple[list[str], bool, bool]:
+    ) -> tuple[list[str], bool, bool, int]:
         fallback_paths: list[str] = []
         has_candidate = False
         changed = False
+        failed_candidates = 0
 
         for image in image_paths or []:
             candidate = self._stream_fallback_candidate(image)
@@ -159,9 +163,10 @@ class MessageSender:
                 fallback_paths.append(streamed_path)
                 changed = True
             else:
+                failed_candidates += 1
                 fallback_paths.append(image)
 
-        return fallback_paths, has_candidate, changed
+        return fallback_paths, has_candidate, changed, failed_candidates
 
     async def _send_dispatch_results(
         self,
@@ -179,6 +184,8 @@ class MessageSender:
             raise RuntimeError("当前事件对象不支持直接发送，无法执行 Stream API 兜底")
 
         sent_count = 0
+        failed_count = 0
+        first_error: Exception | None = None
         async for payload in self.dispatch_send_results(
             event=event,
             image_urls=image_urls,
@@ -194,8 +201,22 @@ class MessageSender:
             except asyncio.CancelledError:
                 raise
             except Exception as exc:
-                raise _DispatchSendError(sent_count=sent_count, cause=exc) from exc
-            sent_count += 1
+                failed_count += 1
+                if first_error is None:
+                    first_error = exc
+                logger.warning(
+                    f"[SEND] {scene} 第 {sent_count + failed_count} 条消息发送失败: {exc}"
+                )
+                continue
+            else:
+                sent_count += 1
+
+        if first_error is not None:
+            raise _DispatchSendError(
+                sent_count=sent_count,
+                failed_count=failed_count,
+                cause=first_error,
+            ) from first_error
 
     async def send_results_with_stream_retry(
         self,
@@ -246,10 +267,15 @@ class MessageSender:
             fallback_paths,
             has_candidate,
             changed,
+            failed_candidates,
         ) = await self._build_stream_fallback_paths(event, image_paths)
         if not has_candidate:
             raise RuntimeError(
                 "原始发送失败，且没有可用于 NapCat Stream API 兜底的本地图片"
+            ) from first_error
+        if failed_candidates:
+            raise RuntimeError(
+                f"原始发送失败，NapCat Stream API 兜底上传仍有 {failed_candidates} 个候选文件失败"
             ) from first_error
         if not changed:
             raise RuntimeError(

--- a/tl/message_sender.py
+++ b/tl/message_sender.py
@@ -12,6 +12,7 @@ from astrbot.api import logger
 from astrbot.api.message_components import Image as AstrImage
 from astrbot.api.message_components import Node, Plain
 
+from .napcat_stream import upload_file_stream
 from .thought_signature import log_thought_signature_debug
 from .tl_utils import encode_file_to_base64
 from .tl_utils import is_valid_base64_image_str as util_is_valid_base64_image_str
@@ -46,22 +47,28 @@ class MessageSender:
         self,
         enable_text_response: bool = False,
         max_inline_image_size_mb: float = 2.0,
+        napcat_stream_threshold_mb: float = 2.0,
         log_debug_fn=None,
     ):
         """
         Args:
             enable_text_response: 是否启用文本响应
             max_inline_image_size_mb: 本地图片 base64 编码阈值（MB）
+            napcat_stream_threshold_mb: NapCat Stream API 兜底上传阈值（MB）
             log_debug_fn: 可选的日志函数
         """
         self.enable_text_response = enable_text_response
         self.max_inline_image_size_bytes = int(max_inline_image_size_mb * 1024 * 1024)
+        self.napcat_stream_threshold_bytes = int(
+            max(float(napcat_stream_threshold_mb or 0), 0.0) * 1024 * 1024
+        )
         self._log_debug = log_debug_fn or logger.debug
 
     def update_config(
         self,
         enable_text_response: bool | None = None,
         max_inline_image_size_mb: float | None = None,
+        napcat_stream_threshold_mb: float | None = None,
     ):
         """更新配置"""
         if enable_text_response is not None:
@@ -69,6 +76,10 @@ class MessageSender:
         if max_inline_image_size_mb is not None:
             self.max_inline_image_size_bytes = int(
                 max_inline_image_size_mb * 1024 * 1024
+            )
+        if napcat_stream_threshold_mb is not None:
+            self.napcat_stream_threshold_bytes = int(
+                max(float(napcat_stream_threshold_mb or 0), 0.0) * 1024 * 1024
             )
 
     @staticmethod
@@ -88,6 +99,126 @@ class MessageSender:
         except Exception as e:
             logger.error(f"发送消息失败: {e}")
             yield event.plain_result("⚠️ 消息发送失败，请稍后重试或检查网络/权限。")
+
+    def _stream_fallback_candidate(self, image: str) -> str | None:
+        if self.napcat_stream_threshold_bytes <= 0 or not image:
+            return None
+        if image.startswith(("http://", "https://", "data:image/")):
+            return None
+        if util_is_valid_base64_image_str(image):
+            return None
+
+        candidate = image[8:] if image.startswith("file:///") else image
+        if not os.path.isfile(candidate):
+            return None
+
+        try:
+            if os.path.getsize(candidate) < self.napcat_stream_threshold_bytes:
+                return None
+        except OSError:
+            return None
+        return candidate
+
+    async def _build_stream_fallback_paths(
+        self,
+        event: AstrMessageEvent,
+        image_paths: list[str] | None,
+    ) -> list[str] | None:
+        fallback_paths: list[str] = []
+        changed = False
+
+        for image in image_paths or []:
+            candidate = self._stream_fallback_candidate(image)
+            if not candidate:
+                if image:
+                    fallback_paths.append(image)
+                continue
+
+            streamed_path = await upload_file_stream(event, candidate)
+            if streamed_path:
+                fallback_paths.append(streamed_path)
+                changed = True
+            else:
+                fallback_paths.append(image)
+
+        return fallback_paths if changed else None
+
+    async def _send_dispatch_results(
+        self,
+        *,
+        event: AstrMessageEvent,
+        image_urls: list[str] | None,
+        image_paths: list[str] | None,
+        text_content: str | None,
+        thought_signature: str | None = None,
+        scene: str = "默认",
+        force_text_response: bool = False,
+        text_content_prepared: bool = False,
+    ) -> None:
+        if not hasattr(event, "send"):
+            raise RuntimeError("当前事件对象不支持直接发送，无法执行 Stream API 兜底")
+
+        async for payload in self.dispatch_send_results(
+            event=event,
+            image_urls=image_urls,
+            image_paths=image_paths,
+            text_content=text_content,
+            thought_signature=thought_signature,
+            scene=scene,
+            force_text_response=force_text_response,
+            text_content_prepared=text_content_prepared,
+        ):
+            await event.send(payload)
+
+    async def send_results_with_stream_retry(
+        self,
+        *,
+        event: AstrMessageEvent,
+        image_urls: list[str] | None,
+        image_paths: list[str] | None,
+        text_content: str | None,
+        thought_signature: str | None = None,
+        scene: str = "默认",
+        force_text_response: bool = False,
+        text_content_prepared: bool = False,
+    ) -> None:
+        """先按现有逻辑发送；失败后再使用 NapCat Stream API 兜底重试一次。"""
+        first_error: Exception | None = None
+        try:
+            await self._send_dispatch_results(
+                event=event,
+                image_urls=image_urls,
+                image_paths=image_paths,
+                text_content=text_content,
+                thought_signature=thought_signature,
+                scene=scene,
+                force_text_response=force_text_response,
+                text_content_prepared=text_content_prepared,
+            )
+            return
+        except Exception as exc:
+            first_error = exc
+            logger.warning(
+                f"[SEND] {scene} 原始发送失败，准备检查 Stream API 兜底: {exc}"
+            )
+
+        fallback_paths = await self._build_stream_fallback_paths(event, image_paths)
+        if not fallback_paths:
+            raise RuntimeError(
+                "原始发送失败，且没有可用于 NapCat Stream API 兜底的本地图片"
+            ) from first_error
+
+        logger.warning(f"[SEND] {scene} 已启用 NapCat Stream API 兜底重试")
+        await self._send_dispatch_results(
+            event=event,
+            image_urls=[],
+            image_paths=fallback_paths,
+            text_content=text_content,
+            thought_signature=thought_signature,
+            scene=f"{scene}/Stream兜底",
+            force_text_response=force_text_response,
+            text_content_prepared=text_content_prepared,
+        )
 
     async def send_api_duration(
         self,

--- a/tl/napcat_stream.py
+++ b/tl/napcat_stream.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import hashlib
 import math
@@ -34,8 +35,10 @@ async def _call_action(bot_client: Any, action: str, params: dict[str, Any]) -> 
 
 
 def _extract_response_data(response: Any) -> dict[str, Any]:
+    if response is None:
+        raise RuntimeError("NapCat Stream API 未返回响应")
     if not isinstance(response, dict):
-        return {}
+        raise RuntimeError(f"NapCat Stream API 返回格式异常: {type(response).__name__}")
 
     status = response.get("status")
     if status == "failed":
@@ -100,7 +103,6 @@ async def upload_file_stream(
 
     chunk_size = max(1, int(chunk_size or DEFAULT_STREAM_CHUNK_SIZE))
     total_chunks = max(1, math.ceil(file_size / chunk_size))
-    expected_sha256 = _calculate_sha256(path)
     stream_id = str(uuid.uuid4())
 
     logger.debug(
@@ -108,11 +110,34 @@ async def upload_file_stream(
     )
 
     try:
+        expected_sha256 = await asyncio.to_thread(_calculate_sha256, path)
+        current_size = path.stat().st_size
+        if current_size != file_size:
+            raise RuntimeError(
+                "文件在上传前大小发生变化，无法按声明大小完成上传: "
+                f"file={path} expected={file_size} actual={current_size}"
+            )
+
         with path.open("rb") as file:
             for chunk_index in range(total_chunks):
                 chunk = file.read(chunk_size)
                 if not chunk:
-                    break
+                    raise RuntimeError(
+                        "文件在上传过程中提前结束，无法按声明的分块数完成上传: "
+                        f"file={path} chunk_index={chunk_index} "
+                        f"total_chunks={total_chunks}"
+                    )
+                expected_chunk_size = (
+                    file_size - chunk_size * chunk_index
+                    if chunk_index == total_chunks - 1
+                    else chunk_size
+                )
+                if len(chunk) != expected_chunk_size:
+                    raise RuntimeError(
+                        "文件在上传过程中大小发生变化，无法按声明大小完成上传: "
+                        f"file={path} chunk_index={chunk_index} "
+                        f"expected={expected_chunk_size} actual={len(chunk)}"
+                    )
 
                 response = await _call_action(
                     bot_client,
@@ -141,6 +166,8 @@ async def upload_file_stream(
         else:
             logger.warning("[NapCat Stream] 上传完成响应缺少 file_path")
         return uploaded_path
+    except asyncio.CancelledError:
+        raise
     except Exception as exc:
         logger.warning(f"[NapCat Stream] 上传失败，回退原文件路径: {exc}")
         return None

--- a/tl/napcat_stream.py
+++ b/tl/napcat_stream.py
@@ -1,0 +1,146 @@
+"""NapCat Stream API upload helpers."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import math
+import uuid
+from pathlib import Path
+from typing import Any
+
+from astrbot.api import logger
+
+DEFAULT_STREAM_CHUNK_SIZE = 64 * 1024
+DEFAULT_FILE_RETENTION_MS = 30 * 1000
+
+
+def _get_bot_client(event: Any) -> Any | None:
+    return getattr(event, "bot", None) or getattr(event, "_bot", None)
+
+
+def _supports_call_action(bot_client: Any) -> bool:
+    return (
+        hasattr(bot_client, "api") and hasattr(bot_client.api, "call_action")
+    ) or hasattr(bot_client, "call_action")
+
+
+async def _call_action(bot_client: Any, action: str, params: dict[str, Any]) -> Any:
+    if hasattr(bot_client, "api") and hasattr(bot_client.api, "call_action"):
+        return await bot_client.api.call_action(action, **params)
+    if hasattr(bot_client, "call_action"):
+        return await bot_client.call_action(action, **params)
+    return None
+
+
+def _extract_response_data(response: Any) -> dict[str, Any]:
+    if not isinstance(response, dict):
+        return {}
+
+    status = response.get("status")
+    if status == "failed":
+        message = response.get("message") or response.get("wording") or response
+        raise RuntimeError(f"NapCat Stream API 返回失败: {message}")
+    retcode = response.get("retcode")
+    if retcode not in (None, 0):
+        message = response.get("message") or response.get("wording") or response
+        raise RuntimeError(f"NapCat Stream API 返回错误: retcode={retcode}, {message}")
+
+    data = response.get("data")
+    if isinstance(data, dict):
+        return data
+    return response
+
+
+def _calculate_sha256(file_path: Path) -> str:
+    hasher = hashlib.sha256()
+    with file_path.open("rb") as file:
+        while True:
+            chunk = file.read(DEFAULT_STREAM_CHUNK_SIZE)
+            if not chunk:
+                break
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def _extract_uploaded_path(response: Any) -> str | None:
+    data = _extract_response_data(response)
+    for key in ("file_path", "file", "path"):
+        value = data.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+async def upload_file_stream(
+    event: Any,
+    file_path: str | Path,
+    *,
+    chunk_size: int = DEFAULT_STREAM_CHUNK_SIZE,
+    file_retention_ms: int = DEFAULT_FILE_RETENTION_MS,
+) -> str | None:
+    """Upload a local file to NapCat through the existing OneBot connection."""
+    bot_client = _get_bot_client(event)
+    if not bot_client:
+        logger.debug("[NapCat Stream] 未找到事件 bot 客户端，跳过流式上传")
+        return None
+    if not _supports_call_action(bot_client):
+        logger.debug("[NapCat Stream] bot 客户端不支持 call_action，跳过流式上传")
+        return None
+
+    path = Path(file_path)
+    if not path.exists() or not path.is_file():
+        logger.debug(f"[NapCat Stream] 文件不存在，跳过流式上传: {file_path}")
+        return None
+
+    file_size = path.stat().st_size
+    if file_size <= 0:
+        logger.debug(f"[NapCat Stream] 文件为空，跳过流式上传: {file_path}")
+        return None
+
+    chunk_size = max(1, int(chunk_size or DEFAULT_STREAM_CHUNK_SIZE))
+    total_chunks = max(1, math.ceil(file_size / chunk_size))
+    expected_sha256 = _calculate_sha256(path)
+    stream_id = str(uuid.uuid4())
+
+    logger.debug(
+        f"[NapCat Stream] 开始上传: file={path.name} size={file_size} chunks={total_chunks}"
+    )
+
+    try:
+        with path.open("rb") as file:
+            for chunk_index in range(total_chunks):
+                chunk = file.read(chunk_size)
+                if not chunk:
+                    break
+
+                response = await _call_action(
+                    bot_client,
+                    "upload_file_stream",
+                    {
+                        "stream_id": stream_id,
+                        "chunk_data": base64.b64encode(chunk).decode("utf-8"),
+                        "chunk_index": chunk_index,
+                        "total_chunks": total_chunks,
+                        "file_size": file_size,
+                        "expected_sha256": expected_sha256,
+                        "filename": path.name,
+                        "file_retention": file_retention_ms,
+                    },
+                )
+                _extract_response_data(response)
+
+        complete_response = await _call_action(
+            bot_client,
+            "upload_file_stream",
+            {"stream_id": stream_id, "is_complete": True},
+        )
+        uploaded_path = _extract_uploaded_path(complete_response)
+        if uploaded_path:
+            logger.debug(f"[NapCat Stream] 上传完成: {uploaded_path}")
+        else:
+            logger.warning("[NapCat Stream] 上传完成响应缺少 file_path")
+        return uploaded_path
+    except Exception as exc:
+        logger.warning(f"[NapCat Stream] 上传失败，回退原文件路径: {exc}")
+        return None

--- a/tl/plugin_config.py
+++ b/tl/plugin_config.py
@@ -96,8 +96,7 @@ class PluginConfig:
     total_timeout: int = 120
 
     # 服务设置
-    nap_server_address: str = "localhost"
-    nap_server_port: int = 3658
+    napcat_stream_threshold_mb: float = 2.0
     auto_avatar_reference: bool = False
 
     # 帮助页渲染
@@ -555,10 +554,13 @@ class ConfigLoader:
 
         # 服务设置
         service_settings = self.raw_config.get("service_settings") or {}
-        config.nap_server_address = (
-            service_settings.get("nap_server_address") or "localhost"
-        )
-        config.nap_server_port = service_settings.get("nap_server_port") or 3658
+        try:
+            config.napcat_stream_threshold_mb = float(
+                service_settings.get("napcat_stream_threshold_mb", 2.0)
+            )
+        except (TypeError, ValueError):
+            config.napcat_stream_threshold_mb = 2.0
+        config.napcat_stream_threshold_mb = max(config.napcat_stream_threshold_mb, 0.0)
         config.auto_avatar_reference = (
             service_settings.get("auto_avatar_reference") or False
         )

--- a/tl/tl_utils.py
+++ b/tl/tl_utils.py
@@ -1,6 +1,6 @@
 """
 工具函数模块
-提供头像管理、文件传输和图像处理功能
+提供头像管理、文件保存和图像处理功能
 """
 
 import asyncio
@@ -10,7 +10,6 @@ import hashlib
 import io
 import os
 import re
-import struct
 import time
 import urllib.parse
 from collections import OrderedDict
@@ -714,102 +713,6 @@ async def download_qq_avatar(
     except Exception as e:
         logger.error(f"下载头像 {cache_name} 失败: {e}")
         return None
-
-
-async def send_file(filename: str, host: str, port: int):
-    """
-    发送文件到远程服务器
-
-    Args:
-        filename: 要发送的文件路径
-        host: 远程主机地址
-        port: 远程主机端口
-
-    Returns:
-        str: 远程文件路径，失败返回None
-    """
-    reader = None
-    writer = None
-
-    async def recv_all(reader, size):
-        """接收指定大小的数据"""
-        data = b""
-        while len(data) < size:
-            chunk = await reader.read(size - len(data))
-            if not chunk:
-                break
-            data += chunk
-        return data
-
-    try:
-        # 添加连接超时控制
-        reader, writer = await asyncio.wait_for(
-            asyncio.open_connection(host, port),
-            timeout=5.0,  # 5秒连接超时
-        )
-
-        file_name = os.path.basename(filename)
-        file_name_bytes = file_name.encode("utf-8")
-
-        # 发送文件名长度和文件名
-        writer.write(struct.pack(">I", len(file_name_bytes)))
-        writer.write(file_name_bytes)
-
-        # 发送文件大小
-        file_size = os.path.getsize(filename)
-        writer.write(struct.pack(">Q", file_size))
-
-        # 发送文件内容，添加总体超时控制
-        await writer.drain()
-        with open(filename, "rb") as f:
-            while True:
-                data = f.read(4096)
-                if not data:
-                    break
-                writer.write(data)
-                await writer.drain()
-
-        logger.debug(f"文件 {file_name} 发送成功")
-
-        # 接收接收端发送的文件绝对路径
-        try:
-            file_abs_path_len_data = await recv_all(reader, 4)
-            if not file_abs_path_len_data:
-                logger.error("无法接收文件绝对路径长度")
-                return None
-            file_abs_path_len = struct.unpack(">I", file_abs_path_len_data)[0]
-
-            file_abs_path_data = await recv_all(reader, file_abs_path_len)
-            if not file_abs_path_data:
-                logger.error("无法接收文件绝对路径")
-                return None
-
-            file_abs_path = file_abs_path_data.decode("utf-8")
-            logger.debug(f"文件在远程服务器保存为: {file_abs_path}")
-            return file_abs_path
-
-        except Exception as e:
-            logger.error(f"接收远程文件路径失败: {e}")
-            return None
-
-    except asyncio.TimeoutError:
-        logger.error(f"连接 {host}:{port} 超时")
-        return None
-    except Exception as e:
-        logger.error(f"发送文件失败: {e}")
-        return None
-    finally:
-        if writer:
-            try:
-                writer.close()
-                await writer.wait_closed()
-            except Exception:
-                pass
-        if reader:
-            try:
-                reader.close()
-            except Exception:
-                pass
 
 
 def is_valid_base64_image_str(value: str) -> bool:


### PR DESCRIPTION
## 改动类型

- [ ] Bug 修复
- [x] 新功能
- [ ] 重构 / 代码优化
- [ ] 文档更新
- [ ] 其他

## 关联 Issue

<!-- 如有关联 Issue 请填写，例如 Fixes #123 -->

## 测试情况

- [ ] 本地测试通过
- [ ] 已测试相关命令（/生图、/改图、/快速 等）
- [ ] 已测试 LLM 工具调用

## 补充说明

<!-- 需要 reviewer 特别关注的点、兼容性说明等 -->

## Summary by Sourcery

在普通消息发送失败时，引入基于 NapCat Stream 的回退路径，用于发送本地的大体积图片，并通过插件打通相关配置。

New Features:
- 在 `MessageSender` 中添加可配置的 NapCat Stream API 回退逻辑：当初次发送失败且本地图片过大时，通过流式上传重试发送结果。
- 暴露一个 `napcat_stream_threshold_mb` 服务配置项，用于控制何时启用 NapCat Stream 回退，并在初始化和配置更新时传入 `MessageSender`。
- 实现一个 NapCat Stream 上传辅助工具，复用现有的 OneBot 连接来流式上传文件并返回可发送的路径。

Enhancements:
- 优化在快速生成（quick-generate）、样式切换（style-change）以及 LLM 工具图片生成中的消息发送流程，使用新的支持流式回退的 `send_results_with_stream_retry` API，而不是直接遍历 `dispatch_send_results`。
- 简化 `ImageGenerator`，移除远程 NAP 文件服务器支持，改为直接使用本地图片路径。

Documentation:
- 更新插件 README 和配置文档，说明 NapCat Stream 回退行为、新的 `napcat_stream_threshold_mb` 选项以及 `upload_file_stream` 辅助工具，并将 provider 覆盖相关文档调整为新的配置模式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a NapCat Stream-based fallback path for sending large local images when normal message delivery fails, and wire its configuration through the plugin.

New Features:
- Add configurable NapCat Stream API fallback logic in MessageSender to retry sending results by streaming oversized local images when initial delivery fails.
- Expose a napcat_stream_threshold_mb service setting to control when NapCat Stream fallback is used and pass it into MessageSender at init and config update time.
- Implement a NapCat Stream upload helper that reuses the existing OneBot connection to stream files and return a sendable path.

Enhancements:
- Refine message sending flows in quick-generate, style-change, and LLM tool image generation to use the new stream-aware send_results_with_stream_retry API instead of directly iterating dispatch_send_results.
- Simplify ImageGenerator by removing remote NAP file server support and using local image paths directly.

Documentation:
- Update plugin README and configuration documentation to describe NapCat Stream fallback behavior, the new napcat_stream_threshold_mb option, and the upload_file_stream helper, and adjust provider override docs to the new configuration pattern.

</details>