### PR TITLE
fix: 移除 /生图 自动关键词检测，修复误触手办化与改图注入

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 > **升级提示**：v1.9.0 以后的配置文件格式不兼容旧版本。升级后如遇配置模板显示错误，请查看 [配置迁移说明](https://github.com/piexian/astrbot_plugin_gemini_image_generation/blob/master/docs/troubleshooting.md#配置迁移说明)。
 
+## [1.10.6] - 2026-05-19
+
+### Fixed
+
+- **移除 `/生图` 内自动关键词检测，修复误触手办化 / 改图提示词注入**（#80）
+  - 删除 `build_quick_prompt()` 及 `modify_keywords` / `figure_keywords` 子串扫描逻辑，`/生图` 不再对用户 prompt 做意图猜测，手办化请用 `/快速 手办化`，改图请用 `/改图`
+  - 删除 `get_auto_modification_prompt()` 和 `enhance_prompt_for_figure()` 死代码
+- **`/改图`、`/换风格` 增加参考图缺失拦截**：无参考图时不再静默退化为纯文本生图，改为提示用户附带图片
+- `/改图` 显式传入 `is_modification=True`，不再依赖关键词扫描驱动 `preserve_reference_image_size`
+- 提取 `_NO_REF_IMAGE_MSG` 通用常量，统一 `/改图`、`/换风格`、`/表情包` 三处的参考图缺失提示
+
 ## [1.10.5] - 2026-05-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-![Version](https://img.shields.io/badge/Version-v1.10.4-blue)
+![Version](https://img.shields.io/badge/Version-v1.10.6-blue)
 ![License](https://img.shields.io/badge/License-AGPL--3.0-orange)
 
 **强大的 AstrBot 图像生成插件，支持生图、改图、头像参考、表情包切分和 LLM 工具调用。**

--- a/main.py
+++ b/main.py
@@ -43,7 +43,6 @@ from .tl import (
 )
 from .tl.api import normalize_api_type
 from .tl.enhanced_prompts import (
-    build_quick_prompt,
     get_avatar_prompt,
     get_card_prompt,
     get_figure_prompt,
@@ -71,6 +70,12 @@ PROVIDER_SETTINGS_ATTR_MAP: dict[str, str] = {
     "xai": "xai_settings",
     "openai_images": "openai_images_settings",
 }
+
+_NO_REF_IMAGE_MSG = (
+    "❌ {mode}模式需要参考图。\n"
+    "🧐 可能原因：消息中未附带图片，或图片格式/大小不被支持。\n"
+    "✅ 建议：{suggestion}"
+)
 
 
 class GeminiImageGenerationPlugin(Star):
@@ -538,7 +543,7 @@ class GeminiImageGenerationPlugin(Star):
         event: AstrMessageEvent,
         prompt: str,
         use_avatar: bool = False,
-        skip_figure_enhance: bool = False,
+        is_modification: bool = False,
         override_resolution: str | None = None,
         override_aspect_ratio: str | None = None,
     ):
@@ -569,9 +574,17 @@ class GeminiImageGenerationPlugin(Star):
                     )
                 )
 
-            enhanced_prompt, is_modification_request = build_quick_prompt(
-                prompt, skip_figure_enhance=skip_figure_enhance
-            )
+            enhanced_prompt = prompt
+            is_modification_request = is_modification
+
+            if is_modification_request and not all_ref_images:
+                yield event.plain_result(
+                    _NO_REF_IMAGE_MSG.format(
+                        mode="改图",
+                        suggestion="请附上一张参考图片后再使用 /改图 指令。",
+                    )
+                )
+                return
 
             effective_resolution = (
                 override_resolution
@@ -860,7 +873,6 @@ class GeminiImageGenerationPlugin(Star):
             "手办化",
             "figure",
             None,
-            skip_figure_enhance=True,
         ):
             yield result
 
@@ -897,9 +909,10 @@ class GeminiImageGenerationPlugin(Star):
 
         if not reference_images:
             yield event.plain_result(
-                "❌ 表情包模式需要参考图才能生成一致的角色。\n"
-                "🧐 可能原因：消息中未附带图片，或图片格式/大小不被支持。\n"
-                "✅ 建议：请附上一张清晰的角色参考图（如头像或原表情）后再试。"
+                _NO_REF_IMAGE_MSG.format(
+                    mode="表情包",
+                    suggestion="请附上一张清晰的角色参考图（如头像或原表情）后再试。",
+                )
             )
             return
 
@@ -1406,7 +1419,7 @@ class GeminiImageGenerationPlugin(Star):
         use_avatar = await self.avatar_handler.should_use_avatar(event)
 
         async for result in self._quick_generate_image(
-            event, modification_prompt, use_avatar
+            event, modification_prompt, use_avatar, is_modification=True
         ):
             yield result
 
@@ -1443,6 +1456,15 @@ class GeminiImageGenerationPlugin(Star):
         ) = await self.image_handler.fetch_images_from_event(
             event, include_at_avatars=use_avatar
         )
