### PR TITLE
feat(minimax): 新增 MiniMax 图片生成 API 供应商

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 > **升级提示**：v1.9.0 以后的配置文件格式不兼容旧版本。升级后如遇配置模板显示错误，请查看 [配置迁移说明](https://github.com/piexian/astrbot_plugin_gemini_image_generation/blob/master/docs/troubleshooting.md#配置迁移说明)。
 
+## [1.10.0] - 2026-04-26
+
+### Added
+
+#### MiniMax 图片生成 API 支持
+
+- 新增 `minimax` API 类型，支持 MiniMax 官方 `/v1/image_generation` 端点，类型别名 `minimax` / `minimaxi` / `hailuo`
+- 新增 `tl/api/minimax.py` 供应商实现（`MiniMaxProvider`），支持文生图和 `subject_reference` 图生图
+- 支持 `image_urls` 和 `image_base64` 两种响应格式，base64 自动保存为本地图片文件
+- 新增 `provider_overrides[minimax]` 完整配置模板：多 Key 轮换、每日限额、模型（`image-01` / `image-01-live`）、`response_format`、`n`（1-9）、提示词自动优化、AIGC 水印、参考图传递方式（`auto` / `base64` / `url`）、自定义尺寸（512-2048，8 的倍数）、随机种子和代理
+- 全局 `resolution`（1K/2K/4K）和 `aspect_ratio` 自动适配：1K + 支持比例使用 MiniMax 原生 `aspect_ratio`；2K/4K 或不支持比例（4:5、5:4）时自动计算显式 `width`/`height`；`image-01-live` 模型仅使用 `aspect_ratio`，不发送 `width`/`height`
+
+#### NapCat Stream API 文件上传
+
+- 新增 `tl/napcat_stream.py`，通过 NapCat `upload_file_stream` 动作分块上传本地文件，替代旧 TCP 文件传输
+- 图片发送失败时自动检测本地大图并通过 Stream API 重试，解决 NapCat 大图发送失败问题
+- 新增 `napcat_stream_threshold_mb` 配置项（默认 2.0MB），控制触发 Stream 回退的文件大小阈值
+
+### Changed
+
+- 移除旧的 NAP TCP 文件传输方式及 `nap_server_address` / `nap_server_port` 配置项，统一替换为 NapCat Stream API 方案
+- 所有图片发送路径（快捷生成、风格变换、LLM 工具后台发送）统一使用 `send_results_with_stream_retry()` 包装器，内置 Stream 自动重试逻辑
+- 文档重构：README 精简为概览入口，详细配置参考、使用指南和故障排除拆分至 `docs/` 目录
+- 新增 `docs/config.md`（完整配置参考）、`docs/usage.md`（使用指南）、`docs/troubleshooting.md`（故障排除与配置迁移说明）
+- 扩展 `tl/README.md` 为完整的内部模块 API 文档索引
+
 ## [1.9.14] - 2026-04-23
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 - **多模式图像生成**：纯文本生图、参考图改图、风格转换、手办化、表情包生成。
 - **快速预设**：头像、海报、壁纸、卡片、手机壁纸、手办化、表情包一键生成。
 - **智能参考图**：自动读取消息图片、引用图片、合并转发、群文件，以及用户头像和 @ 对象头像。
-- **多供应商支持**：Google Gemini、OpenAI 兼容、OpenAI Images、xAI Images、Zai、grok2api、豆包。
+- **多供应商支持**：Google Gemini、OpenAI 兼容、OpenAI Images、xAI Images、MiniMax、Zai、grok2api、豆包。
 - **LLM 工具集成**：支持自然语言触发生图，前台短等待，超时后自动转后台发送。
 - **表情包切分**：内置 SmartMemeSplitter v4，并提供手动网格、视觉识别、主体吸附等兜底路径。
 - **限流与缓存**：支持群白名单/黑名单、周期限流、KV 持久化、临时文件自动清理。
@@ -48,7 +48,7 @@ https://github.com/piexian/astrbot_plugin_gemini_image_generation
 | 配置项 | 说明 |
 |--------|------|
 | `api_settings.provider_id` | 生图模型提供商，从 AstrBot 提供商列表选择；豆包可不填 |
-| `api_settings.api_type` | API 类型：`google` / `openai` / `openai_images` / `xai` / `zai` / `grok2api` / `doubao` |
+| `api_settings.api_type` | API 类型：`google` / `openai` / `openai_images` / `xai` / `minimax` / `zai` / `grok2api` / `doubao` |
 
 常用配置入口：
 
@@ -87,6 +87,20 @@ https://github.com/piexian/astrbot_plugin_gemini_image_generation
 | LLM 工具调用 | LLM 显式传入 `size` 时以该值为准，否则使用配置中的 `custom_size` |
 
 尺寸格式为 `WxH`，支持 `x` 或 `×`，例如 `1024x1024`、`2048×1152`。详细限制和示例见 [OpenAI Images 配置](https://github.com/piexian/astrbot_plugin_gemini_image_generation/blob/master/docs/config.md#openai_images_settingsopenai-images-api-专用配置)。
+
+## MiniMax 提示
+
+`minimax` 供应商支持 MiniMax 官方 `/v1/image_generation` 端点，模型默认 `image-01`：
+
+| 能力 | 说明 |
+|------|------|
+| 文生图 | 直接发送 prompt、长宽比、生成数量等参数 |
+| 图生图 | 通过 `subject_reference` 传入参考图，默认 `type=character` |
+| 多图生成 | `n` 支持 `1-9` |
+| 响应格式 | 默认 `base64` 并保存为本地图片，避免官方 URL 24 小时过期 |
+| 分辨率适配 | 全局 `resolution`（1K/2K/4K）自动映射；不支持的比例（如 4:5）会计算显式像素尺寸 |
+
+详细配置见 [MiniMax 配置](https://github.com/piexian/astrbot_plugin_gemini_image_generation/blob/master/docs/config.md#minimax_settingsminimax-图片生成-api-专用配置)。
 
 ## 项目结构
 

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -14,13 +14,14 @@
       "api_type": {
         "description": "API 类型（必选）",
         "type": "string",
-        "hint": "必须选择 API 类型（google/openai/openai_images/xai/zai/grok2api/doubao）。 不同提供商支持的类型不同，请参考提供商说明",
+        "hint": "必须选择 API 类型（google/openai/openai_images/xai/minimax/zai/grok2api/doubao）。 不同提供商支持的类型不同，请参考提供商说明",
         "default": "openai",
         "options": [
           "google",
           "openai",
           "openai_images",
           "xai",
+          "minimax",
           "zai",
           "grok2api",
           "doubao"
@@ -242,6 +243,99 @@
                 "type": "int",
                 "hint": "单次请求生成的图片数量，xAI 当前单次最多 10 张",
                 "default": 1
+              },
+              "proxy": {
+                "description": "代理地址",
+                "type": "string",
+                "hint": "填写即启用代理，留空使用全局代理或环境变量。支持 http://host:port、https://host:port、socks5://host:port 格式。优先级高于全局代理和环境变量",
+                "default": ""
+              }
+            }
+          },
+          "minimax": {
+            "description": "MiniMax 图片生成 API 覆盖配置",
+            "hint": "配置 MiniMax /v1/image_generation 端点的密钥和参数，支持文生图和 subject_reference 图生图",
+            "items": {
+              "api_keys": {
+                "description": "API Key 列表",
+                "type": "list",
+                "hint": "多个 API Key，支持轮换使用",
+                "default": []
+              },
+              "daily_limit_per_key": {
+                "description": "每个 Key 每日限额",
+                "type": "int",
+                "hint": "每个 API Key 每日最大调用次数，0 表示不限制",
+                "default": 0
+              },
+              "model": {
+                "description": "模型名称",
+                "type": "string",
+                "hint": "MiniMax 图片模型名称，官方支持 image-01 / image-01-live",
+                "default": "image-01"
+              },
+              "api_base": {
+                "description": "API 端点地址",
+                "type": "string",
+                "hint": "MiniMax API 地址，留空使用默认 https://api.minimaxi.com；插件会统一调用 /v1/image_generation",
+                "default": "https://api.minimaxi.com"
+              },
+              "response_format": {
+                "description": "响应格式",
+                "type": "string",
+                "hint": "url 返回 24 小时临时链接，base64 返回编码图片并由插件保存到本地。",
+                "default": "base64",
+                "options": ["base64", "url"]
+              },
+              "n": {
+                "description": "生成数量",
+                "type": "int",
+                "hint": "单次请求生成图片数量，MiniMax 官方范围 1-9",
+                "default": 1,
+                "slider": {"min": 1, "max": 9, "step": 1}
+              },
+              "prompt_optimizer": {
+                "description": "提示词自动优化",
+                "type": "bool",
+                "hint": "是否开启 MiniMax prompt_optimizer",
+                "default": false
+              },
+              "aigc_watermark": {
+                "description": "添加水印",
+                "type": "bool",
+                "hint": "是否在生成图片中添加 AIGC 水印",
+                "default": false
+              },
+              "reference_image_mode": {
+                "description": "参考图传递方式",
+                "type": "string",
+                "hint": "auto 对 URL 直接透传、对本地/base64 转 data URI；base64 强制内联；url 要求参考图必须是公开 URL",
+                "default": "auto",
+                "options": ["auto", "base64", "url"]
+              },
+              "subject_reference_type": {
+                "description": "参考主体类型",
+                "type": "string",
+                "hint": "MiniMax subject_reference.type，默认 character 用于人物主体一致性",
+                "default": "character"
+              },
+              "width": {
+                "description": "自定义宽度",
+                "type": "int",
+                "hint": "仅当未传 aspect_ratio 时生效；需与 height 同时设置，范围 512-2048 且为 8 的倍数，0 表示不传",
+                "default": 0
+              },
+              "height": {
+                "description": "自定义高度",
+                "type": "int",
+                "hint": "仅当未传 aspect_ratio 时生效；需与 width 同时设置，范围 512-2048 且为 8 的倍数，0 表示不传",
+                "default": 0
+              },
+              "seed": {
+                "description": "随机种子",
+                "type": "int",
+                "hint": "固定 seed 可生成相近结果，0 表示不传",
+                "default": 0
               },
               "proxy": {
                 "description": "代理地址",

--- a/docs/config.md
+++ b/docs/config.md
@@ -7,7 +7,7 @@
 | 配置项 | 说明 |
 |--------|------|
 | `api_settings.provider_id` | 生图模型提供商，从 AstrBot 提供商列表选择；豆包可不填 |
-| `api_settings.api_type` | API 类型：`google` / `openai` / `openai_images` / `xai` / `zai` / `grok2api` / `doubao` |
+| `api_settings.api_type` | API 类型：`google` / `openai` / `openai_images` / `xai` / `minimax` / `zai` / `grok2api` / `doubao` |
 
 ## api_settings
 
@@ -35,10 +35,10 @@
 支持的模板：
 
 ```text
-google / openai / zai / grok2api / xai / openai_images / doubao
+google / openai / zai / grok2api / xai / minimax / openai_images / doubao
 ```
 
-下方 `doubao_settings`、`openai_images_settings`、`xai_settings` 章节对应这些模板的专用字段。配置时在 `api_settings.provider_overrides` 中选择相应模板。
+下方 `doubao_settings`、`openai_images_settings`、`xai_settings`、`minimax_settings` 章节对应这些模板的专用字段。配置时在 `api_settings.provider_overrides` 中选择相应模板。
 
 ## image_generation_settings
 
@@ -196,3 +196,46 @@ NapCat v4.8.115+ 支持 Stream API。插件默认仍先按 `max_inline_image_siz
 - 改图：`/v1/images/edits`
 
 改图请求会把参考图统一内联为 `data URI`，不使用 `multipart/form-data`。xAI 官方文档当前说明单次编辑最多支持 `5` 张参考图，分辨率支持 `1k/2k`，单图编辑时输出比例默认跟随输入图。
+
+## minimax_settings（MiniMax 图片生成 API 专用配置）
+
+配置路径：`api_settings.provider_overrides` 中选择 `minimax` 模板。
+
+| 配置项 | 默认值 | 说明 |
+|--------|--------|------|
+| `api_keys` | `[]` | MiniMax API Key 列表，支持多 Key 轮换 |
+| `daily_limit_per_key` | `0` | 每个 Key 每日调用上限，`0` 表示不限制 |
+| `model` | `image-01` | MiniMax 图片模型，官方支持 `image-01` / `image-01-live` |
+| `api_base` | `https://api.minimaxi.com` | API 端点地址，插件会统一调用 `/v1/image_generation` |
+| `response_format` | `base64` | 响应格式：`base64` / `url`。官方 URL 有效期为 24 小时 |
+| `n` | `1` | 单次请求生成图片数量，官方范围 `1-9` |
+| `prompt_optimizer` | `false` | 是否开启 MiniMax 提示词自动优化 |
+| `aigc_watermark` | `false` | 是否添加 AIGC 水印 |
+| `reference_image_mode` | `auto` | 参考图传递方式：`auto` / `base64` / `url` |
+| `subject_reference_type` | `character` | `subject_reference.type`，默认用于人物主体一致性 |
+| `width` / `height` | `0` | 未传 `aspect_ratio` 时可同时设置，范围 `512-2048` 且为 `8` 的倍数；`0` 表示不传 |
+| `seed` | `0` | 固定随机种子，`0` 表示不传 |
+| `proxy` | - | 独立代理地址 |
+
+`minimax` 供应商使用 MiniMax 官方单一图像端点：
+
+- 文生图：`POST /v1/image_generation`
+- 图生图：同一端点，通过 `subject_reference[].image_file` 传入参考图
+
+全局 `resolution` 和 `aspect_ratio` 的适配规则：
+
+| 场景 | resolution | aspect_ratio | 实际行为 |
+|------|-----------|-------------|---------|
+| 1K + 支持比例 | 1K | `1:1`/`16:9`/... | 透传 `aspect_ratio`（MiniMax 原生） |
+| 2K/4K + 支持比例 | 2K/4K | `1:1`/`16:9`/... | 计算显式 `width`/`height`（4K 降级为 2048） |
+| 不支持比例 | 任意 | `4:5`/`5:4` | 计算显式 `width`/`height` |
+| 无比例 + 无 w/h 设置 | 2K/4K | — | 使用 `resolution` 对应的正方形尺寸 |
+| `image-01-live` 模型 | 任意 | 任意 | 仅使用 `aspect_ratio`，不发送 `width`/`height` |
+
+支持的长宽比枚举：`1:1` / `16:9` / `4:3` / `3:2` / `2:3` / `3:4` / `9:16` / `21:9`。`image-01-live` 不支持 `21:9`，插件会自动忽略。
+
+官方文档：
+
+- <https://platform.minimaxi.com/docs/guides/image-generation>
+- <https://platform.minimaxi.com/docs/api-reference/image-generation-t2i>
+- <https://platform.minimaxi.com/docs/api-reference/image-generation-i2i>

--- a/docs/新增API供应商.md
+++ b/docs/新增API供应商.md
@@ -12,6 +12,7 @@ tl/api/
 ├── openai_images.py  # OpenAI Images 原生端点
 ├── google.py         # Google/Gemini 官方接口
 ├── xai.py            # xAI Images 官方接口
+├── minimax.py        # MiniMax 图片生成接口
 ├── doubao.py         # 火山引擎 Ark / 豆包 Seedream
 ├── zai.py            # Zai 适配
 └── grok2api.py       # grok2api 适配
@@ -24,6 +25,7 @@ tl/api/
 | `google` / `gemini` / `googlegenai` / `google_genai` | `GoogleProvider` | Google/Gemini 官方接口 |
 | `openai_images` / `openai_images_api` | `OpenAIImagesProvider` | OpenAI `/v1/images/generations` 与 `/v1/images/edits` |
 | `xai` | `XAIProvider` | xAI 官方图像接口 |
+| `minimax` / `minimaxi` / `hailuo` | `MiniMaxProvider` | MiniMax `/v1/image_generation` |
 | `doubao` / `volcengine` / `ark` / `seedream` | `DoubaoProvider` | 火山引擎 Ark / 豆包 |
 | `zai` / `zai_*` | `ZaiProvider` | Zai 兼容接口 |
 | `grok2api` / `grok2_api` / `grok2api_*` | `Grok2ApiProvider` | grok2api 兼容接口 |
@@ -118,6 +120,7 @@ class MyProvider(OpenAICompatProvider):
 
 - `openai_images.py`：multipart/form-data 图像编辑、`b64_json` / `url` 响应解析、自定义尺寸校验。
 - `xai.py`：JSON 图像接口、参考图转 `data URI`。
+- `minimax.py`：MiniMax `/v1/image_generation`、`subject_reference` 图生图、`image_base64` / `image_urls` 响应解析。
 - `doubao.py`：火山 Ark 请求结构、尺寸映射、组图参数。
 - `google.py`：Google/Gemini 官方协议。
 

--- a/main.py
+++ b/main.py
@@ -423,6 +423,8 @@ class GeminiImageGenerationPlugin(Star):
             # 绑定完整 settings 供适配器使用
             if api_type_norm == "doubao":
                 self.cfg.doubao_settings = override_settings
+            elif api_type_norm == "minimax":
+                self.cfg.minimax_settings = override_settings
             elif api_type_norm == "xai":
                 self.cfg.xai_settings = override_settings
             elif api_type_norm == "openai_images":
@@ -443,6 +445,13 @@ class GeminiImageGenerationPlugin(Star):
                     )
                 except Exception as e:
                     logger.debug(f"绑定 doubao_settings 到 API client 失败: {e}")
+            elif api_type_norm == "minimax":
+                try:
+                    self.api_client.minimax_settings = (
+                        getattr(self.cfg, "minimax_settings", None) or {}
+                    )
+                except Exception as e:
+                    logger.debug(f"绑定 minimax_settings 到 API client 失败: {e}")
             elif api_type_norm == "xai":
                 try:
                     self.api_client.xai_settings = (

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,7 +1,7 @@
 name: astrbot_plugin_gemini_image_generation
 desc: Gemini图像生成插件，支持生图和改图，支持自动获取头像作为参考
 display_name: Gemini 图像生成
-version: v1.9.14
+version: v1.10.0
 author: piexian
 repo: https://github.com/piexian/astrbot_plugin_gemini_image_generation
 astrbot_version: ">=4.10.4"

--- a/tl/README.md
+++ b/tl/README.md
@@ -168,6 +168,7 @@ generate_image()
 | `google` / `gemini` / `googlegenai` / `google_genai` | `GoogleProvider` |
 | `openai_images` / `openai_images_api` | `OpenAIImagesProvider` |
 | `xai` | `XAIProvider` |
+| `minimax` / `minimaxi` / `hailuo` | `MiniMaxProvider` |
 | `doubao` / `volcengine` / `ark` / `seedream` | `DoubaoProvider` |
 | `zai` / `zai_*` | `ZaiProvider` |
 | `grok2api` / `grok2_api` / `grok2api_*` | `Grok2ApiProvider` |
@@ -221,6 +222,20 @@ xAI Images 官方 provider。
 | `_prepare_generations_payload()` | 文生图请求体 |
 | `_prepare_edits_payload()` | 改图请求体，参考图转 `data URI` |
 | `_to_image_url()` | 统一把本地/URL/base64 输入转换为 xAI 可用图片引用 |
+
+### `api/minimax.py`
+
+MiniMax 图片生成官方 provider。
+
+| 接口 | 说明 |
+|------|------|
+| `MiniMaxProvider.build_request()` | 构造 `/v1/image_generation` JSON 请求 |
+| `MiniMaxProvider.parse_response()` | 解析 `data.image_urls` / `data.image_base64` 响应 |
+| `_prepare_payload()` | 组装模型、比例、生成数量、水印、提示词优化和参考图；根据 `resolution` 和 `aspect_ratio` 自动选择 `aspect_ratio` 或显式 `width`/`height` |
+| `_map_resolution()` | 全局 `resolution`（1K/2K/4K）映射为目标像素尺寸（4K 降级为 2048） |
+| `_compute_dimensions_from_ratio()` | 从 W:H 比例和目标长边计算 `width`/`height`，自动对齐 8 的倍数并钳制 512-2048 |
+| `_build_subject_reference()` | 构造 MiniMax `subject_reference` |
+| `_to_image_file()` | 参考图按配置透传 URL 或转为 `data URI` |
 
 ### `api/doubao.py`
 

--- a/tl/api/minimax.py
+++ b/tl/api/minimax.py
@@ -1,0 +1,490 @@
+"""MiniMax Image Generation API provider."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import urllib.parse
+from typing import Any
+
+import aiohttp
+
+from astrbot.api import logger
+
+from ..api_types import APIError, ApiRequestConfig
+from ..tl_utils import save_base64_image
+from .base import ProviderRequest
+
+_SUPPORTED_ASPECT_RATIOS: frozenset[str] = frozenset(
+    {"1:1", "16:9", "4:3", "3:2", "2:3", "3:4", "9:16", "21:9"}
+)
+_SUPPORTED_RESPONSE_FORMATS: frozenset[str] = frozenset({"url", "base64"})
+_REFERENCE_IMAGE_MODES: frozenset[str] = frozenset({"auto", "url", "base64"})
+# MiniMax API width/height 上限为 2048，4K 降级到该上限
+_RESOLUTION_MAP: dict[str, int] = {"1K": 1024, "2K": 2048, "4K": 2048}
+_MAX_IMAGES = 9
+
+
+class MiniMaxProvider:
+    """MiniMax `/v1/image_generation` endpoint implementation."""
+
+    name = "minimax"
+
+    async def build_request(
+        self, *, client: Any, config: ApiRequestConfig
+    ) -> ProviderRequest:  # noqa: ANN401
+        settings: dict[str, Any] = getattr(client, "minimax_settings", None) or {}
+        raw_api_base = config.api_base or settings.get("api_base")
+        base = self._normalize_api_base(raw_api_base)
+        url = f"{base}/v1/image_generation"
+        payload = await self._prepare_payload(
+            client=client,
+            config=config,
+            settings=settings,
+        )
+
+        logger.debug(
+            "[minimax] URL=%s refs=%s n=%s response_format=%s",
+            url,
+            len(config.reference_images or []),
+            payload.get("n"),
+            payload.get("response_format"),
+        )
+        return ProviderRequest(
+            url=url,
+            headers={
+                "Authorization": f"Bearer {config.api_key}",
+                "Content-Type": "application/json",
+            },
+            payload=payload,
+        )
+
+    async def parse_response(
+        self,
+        *,
+        client: Any,
+        response_data: dict[str, Any],
+        session: aiohttp.ClientSession,
+        api_base: str | None = None,
+        http_status: int | None = None,
+    ) -> tuple[list[str], list[str], str | None, str | None]:  # noqa: ANN401
+        self._raise_for_base_resp(response_data, http_status)
+
+        image_urls: list[str] = []
+        image_paths: list[str] = []
+        data = response_data.get("data")
+        if not isinstance(data, dict):
+            raise APIError(
+                "MiniMax 响应格式不正确，缺少 data 字段",
+                http_status,
+                "invalid_response",
+                retryable=True,
+            )
+
+        await self._collect_image_data(data, image_urls, image_paths)
+
+        metadata = response_data.get("metadata")
+        if isinstance(metadata, dict):
+            logger.info(
+                "[minimax] success_count=%s failed_count=%s task_id=%s",
+                metadata.get("success_count"),
+                metadata.get("failed_count"),
+                response_data.get("id"),
+            )
+
+        if image_urls or image_paths:
+            return image_urls, image_paths, None, None
+
+        raise APIError(
+            "MiniMax 未返回图片数据",
+            http_status,
+            "no_image",
+            retryable=False,
+        )
+
+    async def _prepare_payload(
+        self,
+        *,
+        client: Any,
+        config: ApiRequestConfig,
+        settings: dict[str, Any],
+    ) -> dict[str, Any]:
+        model = str(settings.get("model") or config.model or "image-01").strip()
+        payload: dict[str, Any] = {
+            "model": model,
+            "prompt": config.prompt,
+            "response_format": self._normalize_response_format(
+                settings.get("response_format")
+            ),
+            "n": self._coerce_image_count(settings.get("n")),
+        }
+
+        aspect_ratio = self._normalize_aspect_ratio(config.aspect_ratio, model)
+        resolution_dim = self._map_resolution(config.resolution)
+        # image-01-live 仅支持 aspect_ratio，不支持显式 width/height
+        supports_explicit_dims = model != "image-01-live"
+
+        needs_explicit = False
+        reason = ""
+        if supports_explicit_dims and config.aspect_ratio and not aspect_ratio:
+            needs_explicit = True
+            reason = f"aspect_ratio {config.aspect_ratio} 不受 MiniMax 支持"
+        elif supports_explicit_dims and aspect_ratio and resolution_dim > 1024:
+            needs_explicit = True
+            reason = f"resolution {config.resolution} 需要显式尺寸"
+
+        if needs_explicit and config.aspect_ratio:
+            w, h = self._compute_dimensions_from_ratio(
+                config.aspect_ratio, resolution_dim
+            )
+            if w and h:
+                payload["width"] = w
+                payload["height"] = h
+                logger.info("[minimax] %s → %dx%d", reason, w, h)
+            elif aspect_ratio:
+                payload["aspect_ratio"] = aspect_ratio
+                logger.warning(
+                    "[minimax] 无法计算尺寸，回退到 aspect_ratio=%s", aspect_ratio
+                )
+            else:
+                logger.warning(
+                    "[minimax] 无法为 %s 计算有效尺寸，已省略尺寸参数",
+                    config.aspect_ratio,
+                )
+        elif aspect_ratio:
+            payload["aspect_ratio"] = aspect_ratio
+        else:
+            w, h = self._get_dimensions(settings)
+            if w and h:
+                payload["width"] = w
+                payload["height"] = h
+            elif supports_explicit_dims and resolution_dim >= 512:
+                payload["width"] = resolution_dim
+                payload["height"] = resolution_dim
+
+        seed = self._coerce_optional_int(settings.get("seed"))
+        if seed is not None and seed != 0:
+            payload["seed"] = seed
+
+        payload["prompt_optimizer"] = bool(settings.get("prompt_optimizer", False))
+        payload["aigc_watermark"] = bool(settings.get("aigc_watermark", False))
+
+        style = settings.get("style")
+        if isinstance(style, dict) and style and model == "image-01-live":
+            payload["style"] = style
+
+        subject_reference = await self._build_subject_reference(
+            client=client,
+            config=config,
+            settings=settings,
+        )
+        if subject_reference:
+            payload["subject_reference"] = subject_reference
+
+        logger.debug(
+            "[minimax] payload: model=%s n=%s aspect_ratio=%s width=%s height=%s "
+            "response_format=%s refs=%s prompt_len=%s",
+            model,
+            payload.get("n"),
+            payload.get("aspect_ratio"),
+            payload.get("width"),
+            payload.get("height"),
+            payload.get("response_format"),
+            len(subject_reference),
+            len(config.prompt or ""),
+        )
+        return payload
+
+    async def _collect_image_data(
+        self,
+        data: dict[str, Any],
+        image_urls: list[str],
+        image_paths: list[str],
+    ) -> None:
+        for image_url in self._iter_string_list(data.get("image_urls")):
+            image_urls.append(image_url)
+            logger.debug("[minimax] 图片 URL: %s...", image_url[:80])
+
+        for b64_data in self._iter_string_list(data.get("image_base64")):
+            image_path = await save_base64_image(
+                self._strip_data_uri(b64_data),
+                self._detect_image_extension(b64_data),
+            )
+            if image_path:
+                image_urls.append(image_path)
+                image_paths.append(image_path)
+                logger.debug("[minimax] base64 图片已保存: %s", image_path)
+
+    async def _build_subject_reference(
+        self,
+        *,
+        client: Any,
+        config: ApiRequestConfig,
+        settings: dict[str, Any],
+    ) -> list[dict[str, str]]:
+        ref_images = config.reference_images or []
+        if not ref_images:
+            return []
+
+        reference_type = str(settings.get("subject_reference_type") or "character")
+        references: list[dict[str, str]] = []
+        for image_input in ref_images:
+            image_file = await self._to_image_file(
+                client, config, image_input, settings
+            )
+            references.append({"type": reference_type, "image_file": image_file})
+        return references
+
+    async def _to_image_file(
+        self,
+        client: Any,
+        config: ApiRequestConfig,
+        image_input: Any,
+        settings: dict[str, Any],
+    ) -> str:  # noqa: ANN401
+        image_str = str(image_input or "").strip()
+        if not image_str:
+            raise APIError(
+                "参考图为空",
+                None,
+                "invalid_image",
+                retryable=False,
+            )
+
+        mode = self._normalize_reference_image_mode(
+            settings.get("reference_image_mode")
+        )
+        is_url = image_str.startswith(("http://", "https://"))
+        if mode == "url" and not is_url:
+            raise APIError(
+                "MiniMax reference_image_mode=url 时参考图必须是 http(s) URL",
+                None,
+                "invalid_image",
+                retryable=False,
+            )
+        if is_url and mode in {"auto", "url"}:
+            return image_str
+        if image_str.startswith("data:image/") and ";base64," in image_str:
+            return image_str
+
+        mime_type, b64_data = await client._normalize_image_input(
+            image_str,
+            image_input_mode=getattr(config, "image_input_mode", "force_base64"),
+        )
+        if not b64_data:
+            raise APIError(
+                "无法将参考图转换为 MiniMax 可用的 base64 图片",
+                None,
+                "invalid_image",
+                retryable=False,
+            )
+
+        mime = mime_type or "image/png"
+        return f"data:{mime};base64,{b64_data}"
+
+    @staticmethod
+    def _normalize_api_base(value: Any) -> str:
+        raw_api_base = str(value or "").strip().rstrip("/")
+        if not raw_api_base:
+            return "https://api.minimaxi.com"
+
+        parsed = urllib.parse.urlsplit(raw_api_base)
+        if parsed.scheme and parsed.netloc:
+            path = parsed.path.rstrip("/")
+            if path.endswith("/v1"):
+                path = path.removesuffix("/v1")
+            return urllib.parse.urlunsplit(
+                (parsed.scheme, parsed.netloc, path, "", "")
+            ).rstrip("/")
+        return raw_api_base.removesuffix("/v1").rstrip("/")
+
+    @staticmethod
+    def _normalize_response_format(value: Any) -> str:
+        response_format = str(value or "base64").strip().lower()
+        if response_format in _SUPPORTED_RESPONSE_FORMATS:
+            return response_format
+        logger.warning(
+            "[minimax] 忽略不支持的 response_format=%s，已回退为 base64",
+            value,
+        )
+        return "base64"
+
+    @staticmethod
+    def _normalize_reference_image_mode(value: Any) -> str:
+        mode = str(value or "auto").strip().lower()
+        if mode in _REFERENCE_IMAGE_MODES:
+            return mode
+        logger.warning(
+            "[minimax] 忽略不支持的 reference_image_mode=%s，已回退为 auto",
+            value,
+        )
+        return "auto"
+
+    @staticmethod
+    def _normalize_aspect_ratio(value: Any, model: str) -> str | None:
+        aspect_ratio = str(value or "").strip()
+        if not aspect_ratio:
+            return None
+        if aspect_ratio not in _SUPPORTED_ASPECT_RATIOS:
+            logger.warning("[minimax] aspect_ratio=%s 不受 MiniMax 原生支持", value)
+            return None
+        if aspect_ratio == "21:9" and model == "image-01-live":
+            logger.warning("[minimax] image-01-live 不支持 21:9，已忽略")
+            return None
+        return aspect_ratio
+
+    @staticmethod
+    def _map_resolution(value: Any) -> int:
+        key = str(value or "").strip().upper()
+        result = _RESOLUTION_MAP.get(key, 0)
+        if result == 0:
+            if key:
+                logger.warning("[minimax] 未知 resolution=%s，回退为 1024", value)
+            return 1024
+        if key == "4K":
+            logger.info("[minimax] resolution=4K 降级为 2048（MiniMax 最大 2048）")
+        return result
+
+    @staticmethod
+    def _compute_dimensions_from_ratio(
+        aspect_ratio: str, target_long_edge: int
+    ) -> tuple[int | None, int | None]:
+        if not aspect_ratio or target_long_edge < 512:
+            return None, None
+        parts = aspect_ratio.strip().split(":")
+        if len(parts) != 2:
+            return None, None
+        try:
+            rw, rh = int(parts[0]), int(parts[1])
+        except (TypeError, ValueError):
+            return None, None
+        if rw <= 0 or rh <= 0:
+            return None, None
+
+        if rw >= rh:
+            width = target_long_edge
+            height = round(target_long_edge * rh / rw)
+        else:
+            height = target_long_edge
+            width = round(target_long_edge * rw / rh)
+
+        width = round(width / 8) * 8
+        height = round(height / 8) * 8
+
+        # 短边钳制到 512，重新计算长边以维持比例
+        if width < height:
+            if width < 512:
+                width = 512
+                height = max(512, round(512 * rh / rw / 8) * 8)
+        else:
+            if height < 512:
+                height = 512
+                width = max(512, round(512 * rw / rh / 8) * 8)
+
+        width = min(2048, width)
+        height = min(2048, height)
+
+        if width < 512 or height < 512:
+            return None, None
+        return width, height
+
+    @staticmethod
+    def _get_dimensions(settings: dict[str, Any]) -> tuple[int | None, int | None]:
+        width = MiniMaxProvider._coerce_dimension(settings.get("width"))
+        height = MiniMaxProvider._coerce_dimension(settings.get("height"))
+        if width and height:
+            return width, height
+        if width or height:
+            logger.warning("[minimax] width/height 必须同时设置，已忽略像素尺寸")
+        return None, None
+
+    @staticmethod
+    def _coerce_dimension(value: Any) -> int | None:
+        dimension = MiniMaxProvider._coerce_optional_int(value)
+        if dimension is None or dimension == 0:
+            return None
+        if dimension < 512 or dimension > 2048 or dimension % 8 != 0:
+            logger.warning(
+                "[minimax] 忽略非法尺寸 %s，width/height 需为 512-2048 且为 8 的倍数",
+                value,
+            )
+            return None
+        return dimension
+
+    @staticmethod
+    def _coerce_optional_int(value: Any) -> int | None:
+        if value in (None, ""):
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _coerce_image_count(value: Any) -> int:
+        try:
+            count = int(value)
+        except (TypeError, ValueError):
+            count = 1
+        if count < 1:
+            return 1
+        if count > _MAX_IMAGES:
+            logger.warning(
+                "[minimax] n=%s 超出上限，已自动降级到 %s", count, _MAX_IMAGES
+            )
+            return _MAX_IMAGES
+        return count
+
+    @staticmethod
+    def _raise_for_base_resp(
+        response_data: dict[str, Any], http_status: int | None
+    ) -> None:
+        base_resp = response_data.get("base_resp")
+        if not isinstance(base_resp, dict):
+            return
+
+        status_code = base_resp.get("status_code")
+        try:
+            status_code_int = int(status_code)
+        except (TypeError, ValueError):
+            status_code_int = 0
+        if status_code_int == 0:
+            return
+
+        status_msg = str(base_resp.get("status_msg") or "未知错误")
+        raise APIError(
+            f"MiniMax 图像生成失败: {status_msg}",
+            http_status,
+            "api_error",
+            str(status_code),
+            retryable=False,
+        )
+
+    @staticmethod
+    def _iter_string_list(value: Any) -> list[str]:
+        if isinstance(value, str):
+            return [value] if value else []
+        if not isinstance(value, list):
+            return []
+        return [item for item in value if isinstance(item, str) and item]
+
+    @staticmethod
+    def _strip_data_uri(value: str) -> str:
+        if ";base64," in value:
+            _, _, value = value.partition(";base64,")
+        return value
+
+    @staticmethod
+    def _detect_image_extension(value: str) -> str:
+        raw_data = MiniMaxProvider._strip_data_uri(value)
+        try:
+            head = base64.b64decode(raw_data[:128], validate=False)
+        except (binascii.Error, ValueError):
+            return "jpeg"
+        if head.startswith(b"\x89PNG\r\n\x1a\n"):
+            return "png"
+        if head.startswith(b"RIFF") and b"WEBP" in head[:16]:
+            return "webp"
+        if head.startswith(b"\xff\xd8\xff"):
+            return "jpeg"
+        return "jpeg"

--- a/tl/api/minimax.py
+++ b/tl/api/minimax.py
@@ -109,7 +109,7 @@ class MiniMaxProvider:
         config: ApiRequestConfig,
         settings: dict[str, Any],
     ) -> dict[str, Any]:
-        model = str(settings.get("model") or config.model or "image-01").strip()
+        model = str(settings.get("model") or config.model or "image-01").strip().lower()
         payload: dict[str, Any] = {
             "model": model,
             "prompt": config.prompt,
@@ -155,7 +155,7 @@ class MiniMaxProvider:
             payload["aspect_ratio"] = aspect_ratio
         else:
             w, h = self._get_dimensions(settings)
-            if w and h:
+            if supports_explicit_dims and w and h:
                 payload["width"] = w
                 payload["height"] = h
             elif supports_explicit_dims and resolution_dim >= 512:

--- a/tl/api/registry.py
+++ b/tl/api/registry.py
@@ -11,6 +11,7 @@ from .base import ApiProvider
 from .doubao import DoubaoProvider
 from .google import GoogleProvider
 from .grok2api import Grok2ApiProvider
+from .minimax import MiniMaxProvider
 from .openai_compat import OpenAICompatProvider
 from .openai_images import OpenAIImagesProvider
 from .xai import XAIProvider
@@ -19,6 +20,7 @@ from .zai import ZaiProvider
 _DOUBAO: Final[DoubaoProvider] = DoubaoProvider()
 _GOOGLE: Final[GoogleProvider] = GoogleProvider()
 _GROK2API: Final[Grok2ApiProvider] = Grok2ApiProvider()
+_MINIMAX: Final[MiniMaxProvider] = MiniMaxProvider()
 _OPENAI: Final[OpenAICompatProvider] = OpenAICompatProvider()
 _OPENAI_IMAGES: Final[OpenAIImagesProvider] = OpenAIImagesProvider()
 _XAI: Final[XAIProvider] = XAIProvider()
@@ -62,6 +64,7 @@ def get_api_provider(api_type: str | None) -> ApiProvider:
     当前映射：
     - `google/gemini/...` -> GoogleProvider
     - `grok2api` -> Grok2ApiProvider
+    - `minimax/minimaxi/hailuo` -> MiniMaxProvider
     - `xai` -> XAIProvider
     - `zai` -> ZaiProvider
     - `doubao/volcengine/ark/seedream` -> DoubaoProvider
@@ -81,6 +84,10 @@ def get_api_provider(api_type: str | None) -> ApiProvider:
     # grok2api 独立供应商
     if normalized in {"grok2api", "grok2_api"} or normalized.startswith("grok2api_"):
         return _GROK2API
+
+    # MiniMax Image Generation API
+    if normalized in {"minimax", "minimaxi", "hailuo"}:
+        return _MINIMAX
 
     # xAI 官方图像 API
     if normalized == "xai":

--- a/tl/plugin_config.py
+++ b/tl/plugin_config.py
@@ -57,6 +57,7 @@ class PluginConfig:
 
     # 豆包（Volcengine Ark）专用配置（api_type == doubao 时使用）
     doubao_settings: dict[str, Any] = field(default_factory=dict)
+    minimax_settings: dict[str, Any] = field(default_factory=dict)
 
     # 供应商配置覆盖（支持所有 API 类型的多 Key 轮换和限流）
     # 结构：{api_type: {api_keys: [...], daily_limit_per_key: int, ...}}
@@ -477,6 +478,7 @@ class ConfigLoader:
                             _validate_openai_images_settings(override_copy)
                         all_overrides[template_key] = override_copy
         config.provider_overrides = all_overrides
+        config.minimax_settings = all_overrides.get("minimax", {})
 
         # 图像生成设置
         image_settings = self.raw_config.get("image_generation_settings") or {}

--- a/tl/tl_api.py
+++ b/tl/tl_api.py
@@ -909,6 +909,9 @@ class GeminiAPIClient:
                         "openai_images",
                         "openai_images_api",
                         "xai",
+                        "minimax",
+                        "minimaxi",
+                        "hailuo",
                     }:
                         provider = get_api_provider(api_type)
                         return await provider.parse_response(


### PR DESCRIPTION
## 改动说明
- 实现 MiniMaxProvider，支持 /v1/image_generation 端点
- 支持文生图和 subject_reference 图生图
- 支持 image_urls / image_base64 双响应格式解析
- 注册 minimax/minimaxi/hailuo 类型别名
- 全局 resolution（1K/2K/4K）和 aspect_ratio 自动适配： 1K + 支持比例使用 MiniMax 原生 aspect_ratio； 2K/4K 或不支持比例（4:5、5:4）时自动计算显式 width/height； image-01-live 仅使用 aspect_ratio，不发送 width/height

## 改动类型

- [ ] Bug 修复
- [x] 新功能
- [ ] 重构 / 代码优化
- [x] 文档更新
- [ ] 其他

## 关联 Issue

<!-- 如有关联 Issue 请填写，例如 Fixes #123 -->

## 测试情况

- [x] 本地测试通过
- [ ] 已测试相关命令（/生图、/改图、/快速 等）
- [ ] 已测试 LLM 工具调用

## 补充说明

<!-- 需要 reviewer 特别关注的点、兼容性说明等 -->

## Summary by Sourcery

将 MiniMax 添加为一等图像生成提供方，并更新配置、文档和路由以支持它。

新功能：
- 引入实现 MiniMax `/v1/image_generation` API 的 `MiniMaxProvider`，包括文本生成图片（text-to-image）以及基于 subject_reference 的图生图（image-to-image）流程。
- 通过 `minimax_settings` 支持 MiniMax 专用配置，包括 API base、模型、响应格式、多密钥轮换、subject reference 选项，以及分辨率/纵横比处理。
- 增加对解析 MiniMax 图像响应的支持，涵盖 URL 和 base64 两种格式，并支持将 base64 图片保存到本地。

增强：
- 扩展提供方注册表、请求路由和插件配置加载，以识别 `minimax`/`minimaxi`/`hailuo` API 类型并绑定其设置。
- 在 README 中记录 MiniMax 的使用方法，并在配置文档中新增专门的 `minimax_settings` 小节，包括分辨率/aspect_ratio 行为及支持的比例。
- 更新内部 TL README，以包含 `MiniMaxProvider` 的 API 表面（API surface）和行为说明。

文档：
- 更新面向用户的文档（`README`、`docs/config.md`、`tl/README.md`），将 MiniMax 列为受支持的图像提供方，并描述其配置方式及功能。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add MiniMax as a first-class image generation provider and update configuration, docs, and routing to support it.

New Features:
- Introduce MiniMaxProvider implementing the MiniMax /v1/image_generation API, including text-to-image and subject_reference-based image-to-image workflows.
- Support MiniMax-specific configuration via minimax_settings, including API base, models, response format, multi-key rotation, subject reference options, and resolution/aspect ratio handling.
- Add support for parsing MiniMax image responses in both URL and base64 formats and saving base64 images locally.

Enhancements:
- Extend provider registry, request routing, and plugin configuration loading to recognize minimax/minimaxi/hailuo API types and bind their settings.
- Document MiniMax usage in README and add a dedicated minimax_settings section in the configuration docs, including resolution/aspect_ratio behavior and supported ratios.
- Update internal TL README to include MiniMaxProvider API surface and behavior.

Documentation:
- Update user-facing documentation (README, docs/config.md, tl/README.md) to list MiniMax as a supported image provider and describe its configuration and capabilities.

</details>