### PR TITLE
feat(provider): 新接入 SenseNova（商汤日日新）U1 Fast 文生图

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -23,6 +23,7 @@
           "xai",
           "minimax",
           "stepfun",
+          "sensenova",
           "zai",
           "grok2api",
           "doubao"
@@ -590,6 +591,62 @@
                 "type": "int",
                 "hint": "组图最多包含的图片数量（2-15），超出范围将报错",
                 "default": 4
+              }
+            }
+          },
+          "sensenova": {
+            "description": "SenseNova（商汤日日新）API 覆盖配置",
+            "hint": "配置 SenseNova U1 Fast 文生图 API 的密钥与端点",
+            "items": {
+              "api_keys": {
+                "description": "API Key 列表",
+                "type": "list",
+                "hint": "多个 API Key，支持轮换使用（控制台获取的 Bearer Token）",
+                "default": []
+              },
+              "daily_limit_per_key": {
+                "description": "每个 Key 每日限额",
+                "type": "int",
+                "hint": "每个 API Key 每日最大调用次数，0 表示不限制",
+                "default": 0
+              },
+              "model": {
+                "description": "模型名称",
+                "type": "string",
+                "hint": "SenseNova 图像生成模型，目前固定为 sensenova-u1-fast",
+                "default": "sensenova-u1-fast",
+                "options": ["sensenova-u1-fast"]
+              },
+              "api_base": {
+                "description": "API 端点地址",
+                "type": "string",
+                "hint": "SenseNova API 地址，留空使用默认值 https://token.sensenova.cn",
+                "default": "https://token.sensenova.cn"
+              },
+              "default_size": {
+                "description": "默认图像尺寸",
+                "type": "string",
+                "hint": "插件未指定 aspect_ratio 时使用的兜底尺寸；必须为官方支持的 11 种尺寸之一",
+                "default": "2752x1536",
+                "options": [
+                  "2048x2048",
+                  "2752x1536",
+                  "1536x2752",
+                  "2368x1760",
+                  "1760x2368",
+                  "2496x1664",
+                  "1664x2496",
+                  "1824x2272",
+                  "2272x1824",
+                  "3072x1376",
+                  "1344x3136"
+                ]
+              },
+              "proxy": {
+                "description": "代理地址",
+                "type": "string",
+                "hint": "填写即启用代理，留空使用全局代理或环境变量。支持 http://host:port、https://host:port、socks5://host:port 格式",
+                "default": ""
               }
             }
           }

--- a/docs/新增API供应商.md
+++ b/docs/新增API供应商.md
@@ -28,6 +28,7 @@ tl/api/
 | `xai` | `XAIProvider` | xAI 官方图像接口 |
 | `minimax` | `MiniMaxProvider` | MiniMax `/v1/image_generation` |
 | `stepfun` | `StepfunProvider` | StepFun `/v1/images/generations` 与 `/v1/images/edits` |
+| `sensenova` | `SenseNovaProvider` | SenseNova（商汤日日新）`/v1/images/generations`（仅文生图，11 种固定尺寸） |
 | `zai` | `ZaiProvider` | Zai 兼容接口 |
 | `grok2api` | `Grok2ApiProvider` | grok2api 兼容接口 |
 | `doubao` | `DoubaoProvider` | 火山引擎 Ark / 豆包 |

--- a/main.py
+++ b/main.py
@@ -348,7 +348,7 @@ class GeminiImageGenerationPlugin(Star):
         elif not self.cfg.api_type:
             if not quiet:
                 logger.error(
-                    "✗ 未配置 api_settings.api_type（google/openai/openai_images/xai/zai/grok2api/doubao），无法初始化 API 客户端"
+                    "✗ 未配置 api_settings.api_type（google/openai/openai_images/xai/minimax/stepfun/sensenova/zai/grok2api/doubao），无法初始化 API 客户端"
                 )
             return
 
@@ -433,6 +433,8 @@ class GeminiImageGenerationPlugin(Star):
                 self.cfg.minimax_settings = override_settings
             elif api_type_norm == "stepfun":
                 self.cfg.stepfun_settings = override_settings