+
+        if not reference_images and not avatar_reference:
+            yield event.plain_result(
+                _NO_REF_IMAGE_MSG.format(
+                    mode="换风格",
+                    suggestion="请附上一张参考图片后再使用 /换风格 指令。",
+                )
+            )
+            return
 
         yield event.plain_result("🎨 开始转换风格...")
 

--- a/main.py
+++ b/main.py
@@ -71,11 +71,14 @@ PROVIDER_SETTINGS_ATTR_MAP: dict[str, str] = {
     "openai_images": "openai_images_settings",
 }
 
-_NO_REF_IMAGE_MSG = (
-    "❌ {mode}模式需要参考图。\n"
-    "🧐 可能原因：消息中未附带图片，或图片格式/大小不被支持。\n"
-    "✅ 建议：{suggestion}"
-)
+
+def _build_no_ref_msg(mode: str, suggestion: str) -> str:
+    """构建缺少参考图的统一提示"""
+    return (
+        f"❌ {mode}模式需要参考图。\n"
+        "🧐 可能原因：消息中未附带图片，或图片格式/大小不被支持。\n"
+        f"✅ 建议：{suggestion}"
+    )
 
 
 class GeminiImageGenerationPlugin(Star):
@@ -544,6 +547,8 @@ class GeminiImageGenerationPlugin(Star):
         prompt: str,
         use_avatar: bool = False,
         is_modification: bool = False,
+        # 置 True 表示改图请求：参考图缺失时立即拦截；
+        # 配合 preserve_reference_image_size 时保留原图尺寸。
         override_resolution: str | None = None,
         override_aspect_ratio: str | None = None,
     ):
@@ -579,9 +584,9 @@ class GeminiImageGenerationPlugin(Star):
 
             if is_modification_request and not all_ref_images:
                 yield event.plain_result(
-                    _NO_REF_IMAGE_MSG.format(
-                        mode="改图",
-                        suggestion="请附上一张参考图片后再使用 /改图 指令。",
+                    _build_no_ref_msg(
+                        "改图",
+                        "请附上一张参考图片后再使用 /改图 指令。",
                     )
                 )
                 return
@@ -902,16 +907,22 @@ class GeminiImageGenerationPlugin(Star):
         ) = await self.image_handler.fetch_images_from_event(
             event, include_at_avatars=use_avatar
         )
+        valid_reference_images = self.image_handler.filter_valid_reference_images(
+            reference_images, source="消息图片"
+        )
+        valid_avatar_reference = self.image_handler.filter_valid_reference_images(
+            avatar_reference, source="头像"
+        )
 
         stripped_prompt = (prompt or "").strip()
         simple_mode = stripped_prompt.startswith("简单")
         user_prompt = stripped_prompt[len("简单") :].strip() if simple_mode else prompt
 
