### PR TITLE
feat(stepfun): 新增 阶跃星辰 供应商及相关配置

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,0 +1,78 @@
+name: Code Quality
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  workflow_dispatch:
+
+jobs:
+  lint:
+    name: Lint & Format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff
+
+      - name: Ruff lint
+        run: |
+          ruff check . \
+            --line-length 120 \
+            --target-version py310 \
+            --extend-exclude plans,docs,templates \
+            --select E,F,W,I,B,UP \
+            --ignore E501,B008 \
+            --per-file-ignores "__init__.py:F401"
+
+      - name: Ruff format check
+        run: ruff format --check . --line-length 120 --exclude plans,docs,templates
+
+  syntax:
+    name: Syntax Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Compile all Python files
+        run: python -m compileall -q .
+
+  metadata:
+    name: Metadata Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install PyYAML
+        run: pip install pyyaml
+
+      - name: Validate metadata.yaml
+        run: |
+          python -c "import yaml,sys; yaml.safe_load(open('metadata.yaml',encoding='utf-8')); print('metadata.yaml OK')"
+
+      - name: Validate _conf_schema.json
+        run: |
+          python -c "import json; json.load(open('_conf_schema.json',encoding='utf-8')); print('_conf_schema.json OK')"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 > **升级提示**：v1.9.0 以后的配置文件格式不兼容旧版本。升级后如遇配置模板显示错误，请查看 [配置迁移说明](https://github.com/piexian/astrbot_plugin_gemini_image_generation/blob/master/docs/troubleshooting.md#配置迁移说明)。
 
+## [1.10.2] - 2026-04-29
+
+### Added
+
+#### 阶跃星辰 图片生成 API 支持
+
+- 新增 `stepfun` API 类型，类型别名 `stepfun` / `step` / `step_fun`
+- 新增 `tl/api/stepfun.py` 供应商实现（`StepfunProvider`），适配 StepFun 官方 `/v1/images/generations`（文生图，JSON）与 `/v1/images/edits`（图生图，multipart）端点
+- 默认模型 `step-image-edit-2`，同时允许在配置中填写自定义模型名透传
+- 自动将通用 `size` 入参映射到 step-image-edit-2 支持的 5 档预设：`1024x1024` / `768x1360` / `896x1184` / `1360x768` / `1184x896`
+- `api_base` 同时兼容 `https://api.stepfun.com` 与 `https://api.stepfun.com/step_plan/v1` 两种写法，自动识别 `/v1` 后缀
+- 解析 `data[].url` 与 `data[].b64_json` 两种返回格式
+- 451 响应统一识别为安全审核失败（`APIError(..., category="safety", retryable=False)`），不再触发重试
+- 新增 `provider_overrides[stepfun]` 完整配置模板：多 Key 轮换、每日限额、模型、`api_base`、`response_format`、`steps`、`cfg_scale`、`negative_prompt`、`text_mode`、随机种子、代理
+
+### Fixed
+
+- OpenAI Images `edits` 链路在 `size_mode=custom` 且开启 `preserve_reference_image_size` 时不再回退到固定的 `custom_size`
+- 新增 `derive_custom_size_matching_aspect()` 工具：当处于自定义尺寸模式且检测到参考图时，按参考图比例（限制在 3:1 内、对齐到 16 的倍数）自动推导出 WxH 透传给上游，从而真正保留参考图比例
+
 ## [1.10.1] - 2026-04-26
 
 ### Added
@@ -39,6 +59,9 @@
 - 文档重构：README 精简为概览入口，详细配置参考、使用指南和故障排除拆分至 `docs/` 目录
 - 新增 `docs/config.md`（完整配置参考）、`docs/usage.md`（使用指南）、`docs/troubleshooting.md`（故障排除与配置迁移说明）
 - 扩展 `tl/README.md` 为完整的内部模块 API 文档索引
+
+<details>
+<summary><strong>1.9.x 历史版本</strong>（点击展开）</summary>
 
 ## [1.9.14] - 2026-04-23
 
@@ -260,6 +283,11 @@
 - `tl/api/registry.py` - 注册 DoubaoProvider
 - `_conf_schema.json` - 新增 doubao 到 api_type 选项，新增 doubao_settings 配置节
 
+</details>
+
+<details>
+<summary><strong>1.8.x 历史版本</strong>（点击展开）</summary>
+
 ## [1.8.5] - 2026-01-21
 
 ### Added
@@ -367,6 +395,8 @@
 - 新增配置项 `max_inline_image_size_mb` 控制 base64 编码阈值
 - 本地图片大于阈值时使用文件系统引用
 - 修复发送顺序问题
+
+</details>
 
 ## Earlier Versions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,19 +8,27 @@
 
 #### 阶跃星辰 图片生成 API 支持
 
-- 新增 `stepfun` API 类型，类型别名 `stepfun` / `step` / `step_fun`
+- 新增 `stepfun` API 类型
 - 新增 `tl/api/stepfun.py` 供应商实现（`StepfunProvider`），适配 StepFun 官方 `/v1/images/generations`（文生图，JSON）与 `/v1/images/edits`（图生图，multipart）端点
 - 默认模型 `step-image-edit-2`，同时允许在配置中填写自定义模型名透传
-- 自动将通用 `size` 入参映射到 step-image-edit-2 支持的 5 档预设：`1024x1024` / `768x1360` / `896x1184` / `1360x768` / `1184x896`
+- generations 接口按模型自动选择官方支持的 size 预设：`step-image-edit-2` 五档（`1024x1024` / `768x1360` / `896x1184` / `1360x768` / `1184x896`），`step-1x-medium` 六档（`256/512/768/1024` 正方形 + `1280x800`、`800x1280`）
+- edits 接口遵循官方约束：`step-image-edit-2` 仅传单图且不传 `size`（官方明确"该参数不生效"，输出与输入同尺寸）；`step-1x-edit` 仅在 `512x512 / 768x768 / 1024x1024` 三档内透传 `size`
 - `api_base` 同时兼容 `https://api.stepfun.com` 与 `https://api.stepfun.com/step_plan/v1` 两种写法，自动识别 `/v1` 后缀
 - 解析 `data[].url` 与 `data[].b64_json` 两种返回格式
 - 451 响应统一识别为安全审核失败（`APIError(..., category="safety", retryable=False)`），不再触发重试
 - 新增 `provider_overrides[stepfun]` 完整配置模板：多 Key 轮换、每日限额、模型、`api_base`、`response_format`、`steps`、`cfg_scale`、`negative_prompt`、`text_mode`、随机种子、代理
 
+### Changed
+
+- `api_type` 不再支持别名，仅保留与 `_conf_schema.json` 中 `api_type.options` 一致的 9 个 canonical 值（`google` / `openai` / `openai_images` / `xai` / `minimax` / `stepfun` / `zai` / `grok2api` / `doubao`）。原先的 `step` / `step_fun` / `gemini` / `googlegenai` / `google_genai` / `minimaxi` / `hailuo` / `grok2_api` / `volcengine` / `ark` / `seedream` / `openai_images_api` 等别名以及 `zai_*` / `grok2api_*` 前缀匹配全部移除
+- `tl/api/registry.py` 重构：`get_api_provider` 改为字典查表；移除 `DOUBAO_API_TYPES` / `is_doubao_api_type` 公共导出，调用点改为 `normalize_api_type(x) == "doubao"`
+- `main.py` 中两处手写 canonical 化逻辑改为统一调用 `normalize_api_type`，避免规则漂移
+
 ### Fixed
 
 - OpenAI Images `edits` 链路在 `size_mode=custom` 且开启 `preserve_reference_image_size` 时不再回退到固定的 `custom_size`
-- 新增 `derive_custom_size_matching_aspect()` 工具：当处于自定义尺寸模式且检测到参考图时，按参考图比例（限制在 3:1 内、对齐到 16 的倍数）自动推导出 WxH 透传给上游，从而真正保留参考图比例
+- 新增 `derive_custom_size_matching_aspect()` 工具：当处于自定义尺寸模式且检测到参考图时，按参考图比例（限制在 3:1 内、对齐到 16 的倍数、严格不超过 `CUSTOM_SIZE_MAX_EDGE`）自动推导出 WxH 透传给上游，从而真正保留参考图比例
+- `openai_images._resolve_size_value` 不再吞掉 `custom_size` 解析异常：非法值会抛出 `APIError(category="invalid_size", retryable=False)`，避免静默回退到默认 1024×1024 像素
 
 ## [1.10.1] - 2026-04-26
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-![Version](https://img.shields.io/badge/Version-v1.10.1-blue)
+![Version](https://img.shields.io/badge/Version-v1.10.2-blue)
 ![License](https://img.shields.io/badge/License-AGPL--3.0-orange)
 
 **强大的 AstrBot 图像生成插件，支持生图、改图、头像参考、表情包切分和 LLM 工具调用。**
@@ -16,7 +16,7 @@
 - **多模式图像生成**：纯文本生图、参考图改图、风格转换、手办化、表情包生成。
 - **快速预设**：头像、海报、壁纸、卡片、手机壁纸、手办化、表情包一键生成。
 - **智能参考图**：自动读取消息图片、引用图片、合并转发、群文件，以及用户头像和 @ 对象头像。
-- **多供应商支持**：Google Gemini、OpenAI 兼容、OpenAI Images、xAI Images、MiniMax、Zai、grok2api、豆包。
+- **多供应商支持**：Google Gemini、OpenAI 兼容、OpenAI Images、xAI Images、MiniMax、阶跃星辰、Zai、grok2api、豆包。
 - **LLM 工具集成**：支持自然语言触发生图，前台短等待，超时后自动转后台发送。
 - **表情包切分**：内置 SmartMemeSplitter v4，并提供手动网格、视觉识别、主体吸附等兜底路径。
 - **限流与缓存**：支持群白名单/黑名单、周期限流、KV 持久化、临时文件自动清理。
@@ -43,12 +43,13 @@ https://github.com/piexian/astrbot_plugin_gemini_image_generation
 
 ## 最小配置
 
-至少需要配置一个可用的图像模型供应商：
+至少需要配置一个可用的图像模型供应商。以下两种方式 **二选一**：
 
-| 配置项 | 说明 |
-|--------|------|
-| `api_settings.provider_id` | 生图模型提供商，从 AstrBot 提供商列表选择；豆包可不填 |
-| `api_settings.api_type` | API 类型：`google` / `openai` / `openai_images` / `xai` / `minimax` / `zai` / `grok2api` / `doubao` |
+- **方式 A：复用 AstrBot 提供商**
+  - 在 `api_settings.provider_id` 中选择已在 AstrBot 中配置好的提供商，并把 `api_settings.api_type` 设为对应类型（`google` / `openai` 等）。
+- **方式 B：使用插件内置覆盖配置**
+  - 在 `api_settings.api_type` 中选择目标类型；
+  - 在 `api_settings.provider_overrides` 中添加同名模板（如 `google`），填入 `api_keys`、`model`、`api_base` 等字段；
 
 常用配置入口：
 
@@ -76,31 +77,10 @@ https://github.com/piexian/astrbot_plugin_gemini_image_generation
 
 更多参数、快速模式说明和 LLM 工具行为见 [使用指南](https://github.com/piexian/astrbot_plugin_gemini_image_generation/blob/master/docs/usage.md)。
 
-## OpenAI Images 提示
+## 供应商说明
 
-`openai_images` 供应商支持 OpenAI Images 原生端点。启用 `size_mode=custom` 后：
+各供应商的端点、参数、尺寸适配规则等完整说明见 [完整配置参考](https://github.com/piexian/astrbot_plugin_gemini_image_generation/blob/master/docs/config.md)：
 
-| 调用路径 | `size` 取值 |
-|----------|-------------|
-| 普通生图/改图 | 直接使用配置中的 `custom_size` |
-| 快速模式 | 根据模式预设的 `resolution + aspect_ratio` 自动换算 |
-| LLM 工具调用 | LLM 显式传入 `size` 时以该值为准，否则使用配置中的 `custom_size` |
-
-尺寸格式为 `WxH`，支持 `x` 或 `×`，例如 `1024x1024`、`2048×1152`。详细限制和示例见 [OpenAI Images 配置](https://github.com/piexian/astrbot_plugin_gemini_image_generation/blob/master/docs/config.md#openai_images_settingsopenai-images-api-专用配置)。
-
-## MiniMax 提示
-
-`minimax` 供应商支持 MiniMax 官方 `/v1/image_generation` 端点，模型默认 `image-01`：
-
-| 能力 | 说明 |
-|------|------|
-| 文生图 | 直接发送 prompt、长宽比、生成数量等参数 |
-| 图生图 | 通过 `subject_reference` 传入参考图，默认 `type=character` |
-| 多图生成 | `n` 支持 `1-9` |
-| 响应格式 | 默认 `base64` 并保存为本地图片，避免官方 URL 24 小时过期 |
-| 分辨率适配 | 全局 `resolution`（1K/2K/4K）自动映射；不支持的比例（如 4:5）会计算显式像素尺寸 |
-
-详细配置见 [MiniMax 配置](https://github.com/piexian/astrbot_plugin_gemini_image_generation/blob/master/docs/config.md#minimax_settingsminimax-图片生成-api-专用配置)。
 
 ## 项目结构
 

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -14,7 +14,7 @@
       "api_type": {
         "description": "API 类型（必选）",
         "type": "string",
-        "hint": "必须选择 API 类型（google/openai/openai_images/xai/minimax/zai/grok2api/doubao）。 不同提供商支持的类型不同，请参考提供商说明",
+        "hint": "必须选择 API 类型。 不同提供商支持的类型不同，请参考提供商说明",
         "default": "openai",
         "options": [
           "google",
@@ -22,6 +22,7 @@
           "openai_images",
           "xai",
           "minimax",
+          "stepfun",
           "zai",
           "grok2api",
           "doubao"
@@ -330,6 +331,79 @@
                 "type": "int",
                 "hint": "仅当未传 aspect_ratio 时生效；需与 width 同时设置，范围 512-2048 且为 8 的倍数，0 表示不传",
                 "default": 0
+              },
+              "seed": {
+                "description": "随机种子",
+                "type": "int",
+                "hint": "固定 seed 可生成相近结果，0 表示不传",
+                "default": 0
+              },
+              "proxy": {
+                "description": "代理地址",
+                "type": "string",
+                "hint": "填写即启用代理，留空使用全局代理或环境变量。支持 http://host:port、https://host:port、socks5://host:port 格式。优先级高于全局代理和环境变量",
+                "default": ""
+              }
+            }
+          },
+          "stepfun": {
+            "description": "阶跃星辰图片生成 API 覆盖配置",
+            "hint": "仅完全适配 step-image-edit-2 模型参数",
+            "items": {
+              "api_keys": {
+                "description": "API Key 列表",
+                "type": "list",
+                "hint": "多个 API Key，支持轮换使用",
+                "default": []
+              },
+              "daily_limit_per_key": {
+                "description": "每个 Key 每日限额",
+                "type": "int",
+                "hint": "每个 API Key 每日最大调用次数，0 表示不限制",
+                "default": 0
+              },
+              "model": {
+                "description": "模型名称",
+                "type": "string",
+                "hint": "StepFun 图片模型名称",
+                "default": "step-image-edit-2"
+              },
+              "api_base": {
+                "description": "API 端点地址",
+                "type": "string",
+                "hint": "StepFun API 地址，留空使用默认 https://api.stepfun.com",
+                "default": "https://api.stepfun.com"
+              },
+              "response_format": {
+                "description": "响应格式",
+                "type": "string",
+                "hint": "url 返回临时链接，b64_json 返回 base64 编码并由插件保存到本地",
+                "default": "url",
+                "options": ["url", "b64_json"]
+              },
+              "steps": {
+                "description": "采样步数",
+                "type": "int",
+                "hint": "step-image-edit-2 采样步数，0 表示不传（使用服务端默认 8）",
+                "default": 0
+              },
+              "cfg_scale": {
+                "description": "CFG Scale",
+                "type": "float",
+                "hint": "提示词引导强度，0 表示不传（使用服务端默认 1.0）",
+                "default": 0
+              },
+              "negative_prompt": {
+                "description": "负向提示词",
+                "type": "string",
+                "hint": "不希望出现的元素描述，留空不传",
+                "default": ""
+              },
+              "text_mode": {
+                "description": "文字模式",
+                "type": "bool",
+                "hint": "开启后启用 step-image-edit-2 的 text_mode 参数（适用于含文字生成场景）",
+                "default": false
               },
               "seed": {
                 "description": "随机种子",

--- a/docs/config.md
+++ b/docs/config.md
@@ -266,7 +266,9 @@ NapCat v4.8.115+ 支持 Stream API。插件默认仍先按 `max_inline_image_siz
 - 文生图：`POST /v1/images/generations`（JSON 请求体）
 - 图生图：`POST /v1/images/edits`（`multipart/form-data`）
 
-尺寸适配规则：插件会把通用 `size` 入参映射到 step-image-edit-2 支持的 5 档预设：
+尺寸适配规则（按模型自动选择官方支持的预设集合）：
+
+**`step-image-edit-2` 文生图（generations）** 支持五档尺寸：
 
 | 通用尺寸/比例 | 实际下发 |
 |--------------|---------|
@@ -275,6 +277,13 @@ NapCat v4.8.115+ 支持 Stream API。插件默认仍先按 `max_inline_image_siz
 | 竖图 接近 4:5 | `896x1184` |
 | 横图 16:9 / 4:3 | `1360x768` |
 | 横图 接近 5:4 | `1184x896` |
+
+**`step-1x-medium` 文生图（generations）** 支持六档：`256x256` / `512x512` / `768x768` / `1024x1024` / `1280x800` / `800x1280`，按目标长宽比自动选最近预设。
+
+**图生图（edits）**：
+
+- `step-image-edit-2`：官方仅支持单图输入，传入多图会自动取首张并打 debug 日志；`size` 参数官方明确"该参数不生效"，因此插件不再下发，输出尺寸始终与输入图一致。
+- `step-1x-edit`：`size` 仅在 `512x512` / `768x768` / `1024x1024` 三档内透传。
 
 其他注意事项：
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -7,7 +7,7 @@
 | 配置项 | 说明 |
 |--------|------|
 | `api_settings.provider_id` | 生图模型提供商，从 AstrBot 提供商列表选择；豆包可不填 |
-| `api_settings.api_type` | API 类型：`google` / `openai` / `openai_images` / `xai` / `minimax` / `zai` / `grok2api` / `doubao` |
+| `api_settings.api_type` | API 类型：`google` / `openai` / `openai_images` / `xai` / `minimax` / `stepfun` / `zai` / `grok2api` / `doubao` |
 
 ## api_settings
 
@@ -35,10 +35,10 @@
 支持的模板：
 
 ```text
-google / openai / zai / grok2api / xai / minimax / openai_images / doubao
+google / openai / zai / grok2api / xai / minimax / stepfun / openai_images / doubao
 ```
 
-下方 `doubao_settings`、`openai_images_settings`、`xai_settings`、`minimax_settings` 章节对应这些模板的专用字段。配置时在 `api_settings.provider_overrides` 中选择相应模板。
+下方 `doubao_settings`、`openai_images_settings`、`xai_settings`、`minimax_settings`、`stepfun_settings` 章节对应这些模板的专用字段。配置时在 `api_settings.provider_overrides` 中选择相应模板。
 
 ## image_generation_settings
 
@@ -242,3 +242,46 @@ NapCat v4.8.115+ 支持 Stream API。插件默认仍先按 `max_inline_image_siz
 - <https://platform.minimaxi.com/docs/guides/image-generation>
 - <https://platform.minimaxi.com/docs/api-reference/image-generation-t2i>
 - <https://platform.minimaxi.com/docs/api-reference/image-generation-i2i>
+
+## stepfun_settings（StepFun 图片生成 API 专用配置）
+
+配置路径：`api_settings.provider_overrides` 中选择 `stepfun` 模板。仅完全适配 `step-image-edit-2` 模型参数，其他模型名可填写但参数会按 step-image-edit-2 的格式透传。
+
+| 配置项 | 默认值 | 说明 |
+|--------|--------|------|
+| `api_keys` | `[]` | StepFun API Key 列表，支持多 Key 轮换 |
+| `daily_limit_per_key` | `0` | 每个 Key 每日调用上限，`0` 表示不限制 |
+| `model` | `step-image-edit-2` | 图片模型名称，可改为其它 StepFun 图片模型 |
+| `api_base` | `https://api.stepfun.com` | API 端点；同时兼容 `https://api.stepfun.com/step_plan/v1` 写法，自动识别 `/v1` 后缀 |
+| `response_format` | `url` | `url` 返回临时签名链接（`res.stepfun.com`），`b64_json` 返回 base64 并由插件落盘 |
+| `steps` | `0` | 采样步数，`0` 表示不传（服务端默认 `8`） |
+| `cfg_scale` | `0` | 提示词引导强度，`0` 表示不传（服务端默认 `1.0`） |
+| `negative_prompt` | `""` | 负向提示词，留空不传 |
+| `text_mode` | `false` | 是否启用 step-image-edit-2 的 `text_mode`，适用于含文字生成场景 |
+| `seed` | `0` | 固定随机种子，`0` 表示不传 |
+| `proxy` | - | 独立代理地址，优先级高于全局代理和环境变量 |
+
+`stepfun` 供应商使用阶跃星辰官方图片端点：
+
+- 文生图：`POST /v1/images/generations`（JSON 请求体）
+- 图生图：`POST /v1/images/edits`（`multipart/form-data`）
+
+尺寸适配规则：插件会把通用 `size` 入参映射到 step-image-edit-2 支持的 5 档预设：
+
+| 通用尺寸/比例 | 实际下发 |
+|--------------|---------|
+| 正方形 | `1024x1024` |
+| 竖图 9:16 / 3:4 | `768x1360` |
+| 竖图 接近 4:5 | `896x1184` |
+| 横图 16:9 / 4:3 | `1360x768` |
+| 横图 接近 5:4 | `1184x896` |
+
+其他注意事项：
+
+- 请求被安全审核拦截时，StepFun 会返回 `HTTP 451`，插件统一识别为安全类错误（`category="safety"`，不重试）。
+- `b64_json` 模式下生成的图片会保存为本地文件，避免 URL 过期问题。
+
+官方文档：
+
+- <https://platform.stepfun.com/docs/llm/image-edit>
+- <https://platform.stepfun.com/docs/api-reference/image-edit>

--- a/docs/新增API供应商.md
+++ b/docs/新增API供应商.md
@@ -18,18 +18,20 @@ tl/api/
 └── grok2api.py       # grok2api 适配
 ```
 
-当前注册映射：
+当前注册映射（与 `_conf_schema.json` 中 `api_settings.api_type.options` 严格一致，不再提供别名）：
 
 | `api_type` | Provider | 说明 |
 |------------|----------|------|
-| `google` / `gemini` / `googlegenai` / `google_genai` | `GoogleProvider` | Google/Gemini 官方接口 |
-| `openai_images` / `openai_images_api` | `OpenAIImagesProvider` | OpenAI `/v1/images/generations` 与 `/v1/images/edits` |
+| `google` | `GoogleProvider` | Google/Gemini 官方接口 |
+| `openai` | `OpenAICompatProvider` | OpenAI Chat Completions 兼容格式（默认兜底） |
+| `openai_images` | `OpenAIImagesProvider` | OpenAI `/v1/images/generations` 与 `/v1/images/edits` |
 | `xai` | `XAIProvider` | xAI 官方图像接口 |
-| `minimax` / `minimaxi` / `hailuo` | `MiniMaxProvider` | MiniMax `/v1/image_generation` |
-| `doubao` / `volcengine` / `ark` / `seedream` | `DoubaoProvider` | 火山引擎 Ark / 豆包 |
-| `zai` / `zai_*` | `ZaiProvider` | Zai 兼容接口 |
-| `grok2api` / `grok2_api` / `grok2api_*` | `Grok2ApiProvider` | grok2api 兼容接口 |
-| 其他值 | `OpenAICompatProvider` | 默认 OpenAI Chat Completions 兼容格式 |
+| `minimax` | `MiniMaxProvider` | MiniMax `/v1/image_generation` |
+| `stepfun` | `StepfunProvider` | StepFun `/v1/images/generations` 与 `/v1/images/edits` |
+| `zai` | `ZaiProvider` | Zai 兼容接口 |
+| `grok2api` | `Grok2ApiProvider` | grok2api 兼容接口 |
+| `doubao` | `DoubaoProvider` | 火山引擎 Ark / 豆包 |
+| 未知值 | `OpenAICompatProvider` | 默认兜底 |
 
 ## 核心接口
 
@@ -134,19 +136,18 @@ from .my_provider import MyProvider
 _MY_PROVIDER: Final[MyProvider] = MyProvider()
 ```
 
-在 `get_api_provider()` 中添加映射：
+并在模块顶部的 `_PROVIDERS` 字典中追加映射：
 
 ```python
-def get_api_provider(api_type: str | None) -> ApiProvider:
-    normalized = normalize_api_type(api_type)
-
-    if normalized in {"my_provider", "myprovider"}:
-        return _MY_PROVIDER
-
-    return _OPENAI
+_PROVIDERS: Final[dict[str, ApiProvider]] = {
+    # ... 其他 canonical key
+    "my_provider": _MY_PROVIDER,
+}
 ```
 
-`normalize_api_type()` 已统一做小写、去空格，并把 `-` 转为 `_`。如果需要兼容多种写法，建议显式列出别名。
+`get_api_provider()` 本身是一行查表：`_PROVIDERS.get(normalize_api_type(api_type), _OPENAI)`，未知 `api_type` 默认回退到 OpenAI 兼容实现。
+
+> **只使用 canonical key**：所有 canonical `api_type` 名称必须与 `_conf_schema.json` 中 `api_settings.api_type.options` 严格一致（全小写、下划线分隔）；代码内不再维护其他别名。`normalize_api_type()` 仅做小写、去空格、`-` 转 `_` 三项面向输入的宽容处理。
 
 ## 更新配置和文档
 
@@ -193,7 +194,7 @@ def get_api_provider(api_type: str | None) -> ApiProvider:
 
 | 问题 | 原因 | 处理 |
 |------|------|------|
-| 新 `api_type` 没生效 | 未注册或别名未归一化 | 检查 `registry.py` 和 `_conf_schema.json` |
+| 新 `api_type` 没生效 | 未注册或 canonical 名称与 `_conf_schema.json` 不一致 | 检查 `registry.py` 中 `_PROVIDERS` 字典和 `_conf_schema.json` 中 `api_type.options` |
 | 图片重复发送 | 响应结构和文本回退都提取到同一张图 | 在 provider 内做去重，或避免无条件文本扫描 |
 | URL 过期 | 返回的是临时缓存链接 | 在 provider 内立即下载并返回 `image_paths` |
 | 相对路径无法访问 | 响应只给 `/images/...` | 使用 `api_base` 拼接 origin 后下载 |

--- a/main.py
+++ b/main.py
@@ -57,6 +57,7 @@ from .tl.enhanced_prompts import (
     get_wallpaper_prompt,
 )
 from .tl.llm_tools import GeminiImageGenerationTool
+from .tl.api import normalize_api_type
 from .tl.openai_image_size import derive_custom_size_from_preset_params
 from .tl.tl_api import APIClient, ApiRequestConfig, get_api_client
 from .tl.tl_utils import AvatarManager, cleanup_old_images, format_error_message
@@ -225,7 +226,7 @@ class GeminiImageGenerationPlugin(Star):
         resolution: str | None,
         aspect_ratio: str | None,
     ) -> tuple[str | None, str | None]:
-        api_type_norm = (self.cfg.api_type or "").strip().lower().replace("-", "_")
+        api_type_norm = normalize_api_type(self.cfg.api_type)
         if api_type_norm != "openai_images":
             return resolution, aspect_ratio
 
@@ -404,7 +405,7 @@ class GeminiImageGenerationPlugin(Star):
             logger.error(f"读取 AstrBot 提供商配置失败: {e}")
 
         # provider_overrides 中的配置优先于 AstrBot 提供商配置
-        api_type_norm = (self.cfg.api_type or "").strip().lower().replace("-", "_")
+        api_type_norm = normalize_api_type(self.cfg.api_type)
         overrides = getattr(self.cfg, "provider_overrides", None) or {}
         override_settings = overrides.get(api_type_norm, {})
 

--- a/main.py
+++ b/main.py
@@ -431,6 +431,8 @@ class GeminiImageGenerationPlugin(Star):
                 self.cfg.doubao_settings = override_settings
             elif api_type_norm == "minimax":
                 self.cfg.minimax_settings = override_settings
+            elif api_type_norm == "stepfun":
+                self.cfg.stepfun_settings = override_settings
             elif api_type_norm == "xai":
                 self.cfg.xai_settings = override_settings
             elif api_type_norm == "openai_images":
@@ -458,6 +460,13 @@ class GeminiImageGenerationPlugin(Star):
                     )
                 except Exception as e:
                     logger.debug(f"绑定 minimax_settings 到 API client 失败: {e}")
+            elif api_type_norm == "stepfun":
+                try:
+                    self.api_client.stepfun_settings = (
+                        getattr(self.cfg, "stepfun_settings", None) or {}
+                    )
+                except Exception as e:
+                    logger.debug(f"绑定 stepfun_settings 到 API client 失败: {e}")
             elif api_type_norm == "xai":
                 try:
                     self.api_client.xai_settings = (

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,7 +1,7 @@
 name: astrbot_plugin_gemini_image_generation
 desc: Gemini图像生成插件，支持生图和改图，支持自动获取头像作为参考
 display_name: Gemini 图像生成
-version: v1.10.1
+version: v1.10.2
 author: piexian
 repo: https://github.com/piexian/astrbot_plugin_gemini_image_generation
 astrbot_version: ">=4.10.4"

--- a/tl/README.md
+++ b/tl/README.md
@@ -158,21 +158,21 @@ generate_image()
 | 接口 | 说明 |
 |------|------|
 | `normalize_api_type(api_type)` | 小写、去空格、`-` 转 `_` |
-| `is_doubao_api_type(api_type)` | 判断是否为豆包/火山 Ark 类型 |
-| `get_api_provider(api_type)` | 返回对应 provider 单例 |
+| `get_api_provider(api_type)` | 返回对应 provider 单例（字典查表，未知值回退 `OpenAICompatProvider`） |
 
-当前映射：
+当前映射（与 `_conf_schema.json` 中 `api_settings.api_type.options` 严格一致，不再提供别名）：
 
 | `api_type` | Provider |
 |------------|----------|
-| `google` / `gemini` / `googlegenai` / `google_genai` | `GoogleProvider` |
-| `openai_images` / `openai_images_api` | `OpenAIImagesProvider` |
+| `google` | `GoogleProvider` |
+| `openai` | `OpenAICompatProvider`（默认兑底） |
+| `openai_images` | `OpenAIImagesProvider` |
 | `xai` | `XAIProvider` |
-| `minimax` / `minimaxi` / `hailuo` | `MiniMaxProvider` |
-| `doubao` / `volcengine` / `ark` / `seedream` | `DoubaoProvider` |
-| `zai` / `zai_*` | `ZaiProvider` |
-| `grok2api` / `grok2_api` / `grok2api_*` | `Grok2ApiProvider` |
-| 其他 | `OpenAICompatProvider` |
+| `minimax` | `MiniMaxProvider` |
+| `stepfun` | `StepfunProvider` |
+| `doubao` | `DoubaoProvider` |
+| `zai` | `ZaiProvider` |
+| `grok2api` | `Grok2ApiProvider` |
 
 ### `api/openai_compat.py`
 
@@ -507,7 +507,7 @@ _prepare_foreground()
 | 文件 | 作用 |
 |------|------|
 | `tl/__init__.py` | 包初始化文件，目前不暴露额外接口 |
-| `tl/api/__init__.py` | 重新导出 `DOUBAO_API_TYPES`、`get_api_provider()`、`is_doubao_api_type()`、`normalize_api_type()` |
+| `tl/api/__init__.py` | 重新导出 `get_api_provider()`、`normalize_api_type()` |
 
 ## 修改建议
 

--- a/tl/api/__init__.py
+++ b/tl/api/__init__.py
@@ -4,7 +4,5 @@
 对外统一入口仍然是 `tl/tl_api.py`。
 """
 
-from .registry import DOUBAO_API_TYPES as DOUBAO_API_TYPES
 from .registry import get_api_provider as get_api_provider
-from .registry import is_doubao_api_type as is_doubao_api_type
 from .registry import normalize_api_type as normalize_api_type

--- a/tl/api/openai_images.py
+++ b/tl/api/openai_images.py
@@ -10,6 +10,7 @@
 from __future__ import annotations
 
 import base64
+import re
 from typing import Any
 
 import aiohttp
@@ -18,6 +19,8 @@ from astrbot.api import logger
 
 from ..api_types import APIError, ApiRequestConfig
 from ..openai_image_size import (
+    derive_custom_size_matching_aspect,
+    normalize_custom_size_input,
     normalize_size_mode,
     resolve_openai_custom_size,
 )
@@ -66,12 +69,40 @@ def _resolve_size_value(
     model: str,
     resolution: str | None,
     settings: dict[str, Any],
+    *,
+    ref_image_dims: tuple[int, int] | None = None,
 ) -> str | None:
-    """根据配置和请求参数决定最终传给 OpenAI Images API 的 size。"""
+    """根据配置和请求参数决定最终传给 OpenAI Images API 的 size。
+
+    当 ``ref_image_dims`` 提供且 resolution 为空（preserve_reference_image_size 触发）：
+    - preset 模式：返回 None（不传 size，由 API 默认按原图）
+    - custom 模式：根据参考图实际比例推导一个合法 custom size，避免回落到固定 custom_size
+    """
     try:
         size_mode = normalize_size_mode(settings.get("size_mode"))
     except ValueError as e:
         raise APIError(str(e), None, "invalid_size_mode", retryable=False) from e
+
+    # 保留参考图尺寸场景：resolution 被显式置空
+    if not resolution and ref_image_dims is not None:
+        if size_mode != "custom":
+            return None
+        ref_w, ref_h = ref_image_dims
+        # 以用户配置的 custom_size 像素总量作为目标，未配置则默认 1024*1024
+        target_pixels: int | None = None
+        try:
+            normalized = normalize_custom_size_input(settings.get("custom_size"))
+            match = re.fullmatch(r"(\d+)x(\d+)", normalized)
+            if match:
+                target_pixels = int(match.group(1)) * int(match.group(2))
+        except Exception:
+            target_pixels = None
+        try:
+            return derive_custom_size_matching_aspect(
+                ref_w, ref_h, target_pixels=target_pixels
+            )
+        except ValueError as e:
+            raise APIError(str(e), None, "invalid_size", retryable=False) from e
 
     if size_mode == "custom":
         try:
@@ -95,10 +126,6 @@ class OpenAIImagesProvider:
     """OpenAI /v1/images/generations + /v1/images/edits 端点实现"""
 
     name = "openai_images"
-
-    # ------------------------------------------------------------------
-    # build_request
-    # ------------------------------------------------------------------
 
     async def build_request(
         self, *, client: Any, config: ApiRequestConfig
@@ -156,10 +183,6 @@ class OpenAIImagesProvider:
 
         logger.debug(f"[openai_images] URL: {url} (edits={has_ref_images})")
         return ProviderRequest(url=url, headers=headers, payload=payload)
-
-    # ------------------------------------------------------------------
-    # parse_response
-    # ------------------------------------------------------------------
 
     async def parse_response(
         self,
@@ -268,10 +291,6 @@ class OpenAIImagesProvider:
             retryable=False,
         )
 
-    # ------------------------------------------------------------------
-    # _prepare_generations_payload (文生图 JSON)
-    # ------------------------------------------------------------------
-
     async def _prepare_generations_payload(
         self,
         *,
@@ -343,10 +362,6 @@ class OpenAIImagesProvider:
         )
         return payload
 
-    # ------------------------------------------------------------------
-    # _prepare_edits_payload (图像编辑 multipart/form-data)
-    # ------------------------------------------------------------------
-
     async def _prepare_edits_payload(
         self,
         *,
@@ -406,19 +421,21 @@ class OpenAIImagesProvider:
         form.add_field("model", model)
 
         # ---- size ----
+        ref_dims: tuple[int, int] | None = None
+        if not config.resolution:
+            ref_dims = self._probe_image_dims(image_data)
         size_value = _resolve_size_value(
             model,
             config.resolution,
             settings,
+            ref_image_dims=ref_dims,
         )
         if size_value:
             form.add_field("size", size_value)
 
-        # ---- response_format ----
         response_format = str(settings.get("response_format") or "b64_json").strip()
         form.add_field("response_format", response_format)
 
-        # ---- quality ----
         quality = str(settings.get("quality") or "").strip()
         if quality:
             form.add_field("quality", quality)
@@ -435,10 +452,6 @@ class OpenAIImagesProvider:
             "model": model,
             "prompt": config.prompt,
         }
-
-    # ------------------------------------------------------------------
-    # helpers
-    # ------------------------------------------------------------------
 
     @staticmethod
     def _decode_image_input(image_input: str) -> bytes | None:
@@ -457,4 +470,20 @@ class OpenAIImagesProvider:
             return base64.b64decode(s, validate=True)
         except Exception:
             logger.debug(f"[openai_images] 无法 base64 解码图片输入 (len={len(s)})")
+            return None
+
+    @staticmethod
+    def _probe_image_dims(image_bytes: bytes | None) -> tuple[int, int] | None:
+        """读取图片二进制的真实宽高（用于参考图比例感知）"""
+        if not image_bytes:
+            return None
+        try:
+            from io import BytesIO
+
+            from PIL import Image as _PILImage
+
+            with _PILImage.open(BytesIO(image_bytes)) as img:
+                return int(img.width), int(img.height)
+        except Exception as e:
+            logger.debug(f"[openai_images] 读取参考图尺寸失败: {e}")
             return None

--- a/tl/api/openai_images.py
+++ b/tl/api/openai_images.py
@@ -88,15 +88,23 @@ def _resolve_size_value(
         if size_mode != "custom":
             return None
         ref_w, ref_h = ref_image_dims
-        # 以用户配置的 custom_size 像素总量作为目标，未配置则默认 1024*1024
+        # 以用户配置的 custom_size 像素总量作为目标；未配置留为 None 交由推导函数使用默认值
         target_pixels: int | None = None
-        try:
-            normalized = normalize_custom_size_input(settings.get("custom_size"))
-            match = re.fullmatch(r"(\d+)x(\d+)", normalized)
-            if match:
-                target_pixels = int(match.group(1)) * int(match.group(2))
-        except Exception:
-            target_pixels = None
+        raw_custom = settings.get("custom_size")
+        if raw_custom not in (None, ""):
+            try:
+                normalized = normalize_custom_size_input(raw_custom)
+                match = re.fullmatch(r"(\d+)x(\d+)", normalized)
+                if match:
+                    target_pixels = int(match.group(1)) * int(match.group(2))
+            except (TypeError, ValueError) as e:
+                # custom_size 配置不合法时明确报错，不静默回退到默认像素数
+                raise APIError(
+                    f"invalid custom_size: {raw_custom}",
+                    None,
+                    "invalid_size",
+                    retryable=False,
+                ) from e
         try:
             return derive_custom_size_matching_aspect(
                 ref_w, ref_h, target_pixels=target_pixels

--- a/tl/api/openai_images.py
+++ b/tl/api/openai_images.py
@@ -10,7 +10,6 @@
 from __future__ import annotations
 
 import base64
-import re
 from typing import Any
 
 import aiohttp
@@ -20,9 +19,9 @@ from astrbot.api import logger
 from ..api_types import APIError, ApiRequestConfig
 from ..openai_image_size import (
     derive_custom_size_matching_aspect,
-    normalize_custom_size_input,
     normalize_size_mode,
     resolve_openai_custom_size,
+    validate_custom_size,
 )
 from ..tl_utils import save_base64_image
 from .base import ProviderRequest
@@ -93,14 +92,15 @@ def _resolve_size_value(
         raw_custom = settings.get("custom_size")
         if raw_custom not in (None, ""):
             try:
-                normalized = normalize_custom_size_input(raw_custom)
-                match = re.fullmatch(r"(\d+)x(\d+)", normalized)
-                if match:
-                    target_pixels = int(match.group(1)) * int(match.group(2))
-            except (TypeError, ValueError) as e:
+                validated = validate_custom_size(
+                    raw_custom, field_name="openai_images.custom_size"
+                )
+                w_str, h_str = validated.split("x")
+                target_pixels = int(w_str) * int(h_str)
+            except ValueError as e:
                 # custom_size 配置不合法时明确报错，不静默回退到默认像素数
                 raise APIError(
-                    f"invalid custom_size: {raw_custom}",
+                    str(e),
                     None,
                     "invalid_size",
                     retryable=False,

--- a/tl/api/registry.py
+++ b/tl/api/registry.py
@@ -28,83 +28,28 @@ _STEPFUN: Final[StepfunProvider] = StepfunProvider()
 _XAI: Final[XAIProvider] = XAIProvider()
 _ZAI: Final[ZaiProvider] = ZaiProvider()
 
-# Doubao/Volcengine Ark 相关的 API 类型别名
-DOUBAO_API_TYPES: Final[frozenset[str]] = frozenset(
-    {"doubao", "volcengine", "ark", "seedream"}
-)
+# canonical api_type -> provider 映射表（与 _conf_schema.json 中 api_type.options 严格一致）
+_PROVIDERS: Final[dict[str, ApiProvider]] = {
+    "google": _GOOGLE,
+    "openai": _OPENAI,
+    "openai_images": _OPENAI_IMAGES,
+    "xai": _XAI,
+    "minimax": _MINIMAX,
+    "stepfun": _STEPFUN,
+    "zai": _ZAI,
+    "grok2api": _GROK2API,
+    "doubao": _DOUBAO,
+}
 
 
 def normalize_api_type(api_type: str | None) -> str:
-    """规范化 API 类型字符串。
-
-    将 api_type 转换为小写、去除空格、替换连字符为下划线。
-
-    Args:
-        api_type: 原始 API 类型字符串
-
-    Returns:
-        规范化后的字符串
-    """
+    """规范化 API 类型字符串（小写 + 去空格 + 连字符转下划线）。"""
     return (api_type or "").strip().lower().replace("-", "_")
 
 
-def is_doubao_api_type(api_type: str | None) -> bool:
-    """判断是否为豆包/火山引擎 API 类型。
-
-    Args:
-        api_type: API 类型字符串
-
-    Returns:
-        是否为豆包相关类型
-    """
-    return normalize_api_type(api_type) in DOUBAO_API_TYPES
-
-
 def get_api_provider(api_type: str | None) -> ApiProvider:
-    """根据 api_type 返回对应的供应商实现。
+    """根据 canonical ``api_type`` 返回对应的供应商实现。
 
-    当前映射：
-    - `google/gemini/...` -> GoogleProvider
-    - `grok2api` -> Grok2ApiProvider
-    - `minimax/minimaxi/hailuo` -> MiniMaxProvider
-    - `xai` -> XAIProvider
-    - `zai` -> ZaiProvider
-    - `doubao/volcengine/ark/seedream` -> DoubaoProvider
-    - `openai_images` -> OpenAIImagesProvider (/v1/images/generations + /v1/images/edits)
-    - 其他 -> OpenAICompatProvider（用于各类 OpenAI 兼容服务）
+    未知值回退到 ``OpenAICompatProvider``。
     """
-    normalized = normalize_api_type(api_type)
-
-    # Doubao/Volcengine Ark
-    if normalized in DOUBAO_API_TYPES:
-        return _DOUBAO
-
-    # Zai 独立供应商
-    if normalized == "zai" or normalized.startswith("zai_"):
-        return _ZAI
-
-    # grok2api 独立供应商
-    if normalized in {"grok2api", "grok2_api"} or normalized.startswith("grok2api_"):
-        return _GROK2API
-
-    # MiniMax 图片生成 API
-    if normalized in {"minimax", "minimaxi", "hailuo"}:
-        return _MINIMAX
-
-    # xAI 官方图像 API
-    if normalized == "xai":
-        return _XAI
-
-    # Google/Gemini 官方
-    if normalized in {"google", "gemini", "googlegenai", "google_genai"}:
-        return _GOOGLE
-
-    # OpenAI Images API (/v1/images/generations)
-    if normalized in {"openai_images", "openai_images_api"}:
-        return _OPENAI_IMAGES
-
-    # 阶跃星辰 图片生成
-    if normalized in {"stepfun", "step", "step_fun"}:
-        return _STEPFUN
-
-    return _OPENAI
+    return _PROVIDERS.get(normalize_api_type(api_type), _OPENAI)

--- a/tl/api/registry.py
+++ b/tl/api/registry.py
@@ -14,6 +14,7 @@ from .grok2api import Grok2ApiProvider
 from .minimax import MiniMaxProvider
 from .openai_compat import OpenAICompatProvider
 from .openai_images import OpenAIImagesProvider
+from .stepfun import StepfunProvider
 from .xai import XAIProvider
 from .zai import ZaiProvider
 
@@ -23,6 +24,7 @@ _GROK2API: Final[Grok2ApiProvider] = Grok2ApiProvider()
 _MINIMAX: Final[MiniMaxProvider] = MiniMaxProvider()
 _OPENAI: Final[OpenAICompatProvider] = OpenAICompatProvider()
 _OPENAI_IMAGES: Final[OpenAIImagesProvider] = OpenAIImagesProvider()
+_STEPFUN: Final[StepfunProvider] = StepfunProvider()
 _XAI: Final[XAIProvider] = XAIProvider()
 _ZAI: Final[ZaiProvider] = ZaiProvider()
 
@@ -85,7 +87,7 @@ def get_api_provider(api_type: str | None) -> ApiProvider:
     if normalized in {"grok2api", "grok2_api"} or normalized.startswith("grok2api_"):
         return _GROK2API
 
-    # MiniMax Image Generation API
+    # MiniMax 图片生成 API
     if normalized in {"minimax", "minimaxi", "hailuo"}:
         return _MINIMAX
 
@@ -100,5 +102,9 @@ def get_api_provider(api_type: str | None) -> ApiProvider:
     # OpenAI Images API (/v1/images/generations)
     if normalized in {"openai_images", "openai_images_api"}:
         return _OPENAI_IMAGES
+
+    # 阶跃星辰 图片生成
+    if normalized in {"stepfun", "step", "step_fun"}:
+        return _STEPFUN
 
     return _OPENAI

--- a/tl/api/stepfun.py
+++ b/tl/api/stepfun.py
@@ -1,5 +1,4 @@
-"""阶跃星辰图片生成供应商实现。
-"""
+"""阶跃星辰图片生成供应商实现。"""
 
 from __future__ import annotations
 
@@ -14,15 +13,33 @@ from ..api_types import APIError, ApiRequestConfig
 from ..tl_utils import save_base64_image
 from .base import ProviderRequest
 
-# step-image-edit-2 文生图官方支持的预设尺寸（WxH 格式）
-# 文档以 height x width 呈现，这里转换为常见的 WxH 表达
-_STEP_PRESET_SIZES: list[tuple[int, int]] = [
+# generations 接口不同模型支持的 size 预设（WxH 格式）。
+# step-image-edit-2 的 edits 接口：size 不生效，输出始终与输入同尺寸。
+# step-1x-edit 的 edits 接口：仅支持 512x512 / 768x768 / 1024x1024。
+_STEP_IMAGE_EDIT2_GEN_SIZES: list[tuple[int, int]] = [
     (1024, 1024),  # 1:1
     (768, 1360),  # ~9:16  竖
     (896, 1184),  # ~3:4   竖
     (1360, 768),  # ~16:9  横
     (1184, 896),  # ~4:3   横
 ]
+_STEP_1X_MEDIUM_GEN_SIZES: list[tuple[int, int]] = [
+    (256, 256),
+    (512, 512),
+    (768, 768),
+    (1024, 1024),
+    (1280, 800),  # 16:10
+    (800, 1280),  # 10:16
+]
+_STEP1X_EDIT_SIZES: set[str] = {"512x512", "768x768", "1024x1024"}
+
+
+def _gen_size_presets_for(model: str) -> list[tuple[int, int]]:
+    name = (model or "").strip().lower()
+    if name == "step-1x-medium":
+        return _STEP_1X_MEDIUM_GEN_SIZES
+    # 默认按 step-image-edit-2 的预设集处理
+    return _STEP_IMAGE_EDIT2_GEN_SIZES
 
 
 def _parse_aspect_ratio(value: str | None) -> float | None:
@@ -43,11 +60,45 @@ def _parse_aspect_ratio(value: str | None) -> float | None:
         return None
 
 
-def _resolve_step_size(resolution: str | None, aspect_ratio: str | None) -> str | None:
-    """将 resolution + aspect_ratio 映射到 step-image-edit-2 文生图预设尺寸。
+def _normalize_size_str(value: Any) -> str | None:
+    """将 'WxH' / 'W×H' 归一化为 'WxH' 小写格式。"""
+    if value is None:
+        return None
+    text = str(value).strip().lower().replace("×", "x")
+    if not text or "x" not in text:
+        return None
+    parts = text.split("x", 1)
+    try:
+        w = int(parts[0].strip())
+        h = int(parts[1].strip())
+    except (TypeError, ValueError):
+        return None
+    if w <= 0 or h <= 0:
+        return None
+    return f"{w}x{h}"
 
-    仅当 resolution 为 1K 或留空时启用映射；其他情况返回 None（不传 size，由服务端默认）。
+
+def _resolve_step_size(
+    resolution: str | None,
+    aspect_ratio: str | None,
+    *,
+    explicit_size: Any = None,
+    model: str | None = None,
+) -> str | None:
+    """将 resolution + aspect_ratio 映射到当前模型支持的 generations 预设尺寸。
+
+    优先级：
+    1. ``explicit_size`` 合法且在该模型预设集合内 → 透传；
+    2. resolution 为 1K 或留空 + aspect_ratio → 选最接近预设；
+    3. 其他情况 → None（不传 size，服务端默认 1024x1024）。
     """
+    presets = _gen_size_presets_for(model or "")
+    preset_set = {f"{w}x{h}" for w, h in presets}
+
+    norm_explicit = _normalize_size_str(explicit_size)
+    if norm_explicit and norm_explicit in preset_set:
+        return norm_explicit
+
     res_norm = (resolution or "").strip().upper()
     if res_norm and res_norm not in {"1K", ""}:
         return None
@@ -59,7 +110,7 @@ def _resolve_step_size(resolution: str | None, aspect_ratio: str | None) -> str 
 
     # 选择与目标长宽比最接近的预设
     best = min(
-        _STEP_PRESET_SIZES,
+        presets,
         key=lambda wh: abs((wh[0] / wh[1]) - target_ratio),
     )
     return f"{best[0]}x{best[1]}"
@@ -216,7 +267,13 @@ class StepfunProvider:
         }
 
         # ---- size（仅文生图模式）----
-        size_value = _resolve_step_size(config.resolution, config.aspect_ratio)
+        # 优先使用 LLM/工具显式传入的 resolution（可能是 WxH字符串）作为 explicit size
+        size_value = _resolve_step_size(
+            config.resolution,
+            config.aspect_ratio,
+            explicit_size=config.resolution,
+            model=model,
+        )
         if size_value:
             payload["size"] = size_value
 
@@ -243,6 +300,12 @@ class StepfunProvider:
                 retryable=False,
             )
 
+        # 官方文档：edits 接口当前仅支持传入一个图片
+        if len(ref_images) > 1:
+            logger.debug(
+                f"[stepfun] edits 仅支持单张参考图，已提供 {len(ref_images)} 张，取首张"
+            )
+
         image_data = self._decode_image_input(ref_images[0])
         if image_data is None:
             raise APIError(
@@ -261,6 +324,13 @@ class StepfunProvider:
             filename="image.png",
             content_type="image/png",
         )
+
+        # ---- size：仅对 step-1x-edit 生效（官方 512/768/1024 三档）;
+        # step-image-edit-2 的 edits 接口 size 不生效，输出始终与输入同尺寸。
+        if model.strip().lower() == "step-1x-edit":
+            explicit = _normalize_size_str(config.resolution)
+            if explicit and explicit in _STEP1X_EDIT_SIZES:
+                form.add_field("size", explicit)
 
         # ---- 可选参数（仅非零/非空才传） ----
         response_format = str(settings.get("response_format") or "url").strip() or "url"

--- a/tl/api/stepfun.py
+++ b/tl/api/stepfun.py
@@ -1,0 +1,374 @@
+"""阶跃星辰图片生成供应商实现。
+"""
+
+from __future__ import annotations
+
+import base64
+from typing import Any
+
+import aiohttp
+
+from astrbot.api import logger
+
+from ..api_types import APIError, ApiRequestConfig
+from ..tl_utils import save_base64_image
+from .base import ProviderRequest
+
+# step-image-edit-2 文生图官方支持的预设尺寸（WxH 格式）
+# 文档以 height x width 呈现，这里转换为常见的 WxH 表达
+_STEP_PRESET_SIZES: list[tuple[int, int]] = [
+    (1024, 1024),  # 1:1
+    (768, 1360),  # ~9:16  竖
+    (896, 1184),  # ~3:4   竖
+    (1360, 768),  # ~16:9  横
+    (1184, 896),  # ~4:3   横
+]
+
+
+def _parse_aspect_ratio(value: str | None) -> float | None:
+    """解析 'W:H' 格式的长宽比为 W/H 浮点值"""
+    if not value:
+        return None
+    text = str(value).strip().lower().replace("x", ":").replace("×", ":")
+    if ":" not in text:
+        return None
+    try:
+        w_str, h_str = text.split(":", 1)
+        w = float(w_str.strip())
+        h = float(h_str.strip())
+        if w <= 0 or h <= 0:
+            return None
+        return w / h
+    except (TypeError, ValueError):
+        return None
+
+
+def _resolve_step_size(resolution: str | None, aspect_ratio: str | None) -> str | None:
+    """将 resolution + aspect_ratio 映射到 step-image-edit-2 文生图预设尺寸。
+
+    仅当 resolution 为 1K 或留空时启用映射；其他情况返回 None（不传 size，由服务端默认）。
+    """
+    res_norm = (resolution or "").strip().upper()
+    if res_norm and res_norm not in {"1K", ""}:
+        return None
+
+    target_ratio = _parse_aspect_ratio(aspect_ratio)
+    if target_ratio is None:
+        # 未指定长宽比 → 默认正方形
+        return "1024x1024"
+
+    # 选择与目标长宽比最接近的预设
+    best = min(
+        _STEP_PRESET_SIZES,
+        key=lambda wh: abs((wh[0] / wh[1]) - target_ratio),
+    )
+    return f"{best[0]}x{best[1]}"
+
+
+class StepfunProvider:
+    """StepFun /v1/images/generations + /v1/images/edits 端点实现"""
+
+    name = "stepfun"
+
+    # ------------------------------------------------------------------
+    # build_request
+    # ------------------------------------------------------------------
+
+    async def build_request(
+        self, *, client: Any, config: ApiRequestConfig
+    ) -> ProviderRequest:  # noqa: ANN401
+        settings: dict[str, Any] = getattr(client, "stepfun_settings", None) or {}
+
+        api_base = (
+            (config.api_base or "").strip()
+            or str(settings.get("api_base") or "").strip()
+            or "https://api.stepfun.com"
+        )
+        base = api_base.rstrip("/")
+
+        model = (
+            str(settings.get("model") or "").strip()
+            or (config.model or "").strip()
+            or "step-image-edit-2"
+        )
+
+        has_ref = bool(config.reference_images)
+
+        if has_ref:
+            endpoint = "images/edits"
+        else:
+            endpoint = "images/generations"
+
+        if base.endswith("/v1"):
+            url = f"{base}/{endpoint}"
+        else:
+            url = f"{base}/v1/{endpoint}"
+
+        if has_ref:
+            payload = self._prepare_edits_payload(
+                config=config, settings=settings, model=model
+            )
+            headers = {
+                "Authorization": f"Bearer {config.api_key}",
+                # multipart Content-Type 由 aiohttp 自动设置 boundary
+            }
+        else:
+            payload = self._prepare_generations_payload(
+                config=config, settings=settings, model=model
+            )
+            headers = {
+                "Authorization": f"Bearer {config.api_key}",
+                "Content-Type": "application/json",
+            }
+
+        logger.debug(f"[stepfun] URL: {url} (edits={has_ref}) model={model}")
+        return ProviderRequest(url=url, headers=headers, payload=payload)
+
+    # ------------------------------------------------------------------
+    # parse_response
+    # ------------------------------------------------------------------
+
+    async def parse_response(
+        self,
+        *,
+        client: Any,
+        response_data: dict[str, Any],
+        session: aiohttp.ClientSession,
+        api_base: str | None = None,
+        http_status: int | None = None,
+    ) -> tuple[list[str], list[str], str | None, str | None]:  # noqa: ANN401
+        """解析 StepFun Images API 响应"""
+        image_urls: list[str] = []
+        image_paths: list[str] = []
+
+        # 优先处理顶层错误
+        error_obj = response_data.get("error")
+        if error_obj:
+            error_msg = (
+                error_obj.get("message", "未知错误")
+                if isinstance(error_obj, dict)
+                else str(error_obj)
+            )
+            error_code = error_obj.get("code") if isinstance(error_obj, dict) else None
+            logger.warning(f"[stepfun] API 返回错误: {error_msg}")
+            raise APIError(
+                f"StepFun 错误: {error_msg}",
+                http_status,
+                "api_error",
+                error_code,
+                retryable=False,
+            )
+
+        data_list = response_data.get("data")
+        if not isinstance(data_list, list) or not data_list:
+            logger.warning(f"[stepfun] 响应缺少 data: {response_data}")
+            raise APIError(
+                "StepFun 未返回图片",
+                http_status,
+                "no_image",
+                retryable=False,
+            )
+
+        for image_item in data_list:
+            if not isinstance(image_item, dict):
+                continue
+
+            url_value = image_item.get("url")
+            if isinstance(url_value, str) and url_value:
+                image_urls.append(url_value)
+                logger.debug(f"[stepfun] 图片 URL: {url_value[:80]}...")
+                continue
+
+            b64_value = image_item.get("b64_json")
+            if isinstance(b64_value, str) and b64_value:
+                image_path = await save_base64_image(b64_value, "png")
+                if image_path:
+                    image_urls.append(image_path)
+                    image_paths.append(image_path)
+                    logger.debug(f"[stepfun] base64 图片: {len(b64_value)} 字节")
+
+        if not image_urls and not image_paths:
+            logger.warning(f"[stepfun] data 中未提取到图片: {response_data}")
+            raise APIError(
+                "StepFun 未返回图片",
+                http_status,
+                "no_image",
+                retryable=False,
+            )
+
+        logger.debug(f"[stepfun] 共 {len(image_urls)} 张图片")
+        return image_urls, image_paths, None, None
+
+    # ------------------------------------------------------------------
+    # _prepare_generations_payload (文生图 JSON)
+    # ------------------------------------------------------------------
+
+    def _prepare_generations_payload(
+        self,
+        *,
+        config: ApiRequestConfig,
+        settings: dict[str, Any],
+        model: str,
+    ) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "model": model,
+            "prompt": config.prompt,
+        }
+
+        # ---- size（仅文生图模式）----
+        size_value = _resolve_step_size(config.resolution, config.aspect_ratio)
+        if size_value:
+            payload["size"] = size_value
+
+        self._apply_common_params(payload, config=config, settings=settings)
+        return payload
+
+    # ------------------------------------------------------------------
+    # _prepare_edits_payload (图像编辑 multipart/form-data)
+    # ------------------------------------------------------------------
+
+    def _prepare_edits_payload(
+        self,
+        *,
+        config: ApiRequestConfig,
+        settings: dict[str, Any],
+        model: str,
+    ) -> dict[str, Any]:
+        ref_images = config.reference_images or []
+        if not ref_images:
+            raise APIError(
+                "/v1/images/edits 需要至少一张参考图",
+                None,
+                "missing_image",
+                retryable=False,
+            )
+
+        image_data = self._decode_image_input(ref_images[0])
+        if image_data is None:
+            raise APIError(
+                "无法解码参考图为二进制数据",
+                None,
+                "invalid_image",
+                retryable=False,
+            )
+
+        form = aiohttp.FormData()
+        form.add_field("model", model)
+        form.add_field("prompt", config.prompt)
+        form.add_field(
+            "image",
+            image_data,
+            filename="image.png",
+            content_type="image/png",
+        )
+
+        # ---- 可选参数（仅非零/非空才传） ----
+        response_format = str(settings.get("response_format") or "url").strip() or "url"
+        form.add_field("response_format", response_format)
+
+        try:
+            steps = int(settings.get("steps", 0) or 0)
+        except (TypeError, ValueError):
+            steps = 0
+        if steps > 0:
+            form.add_field("steps", str(steps))
+
+        try:
+            cfg_scale = float(settings.get("cfg_scale", 0) or 0)
+        except (TypeError, ValueError):
+            cfg_scale = 0.0
+        if cfg_scale > 0:
+            form.add_field("cfg_scale", str(cfg_scale))
+
+        seed_setting = settings.get("seed", 0)
+        try:
+            seed_value = int(seed_setting or 0)
+        except (TypeError, ValueError):
+            seed_value = 0
+        if seed_value > 0:
+            form.add_field("seed", str(seed_value))
+        elif config.seed is not None and int(config.seed) > 0:
+            form.add_field("seed", str(int(config.seed)))
+
+        negative_prompt = str(settings.get("negative_prompt") or "").strip()
+        if negative_prompt:
+            form.add_field("negative_prompt", negative_prompt)
+
+        if bool(settings.get("text_mode", False)):
+            form.add_field("text_mode", "true")
+
+        logger.debug(
+            f"[stepfun] edits payload: model={model} ref_images={len(ref_images)} "
+            f"prompt_len={len(config.prompt)} response_format={response_format}"
+        )
+
+        return {
+            "_multipart": True,
+            "_form_data": form,
+            "model": model,
+            "prompt": config.prompt,
+        }
+
+    # ------------------------------------------------------------------
+    # helpers
+    # ------------------------------------------------------------------
+
+    def _apply_common_params(
+        self,
+        payload: dict[str, Any],
+        *,
+        config: ApiRequestConfig,
+        settings: dict[str, Any],
+    ) -> None:
+        """文生图 JSON 路径下的可选参数应用"""
+        response_format = str(settings.get("response_format") or "url").strip() or "url"
+        payload["response_format"] = response_format
+
+        try:
+            steps = int(settings.get("steps", 0) or 0)
+        except (TypeError, ValueError):
+            steps = 0
+        if steps > 0:
+            payload["steps"] = steps
+
+        try:
+            cfg_scale = float(settings.get("cfg_scale", 0) or 0)
+        except (TypeError, ValueError):
+            cfg_scale = 0.0
+        if cfg_scale > 0:
+            payload["cfg_scale"] = cfg_scale
+
+        seed_setting = settings.get("seed", 0)
+        try:
+            seed_value = int(seed_setting or 0)
+        except (TypeError, ValueError):
+            seed_value = 0
+        if seed_value > 0:
+            payload["seed"] = seed_value
+        elif config.seed is not None and int(config.seed) > 0:
+            payload["seed"] = int(config.seed)
+
+        negative_prompt = str(settings.get("negative_prompt") or "").strip()
+        if negative_prompt:
+            payload["negative_prompt"] = negative_prompt
+
+        if bool(settings.get("text_mode", False)):
+            payload["text_mode"] = True
+
+    @staticmethod
+    def _decode_image_input(image_input: str) -> bytes | None:
+        """将 base64 字符串或 data URI 解码为二进制数据"""
+        s = (image_input or "").strip()
+        if not s:
+            return None
+
+        if s.startswith("data:"):
+            parts = s.split(",", 1)
+            if len(parts) == 2:
+                s = parts[1]
+
+        try:
+            return base64.b64decode(s, validate=True)
+        except Exception:
+            logger.debug(f"[stepfun] 无法 base64 解码图片输入 (len={len(s)})")
+            return None

--- a/tl/openai_image_size.py
+++ b/tl/openai_image_size.py
@@ -186,18 +186,24 @@ def derive_custom_size_matching_aspect(
     raw_height = math.sqrt(target_pixels / aspect)
     raw_width = raw_height * aspect
 
-    def _round16(v: float) -> int:
-        return max(16, int(round(v / 16.0)) * 16)
+    def _floor16(v: float) -> int:
+        # 向下对齐到 16 的倍数，避免四舍五入推高超过 max edge
+        return max(16, int(math.floor(v / 16.0)) * 16)
 
-    width = _round16(raw_width)
-    height = _round16(raw_height)
+    width = _floor16(raw_width)
+    height = _floor16(raw_height)
 
-    # 收紧到 max edge 约束
+    # 收紧到 max edge 约束（向下对齐 + 必要时迭代缩小）
     max_edge = max(width, height)
     if max_edge > CUSTOM_SIZE_MAX_EDGE:
         scale = CUSTOM_SIZE_MAX_EDGE / max_edge
-        width = _round16(width * scale)
-        height = _round16(height * scale)
+        width = _floor16(width * scale)
+        height = _floor16(height * scale)
+    while max(width, height) > CUSTOM_SIZE_MAX_EDGE and (width > 16 and height > 16):
+        if width >= height:
+            width -= 16
+        else:
+            height -= 16
 
     # 像素总量收敛：若超上限，缩小；若不足下限，放大
     def _pixels(w: int, h: int) -> int:

--- a/tl/openai_image_size.py
+++ b/tl/openai_image_size.py
@@ -154,6 +154,75 @@ def derive_custom_size_from_preset_params(
     return validate_custom_size(f"{width}x{height}", field_name="derived_custom_size")
 
 
+def derive_custom_size_matching_aspect(
+    ref_width: int,
+    ref_height: int,
+    target_pixels: int | None = None,
+) -> str:
+    """根据参考图实际像素比例推导一个合法的 custom size。
+
+    规则：
+    - 输出宽高均为 16 的倍数；
+    - 长短边比 ≤ 3:1（超出时截断到 3:1）；
+    - 总像素接近 ``target_pixels``（默认 1024*1024），并落在合法区间内；
+    - 任一边不超过 ``CUSTOM_SIZE_MAX_EDGE``。
+    """
+    if ref_width <= 0 or ref_height <= 0:
+        raise ValueError("参考图宽高必须大于 0")
+
+    aspect = ref_width / ref_height
+    # 长短边比限制为 3:1
+    if aspect > 3.0:
+        aspect = 3.0
+    elif aspect < 1.0 / 3.0:
+        aspect = 1.0 / 3.0
+
+    if target_pixels is None or target_pixels <= 0:
+        target_pixels = 1024 * 1024
+    target_pixels = max(
+        CUSTOM_SIZE_MIN_PIXELS, min(CUSTOM_SIZE_MAX_PIXELS, int(target_pixels))
+    )
+
+    raw_height = math.sqrt(target_pixels / aspect)
+    raw_width = raw_height * aspect
+
+    def _round16(v: float) -> int:
+        return max(16, int(round(v / 16.0)) * 16)
+
+    width = _round16(raw_width)
+    height = _round16(raw_height)
+
+    # 收紧到 max edge 约束
+    max_edge = max(width, height)
+    if max_edge > CUSTOM_SIZE_MAX_EDGE:
+        scale = CUSTOM_SIZE_MAX_EDGE / max_edge
+        width = _round16(width * scale)
+        height = _round16(height * scale)
+
+    # 像素总量收敛：若超上限，缩小；若不足下限，放大
+    def _pixels(w: int, h: int) -> int:
+        return w * h
+
+    while _pixels(width, height) > CUSTOM_SIZE_MAX_PIXELS and (
+        width > 16 and height > 16
+    ):
+        if width >= height:
+            width -= 16
+        else:
+            height -= 16
+    while _pixels(width, height) < CUSTOM_SIZE_MIN_PIXELS and (
+        max(width, height) + 16 <= CUSTOM_SIZE_MAX_EDGE
+    ):
+        if width <= height:
+            width += 16
+        else:
+            height += 16
+
+    return validate_custom_size(
+        f"{width}x{height}", field_name="derived_from_reference"
+    )
+
+
 def resolve_openai_custom_size(
     size_candidate: Any,
     resolution_candidate: Any,

--- a/tl/plugin_config.py
+++ b/tl/plugin_config.py
@@ -55,11 +55,12 @@ class PluginConfig:
     api_keys: list[str] = field(default_factory=list)
     proxy: str | None = None
 
-    # 豆包（Volcengine Ark）专用配置（api_type == doubao 时使用）
+    # 供应商特定设置
     doubao_settings: dict[str, Any] = field(default_factory=dict)
     minimax_settings: dict[str, Any] = field(default_factory=dict)
+    stepfun_settings: dict[str, Any] = field(default_factory=dict)
 
-    # 供应商配置覆盖（支持所有 API 类型的多 Key 轮换和限流）
+    # 供应商配置覆盖
     # 结构：{api_type: {api_keys: [...], daily_limit_per_key: int, ...}}
     provider_overrides: dict[str, dict[str, Any]] = field(default_factory=dict)
 
@@ -161,7 +162,6 @@ class ConfigLoader:
         migrations_needed = []
 
         # 检查 limit_settings 是否使用旧版格式
-        # 旧版格式特征：存在 enable_rate_limit 字段，且不存在 rate_limit_rules
         limit_settings = self.raw_config.get("limit_settings")
         if isinstance(limit_settings, dict):
             has_old_fields = "enable_rate_limit" in limit_settings
@@ -170,7 +170,6 @@ class ConfigLoader:
                 migrations_needed.append("limit_settings")
 
         # 检查 quick_mode_settings 是否使用旧版 object 格式
-        # 旧版格式特征：是 dict 类型；新版是 list 类型（template_list）
         quick_mode_settings = self.raw_config.get("quick_mode_settings")
         if isinstance(quick_mode_settings, dict):
             migrations_needed.append("quick_mode_settings")
@@ -278,8 +277,6 @@ class ConfigLoader:
         migrated = False
 
         # 迁移旧版限流配置到 rate_limit_rules
-        # 旧版格式：enable_rate_limit, rate_limit_period, max_requests_per_group
-        # 新版格式：rate_limit_rules (template_list)
         limit_settings = self.raw_config.get("limit_settings")
         if isinstance(limit_settings, dict):
             has_old_fields = "enable_rate_limit" in limit_settings
@@ -306,8 +303,6 @@ class ConfigLoader:
                 migrated = True
 
         # 迁移旧版 quick_mode_settings 从 object 格式到 template_list 格式
-        # 旧版格式：{avatar: {resolution: "1K", aspect_ratio: "1:1"}, ...}
-        # 新版格式：[{__template_key: "avatar", resolution: "1K", aspect_ratio: "1:1"}, ...]
         quick_mode_settings = self.raw_config.get("quick_mode_settings")
         if isinstance(quick_mode_settings, dict):
             new_quick_mode_list = []
@@ -350,8 +345,6 @@ class ConfigLoader:
         config.model = (api_settings.get("model") or "").strip()
         config.proxy = str(api_settings.get("proxy") or "").strip() or None
 
-        # Provider overrides（从 api_settings.provider_overrides 读取）
-        # 新结构：api_settings.provider_overrides 是 template_list，每个条目有 __template_key 标识类型
         provider_overrides = api_settings.get("provider_overrides") or []
         doubao_settings = {}
 
@@ -442,7 +435,6 @@ class ConfigLoader:
         config.doubao_settings = doubao_settings
 
         # 解析所有 provider_overrides 并存入 config.provider_overrides
-        # 结构：{api_type: {api_keys: [...], daily_limit_per_key: int, ...}}
         all_overrides: dict[str, dict[str, Any]] = {}
         if isinstance(provider_overrides, list):
             for override in provider_overrides:
@@ -482,6 +474,7 @@ class ConfigLoader:
                         all_overrides[template_key] = override_copy
         config.provider_overrides = all_overrides
         config.minimax_settings = all_overrides.get("minimax", {})
+        config.stepfun_settings = all_overrides.get("stepfun", {})
 
         # 图像生成设置
         image_settings = self.raw_config.get("image_generation_settings") or {}
@@ -597,10 +590,7 @@ class ConfigLoader:
             or {}
         )
 
-        # 设置默认值以确保图片清晰度
-        # scale: "device" 使用设备像素比，生成更清晰的图片
-        # full_page: True 截取整个页面
-        # type: "png" 无损格式
+        # 设置默认值以确保图片清晰度和完整性
         defaults = {
             "scale": "device",
             "full_page": True,

--- a/tl/tl_api.py
+++ b/tl/tl_api.py
@@ -928,6 +928,7 @@ class GeminiAPIClient:
                         "minimax",
                         "minimaxi",
                         "hailuo",
+                        "stepfun",
                     }:
                         provider = get_api_provider(api_type)
                         return await provider.parse_response(
@@ -956,6 +957,18 @@ class GeminiAPIClient:
                 )
                 logger.warning(f"API 配额/权限问题: {error_msg}")
                 raise APIError(error_msg, response.status, "quota")
+            elif response.status == 451:
+                # 内容安全审核拒绝
+                error_msg = response_data.get("error", {}).get(
+                    "message", "内容审核未通过"
+                )
+                logger.warning(f"内容安全拦截 (451): {error_msg}")
+                raise APIError(
+                    f"内容安全审核未通过: {error_msg}",
+                    response.status,
+                    "safety",
+                    retryable=False,
+                )
             else:
                 # 豆包 API 使用专门的错误处理
                 if is_doubao_api_type(api_type):
@@ -1195,7 +1208,7 @@ class GeminiAPIClient:
                 text_chunks.append(content)
                 extracted_urls.extend(self._find_image_urls_in_text(content))
 
-            # 标准 images 字段（兼容 Gemini/OpenAI 混合格式）
+            # 标准 images 字段
             if message.get("images"):
                 for image_item in message["images"]:
                     if not isinstance(image_item, dict):
@@ -1245,7 +1258,7 @@ class GeminiAPIClient:
                             image_url, image_path = await self._download_image(
                                 full_url, session, use_cache=False
                             )
-                            # 只保留本地路径（_download_image 返回的两个值相同，避免重复）
+                            # 只保留本地路径
                             if image_path:
                                 image_paths.append(image_path)
                             continue
@@ -1258,8 +1271,6 @@ class GeminiAPIClient:
                     if candidate_url.startswith("http://") or candidate_url.startswith(
                         "https://"
                     ):
-                        # grok2api 适配：检测临时缓存 URL 并强制下载（避免被清理）
-                        # 临时缓存 URL 特征：包含 /images/users- 或 /temp/image/
                         is_temp_cache = (
                             "/images/users-" in candidate_url
                             or "/temp/image/" in candidate_url
@@ -1271,7 +1282,6 @@ class GeminiAPIClient:
                             image_url, image_path = await self._download_image(
                                 candidate_url, session, use_cache=False
                             )
-                            # 只保留本地路径（_download_image 返回的两个值相同，避免重复）
                             if image_path:
                                 image_paths.append(image_path)
                             if image_url and not image_path:
@@ -1296,7 +1306,7 @@ class GeminiAPIClient:
                     if image_path:
                         image_paths.append(image_path)
 
-            # content 中查找内联 data URI（文本里）—— 仅在结构化数据中未找到图片时作为回退
+            # content 中查找内联 data URI
             if not (image_urls or image_paths):
                 extracted_urls2: list[str] = []
                 extracted_paths2: list[str] = []
@@ -1317,11 +1327,9 @@ class GeminiAPIClient:
                     image_paths.extend(extracted_paths2)
 
             # 仅在前面没有提取到结构化图片时，才回退扫描文本中的 URL，
-            # 避免同一张图被“带签名 URL + 去签名 URL”重复收集。
             if text_content and not (image_urls or image_paths):
                 http_urls = self._find_image_urls_in_text(text_content)
                 for url in http_urls:
-                    # grok2api 适配：跳过临时缓存 URL（已在上面下载并添加到 image_paths）
                     is_temp_cache = "/images/users-" in url or "/temp/image/" in url
                     if is_temp_cache:
                         logger.debug(
@@ -1389,10 +1397,7 @@ class GeminiAPIClient:
             )
             return image_urls, image_paths, text_content, thought_signature
 
-        # 如果只有文本内容，也返回
         if text_content:
-            # 如果配置了需要文本响应，且确实没有找到图片，这里应该报错触发重试而不是直接返回文本
-            # 除非这是一个纯文本请求（但在生图插件里通常不是）
             detail = (
                 f" | 参考图处理提示: {'; '.join(fail_reasons[:3])}"
                 if fail_reasons
@@ -1613,7 +1618,7 @@ class GeminiAPIClient:
                 cleaned_b64 or base64_string, image_format.lower()
             )
             if image_path:
-                # 直接使用文件路径，不使用 file:// URI（根据 AstrBot 文档要求）
+                # 直接使用文件路径，不使用 file:// URI
                 image_url = image_path
                 image_urls.append(image_url)
                 image_paths.append(image_path)
@@ -1641,7 +1646,7 @@ class GeminiAPIClient:
 
         def _push(candidate: str):
             cleaned = candidate.strip().replace("&amp;", "&").rstrip(").,;")
-            # grok2api 适配：移除 URL 两端的引号（单引号或双引号）
+            # grok2api 适配：移除 URL 两端的引号
             cleaned = cleaned.strip("'\"")
             if cleaned and cleaned not in seen:
                 seen.add(cleaned)
@@ -1656,7 +1661,7 @@ class GeminiAPIClient:
             if not match.startswith(("http://", "https://", "data:")):
                 _push(match)
 
-        # 适配带空格的 http:// 片段（如 "http: //1. 2. 3. 4/image.png"）
+        # 适配带空格的 http:// 片段
         for match in re.findall(spaced_pattern, text, flags=re.IGNORECASE):
             compact = re.sub(r"\s+", "", match)
             if compact.lower().startswith(("http://", "https://")):
@@ -1857,6 +1862,6 @@ def get_api_client(api_keys: list[str]) -> GeminiAPIClient:
 
 
 def clear_api_client():
-    """清除全局 API 客户端实例（用于测试）"""
+    """清除全局 API 客户端实例"""
     global _api_client
     _api_client = None

--- a/tl/tl_api.py
+++ b/tl/tl_api.py
@@ -20,7 +20,7 @@ import aiohttp
 
 from astrbot.api import logger
 
-from .api import get_api_provider, is_doubao_api_type, normalize_api_type
+from .api import get_api_provider, normalize_api_type
 from .api_types import APIError, ApiRequestConfig
 
 try:
@@ -910,7 +910,7 @@ class GeminiAPIClient:
                     return await self._parse_gresponse(response_data, session)
                 else:  # openai 兼容格式
                     # 豆包使用专门的解析方法
-                    if is_doubao_api_type(api_type):
+                    if normalize_api_type(api_type) == "doubao":
                         # 传递重试标记用于降级处理
                         is_retry = payload.get("_is_retry", False)
                         return await self._parse_doubao_response(
@@ -923,11 +923,8 @@ class GeminiAPIClient:
                     # OpenAI Images / xAI Images 使用 provider 自身的解析方法
                     if normalize_api_type(api_type) in {
                         "openai_images",
-                        "openai_images_api",
                         "xai",
                         "minimax",
-                        "minimaxi",
-                        "hailuo",
                         "stepfun",
                     }:
                         provider = get_api_provider(api_type)
@@ -943,7 +940,7 @@ class GeminiAPIClient:
                     )
             elif response.status in [429, 402, 403]:
                 # 豆包 API 使用专门的错误处理
-                if is_doubao_api_type(api_type):
+                if normalize_api_type(api_type) == "doubao":
                     is_retry = payload.get("_is_retry", False)
                     return await self._parse_doubao_response(
                         response_data,
@@ -971,7 +968,7 @@ class GeminiAPIClient:
                 )
             else:
                 # 豆包 API 使用专门的错误处理
-                if is_doubao_api_type(api_type):
+                if normalize_api_type(api_type) == "doubao":
                     is_retry = payload.get("_is_retry", False)
                     return await self._parse_doubao_response(
                         response_data,


### PR DESCRIPTION
## 改动说明

新增 阶跃星辰 供应商及相关配置

## 改动类型

- [x] Bug 修复
- [x] 新功能
- [x] 重构 / 代码优化
- [x] 文档更新
- [ ] 其他

## 关联 Issue

<!-- 如有关联 Issue 请填写，例如 Fixes #123 -->

## 测试情况

- [x] 本地测试通过
- [x] 已测试相关命令（/生图、/改图、/快速 等）
- [x] 已测试 LLM 工具调用

## 补充说明

<!-- 需要 reviewer 特别关注的点、兼容性说明等 -->

## Summary by Sourcery

将 Stepfun 添加为新的图像生成提供方，并在保留参考图像尺寸时改进图像尺寸处理。

新功能：
- 引入 Stepfun 图像生成提供方，支持 text-to-image 和 image-edit 端点，包括配置模板和 provider overrides 集成。
- 通过插件配置和 API 客户端支持 Stepfun 特定的 API 类型解析和设置注入，包括多 API Key 管理以及按 Key 的限额控制。
- 为 text-to-image 请求添加从通用尺寸参数到 Stepfun 支持的预设分辨率的自动映射。

错误修复：
- 确保在 OpenAI Images 的 edits 请求中，当使用自定义尺寸模式并保留参考图像尺寸时，会根据参考图像的纵横比推导出自定义尺寸，而不是退回到固定的 `custom_size`。

增强改进：
- 添加辅助工具，用于在平台约束下推导与参考图像纵横比匹配的自定义图像尺寸，并用于探测参考图像的尺寸。
- 增强错误处理，将 HTTP 451 响应视为不可重试的安全/审计失败。
- 清理并澄清与提供方特定设置和响应解析相关的各种内部注释和默认值。

文档：
- 在配置参考和 README 中文档化 Stepfun 特定的配置、端点以及尺寸映射行为，并更新提供方列表和最小配置指引。
- 更新变更日志和版本徽章/元数据，以反映新增 Stepfun 支持的发布版本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add Stepfun as a new image generation provider and improve image size handling when preserving reference image dimensions.

New Features:
- Introduce Stepfun image generation provider with support for text-to-image and image-edit endpoints, including configuration template and provider overrides integration.
- Support Stepfun-specific API type resolution and settings wiring through the plugin configuration and API client, including multiple API key management and per-key limits.
- Add automatic mapping from generic size parameters to Stepfun’s supported preset resolutions for text-to-image requests.

Bug Fixes:
- Ensure OpenAI Images edits requests with custom size mode and preserved reference image size derive a custom size from the reference image’s aspect ratio instead of falling back to a fixed custom_size.

Enhancements:
- Add helper utilities to derive custom image sizes matching a reference image’s aspect ratio under platform constraints and to probe reference image dimensions.
- Enhance error handling by treating HTTP 451 responses as non-retryable safety/audit failures.
- Clean up and clarify various internal comments and defaults related to provider-specific settings and response parsing.

Documentation:
- Document Stepfun-specific configuration, endpoints, and size mapping behavior in the config reference and README, and update provider lists and minimal configuration guidance.
- Update the changelog and version badges/metadata to reflect the new Stepfun support release.

</details>