+            elif api_type_norm == "sensenova":
+                self.cfg.sensenova_settings = override_settings
             elif api_type_norm == "xai":
                 self.cfg.xai_settings = override_settings
             elif api_type_norm == "openai_images":
@@ -467,6 +469,13 @@ class GeminiImageGenerationPlugin(Star):
                     )
                 except Exception as e:
                     logger.debug(f"绑定 stepfun_settings 到 API client 失败: {e}")
+            elif api_type_norm == "sensenova":
+                try:
+                    self.api_client.sensenova_settings = (
+                        getattr(self.cfg, "sensenova_settings", None) or {}
+                    )
+                except Exception as e:
+                    logger.debug(f"绑定 sensenova_settings 到 API client 失败: {e}")
             elif api_type_norm == "xai":
                 try:
                     self.api_client.xai_settings = (

--- a/tl/api/registry.py
+++ b/tl/api/registry.py
@@ -14,6 +14,7 @@ from .grok2api import Grok2ApiProvider
 from .minimax import MiniMaxProvider
 from .openai_compat import OpenAICompatProvider
 from .openai_images import OpenAIImagesProvider
+from .sensenova import SenseNovaProvider
 from .stepfun import StepfunProvider
 from .xai import XAIProvider
 from .zai import ZaiProvider
@@ -24,6 +25,7 @@ _GROK2API: Final[Grok2ApiProvider] = Grok2ApiProvider()
 _MINIMAX: Final[MiniMaxProvider] = MiniMaxProvider()
 _OPENAI: Final[OpenAICompatProvider] = OpenAICompatProvider()
 _OPENAI_IMAGES: Final[OpenAIImagesProvider] = OpenAIImagesProvider()
+_SENSENOVA: Final[SenseNovaProvider] = SenseNovaProvider()
 _STEPFUN: Final[StepfunProvider] = StepfunProvider()
 _XAI: Final[XAIProvider] = XAIProvider()
 _ZAI: Final[ZaiProvider] = ZaiProvider()
@@ -36,6 +38,7 @@ _PROVIDERS: Final[dict[str, ApiProvider]] = {
     "xai": _XAI,
     "minimax": _MINIMAX,
     "stepfun": _STEPFUN,
+    "sensenova": _SENSENOVA,
     "zai": _ZAI,
     "grok2api": _GROK2API,
     "doubao": _DOUBAO,

--- a/tl/api/sensenova.py
+++ b/tl/api/sensenova.py
@@ -1,0 +1,271 @@
+"""SenseNova（商汤日日新）图像生成供应商实现。
+
+支持模型：
+- ``sensenova-u1-fast``：基于 SenseNova U1 的加速版本，专供信息图（Infographics）生成场景。
+
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import aiohttp
+from astrbot.api import logger
+
+from ..api_types import APIError, ApiRequestConfig
+from ..tl_utils import save_base64_image
+from .base import ProviderRequest
+
+# 官方默认 API Base
+_DEFAULT_API_BASE: str = "https://token.sensenova.cn"
+
+# 默认模型
+_DEFAULT_MODEL: str = "sensenova-u1-fast"
+
+# 11 种官方支持的尺寸（width x height）
+_ALLOWED_SIZES: tuple[str, ...] = (
+    "1664x2496",  # 2:3
+    "2496x1664",  # 3:2
+    "1760x2368",  # 3:4
+    "2368x1760",  # 4:3
+    "1824x2272",  # 4:5
+    "2272x1824",  # 5:4
+    "2048x2048",  # 1:1
+    "2752x1536",  # 16:9
+    "1536x2752",  # 9:16
+    "3072x1376",  # 21:9
+    "1344x3136",  # 9:21
+)
+
+# aspect_ratio → size 映射（覆盖插件配置中所有 aspect_ratio 选项）
+_ASPECT_TO_SIZE: dict[str, str] = {
+    "1:1": "2048x2048",
+    "2:3": "1664x2496",
+    "3:2": "2496x1664",
+    "3:4": "1760x2368",
+    "4:3": "2368x1760",
+    "4:5": "1824x2272",
+    "5:4": "2272x1824",
+    "16:9": "2752x1536",
+    "9:16": "1536x2752",
+    "21:9": "3072x1376",
+    "9:21": "1344x3136",
+}
+
+_DEFAULT_SIZE: str = "2752x1536"
+
+# prompt 最大 token 数
+_PROMPT_CHAR_SOFT_LIMIT: int = 4096
+
+
+def _normalize_aspect_ratio(value: Any) -> str | None:
+    """将 'WxH' / 'W×H' / 'W:H' 归一化为 'W:H'。"""
+    if value is None:
+        return None
+    text = str(value).strip().lower().replace("×", ":").replace("x", ":")
+    if ":" not in text:
+        return None
+    parts = text.split(":", 1)
+    try:
+        w = int(parts[0].strip())
+        h = int(parts[1].strip())
+    except (TypeError, ValueError):
+        return None
+    if w <= 0 or h <= 0:
+        return None
+    return f"{w}:{h}"
+
+
+def _resolve_size(
+    *,
+    explicit_size: Any,
+    aspect_ratio: str | None,
+    default_size: str | None,
+) -> str:
+    """决定最终 size。
+
+    优先级：
+    1. ``explicit_size`` 合法且在白名单 → 直接使用
+    2. ``aspect_ratio`` 能映射到白名单 → 使用映射结果
+    3. ``default_size`` 合法且在白名单 → 使用
+    4. 兜底使用 ``_DEFAULT_SIZE``
+    """
+    if explicit_size:
+        text = str(explicit_size).strip().lower().replace("×", "x")
+        if text in _ALLOWED_SIZES:
+            return text
+        logger.warning(
+            "[sensenova] 显式 size=%s 不在官方支持列表，将根据 aspect_ratio 重选",
+            explicit_size,
+        )
+
+    ratio = _normalize_aspect_ratio(aspect_ratio)
+    if ratio and ratio in _ASPECT_TO_SIZE:
+        return _ASPECT_TO_SIZE[ratio]
+    if ratio:
+        logger.info(
+            "[sensenova] aspect_ratio=%s 不在官方支持列表，将回退到默认尺寸", ratio
+        )
+
+    if default_size:
+        text = str(default_size).strip().lower().replace("×", "x")
+        if text in _ALLOWED_SIZES:
+            return text
+        logger.warning(
+            "[sensenova] sensenova_settings.default_size=%s 非法，已忽略", default_size
+        )
+
+    return _DEFAULT_SIZE
+
+
+def _coerce_n(value: Any, default: int = 1) -> int:
+    try:
+        n = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(1, min(n, 4))
+
+
+def _ensure_v1_endpoint(api_base: str) -> str:
+    base = (api_base or "").strip().rstrip("/")
+    if not base:
+        base = _DEFAULT_API_BASE
+    if base.endswith("/v1"):
+        return f"{base}/images/generations"
+    return f"{base}/v1/images/generations"
+
+
+class SenseNovaProvider:
+    """SenseNova ``/v1/images/generations`` 端点实现。"""
+
+    name = "sensenova"
+
+    async def build_request(
+        self, *, client: Any, config: ApiRequestConfig
+    ) -> ProviderRequest:  # noqa: ANN401
+        settings: dict[str, Any] = getattr(client, "sensenova_settings", None) or {}
+
+        api_base = settings.get("api_base") or config.api_base or _DEFAULT_API_BASE
+        url = _ensure_v1_endpoint(str(api_base))
+
+        if not config.api_key:
+            raise APIError(
+                "SenseNova 缺少 API Key，请在 provider_overrides.sensenova.api_keys 中配置",
+                None,
+                "missing_api_key",
+                retryable=False,
+            )
+
+        # 参考图不支持，给出明确日志而非静默
+        if config.reference_images:
+            logger.info(
+                "[sensenova] U1 Fast 不支持图像输入，已忽略 %d 张参考图",
+                len(config.reference_images),
+            )
+
+        prompt = (config.prompt or "").strip()
+        if not prompt:
+            raise APIError(
+                "SenseNova 需要非空 prompt", None, "empty_prompt", retryable=False
+            )
+        if len(prompt) > _PROMPT_CHAR_SOFT_LIMIT:
+            logger.warning(
+                "[sensenova] prompt 长度 %d 超过软上限 %d，可能被服务端截断",
+                len(prompt),
+                _PROMPT_CHAR_SOFT_LIMIT,
+            )
+
+        model = (
+            config.model or settings.get("model") or _DEFAULT_MODEL
+        ).strip() or _DEFAULT_MODEL
+
+        size = _resolve_size(
+            explicit_size=settings.get("size"),
+            aspect_ratio=config.aspect_ratio,
+            default_size=settings.get("default_size"),
+        )
+
+        n = _coerce_n(settings.get("n", 1))
+
+        payload: dict[str, Any] = {
+            "model": model,
+            "prompt": prompt,
+            "size": size,
+            "n": n,
+        }
+
+        headers = {
+            "Authorization": f"Bearer {config.api_key}",
+            "Content-Type": "application/json",
+        }
+
+        logger.debug(
+            "[sensenova] build_request: url=%s model=%s size=%s n=%s prompt_len=%s",
+            url,
+            model,
+            size,
+            n,
+            len(prompt),
+        )
+        return ProviderRequest(url=url, headers=headers, payload=payload)
+
+    async def parse_response(
+        self,
+        *,
+        client: Any,
+        response_data: dict[str, Any],
+        session: aiohttp.ClientSession,
+        api_base: str | None = None,
+        http_status: int | None = None,
+    ) -> tuple[list[str], list[str], str | None, str | None]:  # noqa: ANN401
+        image_urls: list[str] = []
+        image_paths: list[str] = []
+
+        data = response_data.get("data")
+        if not isinstance(data, list) or not data:
+            error_obj = response_data.get("error")
+            if error_obj:
+                error_msg = (
+                    error_obj.get("message", "未知错误")
+                    if isinstance(error_obj, dict)
+                    else str(error_obj)
+                )
+                raise APIError(
+                    f"SenseNova 图像生成失败: {error_msg}",
+                    http_status,
+                    "api_error",
+                    error_obj.get("code") if isinstance(error_obj, dict) else None,
+                    retryable=False,
+                )
+            raise APIError(
+                "SenseNova 响应缺少 data 字段",
+                http_status,
+                "invalid_response",
+                retryable=True,
+            )
+
+        for item in data:
+            if not isinstance(item, dict):
+                continue
+            url = item.get("url")
+            if isinstance(url, str) and url:
+                image_urls.append(url)
+                logger.debug("[sensenova] 图片 URL: %s...", url[:80])
+                continue
+            b64 = item.get("b64_json")
+            if isinstance(b64, str) and b64:
+                saved = await save_base64_image(b64, "png")
+                if saved:
+                    image_urls.append(saved)
+                    image_paths.append(saved)
+
+        if not image_urls:
+            raise APIError(
+                "SenseNova 未返回图片数据",
+                http_status,
+                "no_image",
+                retryable=False,
+            )
+
+        logger.debug("[sensenova] 共 %d 张图片", len(image_urls))
+        return image_urls, image_paths, None, None

--- a/tl/api/sensenova.py
+++ b/tl/api/sensenova.py
@@ -145,7 +145,7 @@ class SenseNovaProvider:
     ) -> ProviderRequest:  # noqa: ANN401
         settings: dict[str, Any] = getattr(client, "sensenova_settings", None) or {}
 
-        api_base = settings.get("api_base") or config.api_base or _DEFAULT_API_BASE
+        api_base = config.api_base or settings.get("api_base") or _DEFAULT_API_BASE
         url = _ensure_v1_endpoint(str(api_base))
 
         if not config.api_key:

--- a/tl/api/sensenova.py
+++ b/tl/api/sensenova.py
@@ -1,0 +1,272 @@
+"""SenseNova（商汤日日新）图像生成供应商实现。
+
+支持模型：
+- ``sensenova-u1-fast``：基于 SenseNova U1 的加速版本，专供信息图（Infographics）生成场景。
+
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import aiohttp
+
+from astrbot.api import logger
+
+from ..api_types import APIError, ApiRequestConfig
+from ..tl_utils import save_base64_image
+from .base import ProviderRequest
+
+# 官方默认 API Base
+_DEFAULT_API_BASE: str = "https://token.sensenova.cn"
+
+# 默认模型
+_DEFAULT_MODEL: str = "sensenova-u1-fast"
+
+# 11 种官方支持的尺寸（width x height）
+_ALLOWED_SIZES: tuple[str, ...] = (
+    "1664x2496",  # 2:3
+    "2496x1664",  # 3:2
+    "1760x2368",  # 3:4
+    "2368x1760",  # 4:3
+    "1824x2272",  # 4:5
+    "2272x1824",  # 5:4
+    "2048x2048",  # 1:1
+    "2752x1536",  # 16:9
+    "1536x2752",  # 9:16
+    "3072x1376",  # 21:9
+    "1344x3136",  # 9:21
+)
+
+# aspect_ratio → size 映射（覆盖插件配置中所有 aspect_ratio 选项）
+_ASPECT_TO_SIZE: dict[str, str] = {
+    "1:1": "2048x2048",
+    "2:3": "1664x2496",
+    "3:2": "2496x1664",
+    "3:4": "1760x2368",
+    "4:3": "2368x1760",
+    "4:5": "1824x2272",
+    "5:4": "2272x1824",
+    "16:9": "2752x1536",
+    "9:16": "1536x2752",
+    "21:9": "3072x1376",
+    "9:21": "1344x3136",
+}
+
+_DEFAULT_SIZE: str = "2752x1536"
+
+# prompt 最大 token 数
+_PROMPT_CHAR_SOFT_LIMIT: int = 4096
+
+
+def _normalize_aspect_ratio(value: Any) -> str | None:
+    """将 'WxH' / 'W×H' / 'W:H' 归一化为 'W:H'。"""
+    if value is None:
+        return None
+    text = str(value).strip().lower().replace("×", ":").replace("x", ":")
+    if ":" not in text:
+        return None
+    parts = text.split(":", 1)
+    try:
+        w = int(parts[0].strip())
+        h = int(parts[1].strip())
+    except (TypeError, ValueError):
+        return None
+    if w <= 0 or h <= 0:
+        return None
+    return f"{w}:{h}"
+
+
+def _resolve_size(
+    *,
+    explicit_size: Any,
+    aspect_ratio: str | None,
+    default_size: str | None,
+) -> str:
+    """决定最终 size。
+
+    优先级：
+    1. ``explicit_size`` 合法且在白名单 → 直接使用
+    2. ``aspect_ratio`` 能映射到白名单 → 使用映射结果
+    3. ``default_size`` 合法且在白名单 → 使用
+    4. 兜底使用 ``_DEFAULT_SIZE``
+    """
+    if explicit_size:
+        text = str(explicit_size).strip().lower().replace("×", "x")
+        if text in _ALLOWED_SIZES:
+            return text
+        logger.warning(
+            "[sensenova] 显式 size=%s 不在官方支持列表，将根据 aspect_ratio 重选",
+            explicit_size,
+        )
+
+    ratio = _normalize_aspect_ratio(aspect_ratio)
+    if ratio and ratio in _ASPECT_TO_SIZE:
+        return _ASPECT_TO_SIZE[ratio]
+    if ratio:
+        logger.info(
+            "[sensenova] aspect_ratio=%s 不在官方支持列表，将回退到默认尺寸", ratio
+        )
+
+    if default_size:
+        text = str(default_size).strip().lower().replace("×", "x")
+        if text in _ALLOWED_SIZES:
+            return text
+        logger.warning(
+            "[sensenova] sensenova_settings.default_size=%s 非法，已忽略", default_size
+        )
+
+    return _DEFAULT_SIZE
+
+
+def _coerce_n(value: Any, default: int = 1) -> int:
+    try:
+        n = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(1, min(n, 4))
+
+
+def _ensure_v1_endpoint(api_base: str) -> str:
+    base = (api_base or "").strip().rstrip("/")
+    if not base:
+        base = _DEFAULT_API_BASE
+    if base.endswith("/v1"):
+        return f"{base}/images/generations"
+    return f"{base}/v1/images/generations"
+
+
+class SenseNovaProvider:
+    """SenseNova ``/v1/images/generations`` 端点实现。"""
+
+    name = "sensenova"
+
+    async def build_request(
+        self, *, client: Any, config: ApiRequestConfig
+    ) -> ProviderRequest:  # noqa: ANN401
+        settings: dict[str, Any] = getattr(client, "sensenova_settings", None) or {}
+
+        api_base = settings.get("api_base") or config.api_base or _DEFAULT_API_BASE
+        url = _ensure_v1_endpoint(str(api_base))
+
+        if not config.api_key:
+            raise APIError(
+                "SenseNova 缺少 API Key，请在 provider_overrides.sensenova.api_keys 中配置",
+                None,
+                "missing_api_key",
+                retryable=False,
+            )
+
+        # 参考图不支持，给出明确日志而非静默
+        if config.reference_images:
+            logger.info(
+                "[sensenova] U1 Fast 不支持图像输入，已忽略 %d 张参考图",
+                len(config.reference_images),
+            )
+
+        prompt = (config.prompt or "").strip()
+        if not prompt:
+            raise APIError(
+                "SenseNova 需要非空 prompt", None, "empty_prompt", retryable=False
+            )
+        if len(prompt) > _PROMPT_CHAR_SOFT_LIMIT:
+            logger.warning(
+                "[sensenova] prompt 长度 %d 超过软上限 %d，可能被服务端截断",
+                len(prompt),
+                _PROMPT_CHAR_SOFT_LIMIT,
+            )
+
+        model = (
+            config.model or settings.get("model") or _DEFAULT_MODEL
+        ).strip() or _DEFAULT_MODEL
+
+        size = _resolve_size(
+            explicit_size=settings.get("size"),
+            aspect_ratio=config.aspect_ratio,
+            default_size=settings.get("default_size"),
+        )
+
+        n = _coerce_n(settings.get("n", 1))
+
+        payload: dict[str, Any] = {
+            "model": model,
+            "prompt": prompt,
+            "size": size,
+            "n": n,
+        }
+
+        headers = {
+            "Authorization": f"Bearer {config.api_key}",
+            "Content-Type": "application/json",
+        }
+
+        logger.debug(
+            "[sensenova] build_request: url=%s model=%s size=%s n=%s prompt_len=%s",
+            url,
+            model,
+            size,
+            n,
+            len(prompt),
+        )
+        return ProviderRequest(url=url, headers=headers, payload=payload)
+
+    async def parse_response(
+        self,
+        *,
+        client: Any,
+        response_data: dict[str, Any],
+        session: aiohttp.ClientSession,
+        api_base: str | None = None,
+        http_status: int | None = None,
+    ) -> tuple[list[str], list[str], str | None, str | None]:  # noqa: ANN401
+        image_urls: list[str] = []
+        image_paths: list[str] = []
+
+        data = response_data.get("data")
+        if not isinstance(data, list) or not data:
+            error_obj = response_data.get("error")
+            if error_obj:
+                error_msg = (
+                    error_obj.get("message", "未知错误")
+                    if isinstance(error_obj, dict)
+                    else str(error_obj)
+                )
+                raise APIError(
+                    f"SenseNova 图像生成失败: {error_msg}",
+                    http_status,
+                    "api_error",
+                    error_obj.get("code") if isinstance(error_obj, dict) else None,
+                    retryable=False,
+                )
+            raise APIError(
+                "SenseNova 响应缺少 data 字段",
+                http_status,
+                "invalid_response",
+                retryable=True,
+            )
+
+        for item in data:
+            if not isinstance(item, dict):
+                continue
+            url = item.get("url")
+            if isinstance(url, str) and url:
+                image_urls.append(url)
+                logger.debug("[sensenova] 图片 URL: %s...", url[:80])
+                continue
+            b64 = item.get("b64_json")
+            if isinstance(b64, str) and b64:
+                saved = await save_base64_image(b64, "png")
+                if saved:
+                    image_urls.append(saved)
+                    image_paths.append(saved)
+
+        if not image_urls:
+            raise APIError(
+                "SenseNova 未返回图片数据",
+                http_status,
+                "no_image",
+                retryable=False,
+            )
+
+        logger.debug("[sensenova] 共 %d 张图片", len(image_urls))
+        return image_urls, image_paths, None, None

--- a/tl/plugin_config.py
+++ b/tl/plugin_config.py
@@ -59,6 +59,7 @@ class PluginConfig:
     doubao_settings: dict[str, Any] = field(default_factory=dict)
     minimax_settings: dict[str, Any] = field(default_factory=dict)
     stepfun_settings: dict[str, Any] = field(default_factory=dict)
+    sensenova_settings: dict[str, Any] = field(default_factory=dict)
 
     # 供应商配置覆盖
     # 结构：{api_type: {api_keys: [...], daily_limit_per_key: int, ...}}
@@ -475,6 +476,7 @@ class ConfigLoader:
         config.provider_overrides = all_overrides
         config.minimax_settings = all_overrides.get("minimax", {})
         config.stepfun_settings = all_overrides.get("stepfun", {})
+        config.sensenova_settings = all_overrides.get("sensenova", {})
 
         # 图像生成设置
         image_settings = self.raw_config.get("image_generation_settings") or {}

--- a/tl/tl_api.py
+++ b/tl/tl_api.py
@@ -925,6 +925,7 @@ class GeminiAPIClient:
                         "xai",
                         "minimax",
                         "stepfun",
+                        "sensenova",
                     }:
                         provider = get_api_provider(api_type)
                         return await provider.parse_response(


### PR DESCRIPTION
## 改动说明
- tl/api/sensenova.py: 新增 SenseNovaProvider，调用 /v1/images/generations
- 仅支持文生图；忽略参考图（U1 Fast 不支持图像输入）
- 11 种官方固定尺寸；aspect_ratio → size 自动映射（含 9:21） 实测 aspect_ratio 字段被服务端忽略，必须用 size 枚举
- registry: 注册 sensenova → SenseNovaProvider
- _conf_schema.json: api_type 选项追加 sensenova；新增 provider_overrides.sensenova 模板
- plugin_config.py: PluginConfig 新增 sensenova_settings 字段及加载
- main.py: settings 双阶段绑定补充 sensenova 分支；错误提示同步
- tl_api.py: parse_response 路由集合纳入 sensenova
- docs/新增API供应商.md: 注册表新增一行

<!-- 简要描述本次 PR 的改动内容和目的 -->

## 改动类型

- [ ] Bug 修复
- [x] 新功能
- [ ] 重构 / 代码优化
- [ ] 文档更新
- [ ] 其他

## 关联 Issue

<!-- 如有关联 Issue 请填写，例如 Fixes #123 -->

## 测试情况

- [x] 本地测试通过
- [x] 已测试相关命令（/生图、/改图、/快速 等）
- [x] 已测试 LLM 工具调用

## 补充说明

<!-- 需要 reviewer 特别关注的点、兼容性说明等 -->

## Summary by Sourcery

添加 SenseNova U1 Fast 作为新的图像生成提供商，并将其接入配置、路由和错误消息体系。

新特性：
- 为 `/v1/images/generations` 端点引入 `SenseNovaProvider` 实现，支持 U1 Fast 图像生成模型。

改进：
- 在 API 提供商注册表和响应解析管线中注册 SenseNova 提供商，以便能够通过现有的图像命令使用它。
- 扩展插件配置、提供商覆盖和运行时绑定逻辑，以支持 sensenova 专属设置。
- 更新 `api_type` 校验/错误消息和提供商文档，将新的 sensenova 选项包含在内。

文档：
- 在提供商注册表文档中记录 SenseNova 作为新支持的 API 提供商。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add SenseNova U1 Fast as a new image generation provider and wire it into configuration, routing, and error messaging.

New Features:
- Introduce SenseNovaProvider implementation for the /v1/images/generations endpoint, supporting the U1 Fast image generation model.

Enhancements:
- Register the SenseNova provider in the API provider registry and response parsing pipeline so it can be used via existing image commands.
- Extend plugin configuration, provider overrides, and runtime binding logic to support sensenova-specific settings.
- Update api_type validation/error messaging and provider documentation to include the new sensenova option.

Documentation:
- Document SenseNova as a newly supported API provider in the provider registry documentation.

</details>