-        if not reference_images:
+        if not valid_reference_images and not valid_avatar_reference:
             yield event.plain_result(
-                _NO_REF_IMAGE_MSG.format(
-                    mode="表情包",
-                    suggestion="请附上一张清晰的角色参考图（如头像或原表情）后再试。",
+                _build_no_ref_msg(
+                    "表情包",
+                    "请附上一张清晰的角色参考图（如头像或原表情）后再试。",
                 )
             )
             return
@@ -972,8 +983,8 @@ class GeminiImageGenerationPlugin(Star):
             success, result_data = await self.image_generator.generate_image_core(
                 event=event,
                 prompt=full_prompt,
-                reference_images=reference_images,
-                avatar_reference=avatar_reference,
+                reference_images=valid_reference_images,
+                avatar_reference=valid_avatar_reference,
                 override_resolution=sticker_resolution,
                 override_aspect_ratio=sticker_aspect_ratio,
             )
@@ -1459,9 +1470,9 @@ class GeminiImageGenerationPlugin(Star):
 
         if not reference_images and not avatar_reference:
             yield event.plain_result(
-                _NO_REF_IMAGE_MSG.format(
-                    mode="换风格",
-                    suggestion="请附上一张参考图片后再使用 /换风格 指令。",
+                _build_no_ref_msg(
+                    "换风格",
+                    "请附上一张参考图片后再使用 /换风格 指令。",
                 )
             )
             return

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,7 +1,7 @@
 name: astrbot_plugin_gemini_image_generation
 desc: Gemini图像生成插件，支持生图和改图，支持自动获取头像作为参考
 display_name: Gemini 图像生成
-version: v1.10.5
+version: v1.10.6
 author: piexian
 repo: https://github.com/piexian/astrbot_plugin_gemini_image_generation
 astrbot_version: ">=4.10.4"

--- a/tl/enhanced_prompts.py
+++ b/tl/enhanced_prompts.py
@@ -133,20 +133,6 @@ def get_modification_prompt(prompt: str) -> str:
 - 确保修改后的图像与原图有可区分的差异"""
 
 
-def get_auto_modification_prompt(prompt: str) -> str:
-    """获取自动改图提示词（用于快捷模式中的自动判断）"""
-    return f"""图像修改任务：{prompt}
-
-请严格按照用户要求修改参考图像，确保：
-1. 必须基于提供的参考图像进行修改
-2. 保持主要对象和构图，只修改用户要求的部分
-3. 修改后的图像要与原图有明显区别
-4. 不要返回完全相同的原图
-5. 修改要自然、合理，保持图像质量
-
-重要：这是一项图像修改任务，不是生成新图像，必须基于参考图像进行修改！"""
-
-
 def get_style_change_prompt(style: str, prompt: str = "") -> str:
     """获取风格转换提示词"""
     full_prompt = f"将参考图像改为{style}风格"
@@ -178,11 +164,6 @@ def get_vision_crop_system_prompt() -> str:
     )
 
 
-def enhance_prompt_for_figure(prompt: str) -> str:
-    """兼容旧接口"""
-    return get_figure_prompt(prompt, style_type=1)
-
-
 def get_q_version_sticker_prompt(
     prompt: str = "", *, rows: int = 4, cols: int = 4
 ) -> str:
@@ -212,36 +193,3 @@ def get_grid_detect_prompt() -> str:
         "Rows/cols must be positive integers (1-20). "
         'If the image cannot be expressed as an N x N (or N x M) grid, respond {"rows":0,"cols":0} (i.e., 0x0).'
     )
-
-
-def build_quick_prompt(
-    prompt: str, *, skip_figure_enhance: bool = False
-) -> tuple[str, bool]:
-    """快捷模式统一提示词构建，返回(增强后的提示词, 是否判定为改图)"""
-    modify_keywords = [
-        "修改",
-        "改图",
-        "改成",
-        "变成",
-        "调整",
-        "优化",
-        "重做",
-        "更换",
-        "替换",
-        "删除",
-        "添加",
-    ]
-    figure_keywords = ["手办", "figure", "模型", "手办化", "手办模型"]
-
-    is_modification_request = any(keyword in prompt for keyword in modify_keywords)
-
-    if (not skip_figure_enhance) and any(
-        keyword in prompt.lower() for keyword in figure_keywords
-    ):
-        enhanced_prompt = enhance_prompt_for_figure(prompt)
-    elif is_modification_request:
-        enhanced_prompt = get_auto_modification_prompt(prompt)
-    else:
-        enhanced_prompt = prompt
-
-    return enhanced_prompt, is_modification_request


### PR DESCRIPTION
## 改动说明

删除 build_quick_prompt() 及其 modify_keywords / figure_keywords 子串扫描 逻辑，/生图 不再对用户 prompt 做意图猜测。手办化请用 /快速 手办化，
改图请用 /改图，指令路由已归位。

/改图 显式传入 is_modification 参数，不再靠扫文本驱动行为。
/改图、/换风格 增加参考图缺失拦截，避免静默退化为纯文本生图。
提取 _NO_REF_IMAGE_MSG 通用常量，统一三处参考图缺失提示。
清理 get_auto_modification_prompt / enhance_prompt_for_figure 死代码。


## 改动类型

- [x] Bug 修复
- [ ] 新功能
- [x] 重构 / 代码优化
- [ ] 文档更新
- [ ] 其他

## 关联 Issue

Fixes #80 

## 测试情况

- [x] 本地测试通过
- [x] 已测试相关命令（/生图、/改图、/快速 等）
- [x] 已测试 LLM 工具调用

## 补充说明

<!-- 需要 reviewer 特别关注的点、兼容性说明等 -->

## Summary by Sourcery

从 `/生图` 命令中移除自动意图检测，使图片修改和风格切换行为依赖显式的参数标记和参考图片，而非通过关键词扫描来判断意图。

Bug Fixes（错误修复）:
- 防止 `/生图` 因基于关键词的意图猜测而错误触发人物风格生成或修改类提示。
- 确保 `/改图` 和 `/换风格` 需要提供参考图片，当未提供参考图片时不再静默回退为纯文本生图。

Enhancements（功能改进）:
- 通过共享的消息模板常量，统一 `/改图`、`/换风格`、`/表情包` 在缺少参考图片时的用户提示文案。
- 通过移除未使用的提示增强辅助方法和无效代码，简化快速生图流程。

Build（构建）:
- 在元数据中将插件版本号提升至 `v1.10.6`。

Documentation（文档）:
- 更新变更日志和 README 版本徽章以反映 `v1.10.6` 版本发布。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove automatic intent detection from the /生图 command and make image modification and style change behavior rely on explicit flags and reference images instead of keyword scanning.

Bug Fixes:
- Prevent /生图 from incorrectly triggering figure-style generation or modification prompts due to keyword-based intent guesses.
- Ensure /改图 and /换风格 require a reference image and no longer silently fall back to plain text image generation when none is provided.

Enhancements:
- Unify reference-image-missing user messaging across /改图、/换风格、/表情包 via a shared message template constant.
- Simplify quick image generation flow by removing unused prompt enhancement helpers and dead code.

Build:
- Bump plugin version to v1.10.6 in metadata.

Documentation:
- Update changelog and README version badge to reflect release v1.10.6.

</details>