### PR TITLE
支持本地路径参考图

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@
 
 ## [Unreleased]
 
+## [2.2.0] - 2026-07-04
+
+### Added
+
+- **LLM 工具支持本地路径参考图**：`gemini_image_generation` 工具新增 `reference_image_paths` 参数，允许 LLM 提交本地文件路径作为参考图，解决「本地路径有文件但不在消息内」的场景（如复用上一轮工具调用缓存在 `data/temp/tool_images/` 的图片）。
+- **新增 `tl/tool_path_guard.py`**：路径白名单守卫模块。默认白名单覆盖各系统 AstrBot 数据目录（Linux/macOS `~/.astrbot/data`、Docker `/opt/astrbot/data`、`/AstrBot/data`、`/app/data`）及 `ASTRBOT_DATA_PATH` 环境变量；拒绝 `..` 路径穿越，`Path.resolve` 跟随符号链接后校验 `parents` 链。
+- **新增 `llm_tool_reference_path_mode` 配置**：`whitelist`（默认，仅允许白名单目录）/ `global`（允许任意本地路径，适用于管理员）。`global` 模式下会尝试将工具默认权限自动设为管理员可用（`tl/tool_permission.py`），权限管控也可在 AstrBot WebUI「插件-管理行为-函数工具」中手动调整。
+- **新增 `llm_tool_reference_allowed_dirs` 配置**：`whitelist` 模式下可追加自定义允许目录。
+
+### Changed
+
+- `provider_polling` 配置项新增 `options` 预制供应商列表（11 个已知 api_type），前端渲染为带搜索的下拉多选，并更新 hint。
+- `docs/config.md` 补充 LLM 工具本地路径参考图相关字段说明。
+
 ## [2.1.0] - 2026-06-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-![Version](https://img.shields.io/badge/Version-v2.1.0-blue)
+![Version](https://img.shields.io/badge/Version-v2.2.0-blue)
 ![License](https://img.shields.io/badge/License-AGPL--3.0-orange)
 
 **强大的 AstrBot 图像生成插件，支持生图、改图、头像参考、表情包切分和 LLM 工具调用。**

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -1313,9 +1313,9 @@
       "llm_tool_timeout_reserve_percent": {
         "name": "LLM Tool Timeout Reserve Percent",
         "description": "LLM 工具超时预留百分比",
-        "hint": "LLM 工具触发生图时，会从当前聊天工具超时配置中按比例预留安全时间。剩余时间用于前台同步等待；超出后转为后台发送。默认 75%，即默认 60 秒超时下，前台最多等待约 45 秒。",
+        "hint": "LLM 工具触发生图时，会从当前聊天工具超时配置中按比例预留安全时间。剩余时间用于前台同步等待；超出后转为后台发送。默认 50%，即默认 60 秒超时下，前台最多等待约 30 秒。",
         "type": "int",
-        "default": 75,
+        "default": 50,
         "slider": {
           "min": 1,
           "max": 100,

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -7,7 +7,20 @@
       "provider_polling": {
         "description": "供应商轮询顺序",
         "type": "list",
-        "hint": "按列表从上到下尝试生成。填写供应商名称，如 google/openai/openai_images。留空时按配置表中的有效供应商顺序尝试。",
+        "hint": "按列表从上到下尝试生成。请选择并按优先级排列：google / openai / zai / grok2api / agnes_ai / xai / minimax / stepfun / openai_images / doubao / sensenova。留空时按配置表中的有效供应商顺序尝试。",
+        "options": [
+          "google",
+          "openai",
+          "zai",
+          "grok2api",
+          "agnes_ai",
+          "xai",
+          "minimax",
+          "stepfun",
+          "openai_images",
+          "doubao",
+          "sensenova"
+        ],
         "default": []
       },
       "proxy": {
@@ -1308,6 +1321,22 @@
           "max": 100,
           "step": 1
         }
+      },
+      "llm_tool_reference_path_mode": {
+        "description": "LLM 工具本地路径参考图模式",
+        "type": "string",
+        "hint": "控制 reference_image_paths 的本地路径范围。whitelist=仅允许白名单目录；global=允许任意本地图片路径，并会尝试将工具默认权限设为管理员。",
+        "default": "whitelist",
+        "options": [
+          "whitelist",
+          "global"
+        ]
+      },
+      "llm_tool_reference_allowed_dirs": {
+        "description": "LLM 工具参考图允许目录",
+        "type": "list",
+        "hint": "whitelist 模式下额外允许的参考图目录；默认已覆盖常见 AstrBot 数据目录。仅接受可完整校验的图片文件，详见 docs/config.md。",
+        "default": []
       }
     }
   },

--- a/docs/config.md
+++ b/docs/config.md
@@ -69,8 +69,23 @@ google / openai / zai / grok2api / agnes_ai / xai / minimax / stepfun / openai_i
 | `preserve_reference_image_size` | `false` | 改图时保留参考图尺寸 |
 | `max_inline_image_size_mb` | `2.0` | 本地图片 base64 编码阈值 |
 | `llm_tool_timeout_reserve_percent` | `50` | 为 `tool_call_timeout` 预留的百分比，剩余时间用于前台同步等待 |
+| `llm_tool_reference_path_mode` | `whitelist` | LLM 工具 `reference_image_paths` 的本地路径权限模式 |
+| `llm_tool_reference_allowed_dirs` | `[]` | `whitelist` 模式下额外允许的参考图目录 |
 
 分辨率、长宽比、最大参考图数量、Google 文本响应、Google 搜索接地、OpenAI/OpenAI 兼容参数名等均在 `provider_settings.provider_overrides` 的各供应商条目内配置。
+
+### LLM 工具本地路径参考图
+
+`gemini_image_generation` 工具支持 `reference_image_paths` 参数，用于让 LLM 复用上一次工具调用缓存在本地的图片，例如 `data/temp/tool_images/` 下的文件。
+
+路径守卫规则：
+
+- `llm_tool_reference_path_mode=whitelist`：默认模式，只允许默认目录和 `llm_tool_reference_allowed_dirs` 中的文件。
+- `llm_tool_reference_path_mode=global`：跳过白名单目录检查，但仍会检查路径穿越、文件存在性和图片完整性。插件会在支持函数工具权限配置的 AstrBot 新版上，尝试将 `gemini_image_generation` 默认权限设为管理员；若管理员已在 WebUI 手动配置过该工具权限，则不会覆盖。
+- 默认白名单包含常见 AstrBot 数据目录：`~/.astrbot/data`、`/opt/astrbot/data`、`/AstrBot/data`、`/app/data`，以及 `ASTRBOT_DATA_PATH` 环境变量指向的目录。
+- `llm_tool_reference_allowed_dirs` 可追加自定义目录，支持绝对路径或 `~` 开头路径。
+- 原始路径中包含 `..` 穿越会被拒绝；符号链接会先 `resolve`，再检查最终路径是否仍位于允许目录内。
+- 只有能通过完整性校验的图片文件会被接受；不存在、非文件、非图片或损坏图片都会被拒绝并写入日志。
 
 ## quick_mode_settings
 

--- a/main.py
+++ b/main.py
@@ -56,8 +56,8 @@ from .tl.enhanced_prompts import (
 from .tl.llm_tools import GeminiImageGenerationTool
 from .tl.plugin_config import max_configured_reference_images
 from .tl.tl_api import APIClient, ApiRequestConfig, get_api_client
-from .tl.tool_permission import ensure_admin_default_tool_permission
 from .tl.tl_utils import AvatarManager, cleanup_old_images, format_error_message
+from .tl.tool_permission import ensure_admin_default_tool_permission
 
 
 def _build_no_ref_msg(mode: str, suggestion: str) -> str:

--- a/main.py
+++ b/main.py
@@ -56,6 +56,7 @@ from .tl.enhanced_prompts import (
 from .tl.llm_tools import GeminiImageGenerationTool
 from .tl.plugin_config import max_configured_reference_images
 from .tl.tl_api import APIClient, ApiRequestConfig, get_api_client
+from .tl.tool_permission import ensure_admin_default_tool_permission
 from .tl.tl_utils import AvatarManager, cleanup_old_images, format_error_message
 
 
@@ -239,6 +240,8 @@ class GeminiImageGenerationPlugin(Star):
             tool.refresh_from_plugin()
             self.llm_image_tool = tool
             self.context.add_llm_tools(tool)
+            if self.cfg.llm_tool_reference_path_mode == "global":
+                ensure_admin_default_tool_permission(tool.name)
             logger.debug("已注册 GeminiImageGenerationTool 到 LLM 工具列表")
         except Exception as e:
             logger.warning(f"注册 LLM 工具失败: {e}，将使用装饰器方式")

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,7 +1,7 @@
 name: astrbot_plugin_gemini_image_generation
 desc: Gemini图像生成插件，支持生图和改图，支持自动获取头像作为参考
 display_name: Gemini 图像生成
-version: v2.1.0
+version: v2.2.0
 author: piexian
 repo: https://github.com/piexian/astrbot_plugin_gemini_image_generation
 astrbot_version: ">=4.10.4"

--- a/tests/test_tool_permission.py
+++ b/tests/test_tool_permission.py
@@ -1,0 +1,58 @@
+"""函数工具权限默认值辅助测试。"""
+
+from __future__ import annotations
+
+from tl.tool_permission import (
+    TOOL_PERMISSION_KEY,
+    TOOL_PERMISSION_SCOPE,
+    TOOL_PERMISSION_SCOPE_ID,
+    ensure_admin_default_tool_permission,
+)
+
+
+class _FakeSharedPreferences:
+    def __init__(self, initial=None):
+        self.store = initial if initial is not None else {}
+        self.put_calls = []
+
+    def get(self, key, default=None, scope=None, scope_id=None):
+        assert key == TOOL_PERMISSION_KEY
+        assert scope == TOOL_PERMISSION_SCOPE
+        assert scope_id == TOOL_PERMISSION_SCOPE_ID
+        return self.store or default
+
+    def put(self, key, value, scope=None, scope_id=None):
+        assert key == TOOL_PERMISSION_KEY
+        assert scope == TOOL_PERMISSION_SCOPE
+        assert scope_id == TOOL_PERMISSION_SCOPE_ID
+        self.store = value
+        self.put_calls.append(value)
+
+
+def test_ensure_admin_default_tool_permission_sets_admin_when_missing():
+    sp = _FakeSharedPreferences({})
+
+    changed = ensure_admin_default_tool_permission("gemini_image_generation", sp_obj=sp)
+
+    assert changed is True
+    assert sp.store["_default"]["gemini_image_generation"] == "admin"
+    assert len(sp.put_calls) == 1
+
+
+def test_ensure_admin_default_tool_permission_does_not_override_existing_member():
+    sp = _FakeSharedPreferences({"_default": {"gemini_image_generation": "member"}})
+
+    changed = ensure_admin_default_tool_permission("gemini_image_generation", sp_obj=sp)
+
+    assert changed is False
+    assert sp.store["_default"]["gemini_image_generation"] == "member"
+    assert sp.put_calls == []
+
+
+def test_ensure_admin_default_tool_permission_handles_invalid_store_shape():
+    sp = _FakeSharedPreferences([])
+
+    changed = ensure_admin_default_tool_permission("gemini_image_generation", sp_obj=sp)
+
+    assert changed is True
+    assert sp.store["_default"]["gemini_image_generation"] == "admin"

--- a/tests/test_tool_reference_paths.py
+++ b/tests/test_tool_reference_paths.py
@@ -1,0 +1,418 @@
+"""reference_image_paths 参数与 tool_path_guard 的单元测试。"""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from tl.tool_path_guard import (
+    expand_allowed_dirs,
+    filter_reference_paths,
+    is_path_allowed,
+    is_supported_image_file,
+    normalize_candidate,
+    raw_has_traversal,
+)
+
+PNG_1X1 = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGP4z8DwHwAFAAH/"
+    "iZk9HQAAAABJRU5ErkJggg=="
+)
+
+# ---------- raw_has_traversal ----------
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("a/b.png", False),
+        ("a..b.png", False),
+        ("../etc/passwd", True),
+        ("a/../b", True),
+        ("foo/../../etc", True),
+        ("foo/%2e%2e/etc", True),
+        ("a//b", False),
+        ("/foo/bar", False),
+        ("", False),
+    ],
+)
+def test_raw_has_traversal_posix(raw, expected):
+    assert raw_has_traversal(raw) is expected
+
+
+def test_raw_has_traversal_windows_style():
+    # backslash 会被统一为 / 处理
+    assert raw_has_traversal("a\\..\\b") is True
+    assert raw_has_traversal("..\\passwd") is True
+    assert raw_has_traversal("a\\b\\c.png") is False
+
+
+# ---------- normalize_candidate ----------
+
+
+def test_normalize_candidate_strips_quotes(tmp_path):
+    f = tmp_path / "x.png"
+    f.write_bytes(PNG_1X1)
+    p = normalize_candidate(f'"{f}"')
+    assert p is not None and p == f.resolve()
+
+
+def test_normalize_candidate_empty():
+    assert normalize_candidate("") is None
+    assert normalize_candidate("   ") is None
+
+
+def test_normalize_candidate_expanduser(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    p = normalize_candidate("~/sub/a.png")
+    assert p is not None
+    assert str(tmp_path) in str(p)
+
+
+def test_normalize_candidate_file_uri(tmp_path):
+    f = tmp_path / "x.png"
+    f.write_bytes(PNG_1X1)
+    p = normalize_candidate(f.resolve().as_uri())
+    assert p is not None and p == f.resolve()
+
+
+# ---------- is_path_allowed ----------
+
+
+def test_is_path_allowed_inside(tmp_path):
+    sub = tmp_path / "tool_images"
+    sub.mkdir()
+    allowed = expand_allowed_dirs([str(tmp_path)])
+    f = sub / "a.png"
+    f.write_bytes(b"data")
+    assert is_path_allowed(f.resolve(), allowed) is True
+
+
+def test_is_path_allowed_outside(tmp_path):
+    allowed = expand_allowed_dirs([str(tmp_path)])
+    # /etc/passwd 通常存在但不属于 tmp_path
+    etc = Path("/etc/passwd")
+    if etc.exists():
+        assert is_path_allowed(etc.resolve(), allowed) is False
+
+
+def test_is_path_allowed_rejects_sibling_prefix(tmp_path):
+    sibling = tmp_path.parent / f"{tmp_path.name}-other"
+    sibling.mkdir()
+    f = sibling / "a.png"
+    f.write_bytes(b"data")
+    allowed = expand_allowed_dirs([str(tmp_path)])
+    assert is_path_allowed(f.resolve(), allowed) is False
+
+
+def test_is_path_allowed_empty_allowed(tmp_path):
+    f = tmp_path / "a.png"
+    f.write_bytes(b"data")
+    assert is_path_allowed(f.resolve(), []) is False
+
+
+# ---------- filter_reference_paths ----------
+
+
+def _make_img(dir_path: Path, name: str = "a.png") -> Path:
+    p = dir_path / name
+    p.write_bytes(PNG_1X1)
+    return p
+
+
+def test_is_supported_image_file_rejects_broken_image(tmp_path):
+    f = tmp_path / "broken.png"
+    f.write_bytes(b"\x89PNG\r\n\x1a\n")
+    assert is_supported_image_file(f) is False
+
+
+def test_is_supported_image_file_rejects_non_image(tmp_path):
+    f = tmp_path / "not-image.png"
+    f.write_text("secret", encoding="utf-8")
+    assert is_supported_image_file(f) is False
+
+
+def test_filter_whitelist_accepts_inside(tmp_path):
+    f = _make_img(tmp_path)
+    accepted, rejected = filter_reference_paths(
+        [str(f)], allowed_dirs=[str(tmp_path)], global_mode=False
+    )
+    assert accepted == [f.resolve().as_uri()]
+    assert rejected == []
+
+
+def test_filter_whitelist_accepts_quoted_path_as_normalized_uri(tmp_path):
+    f = _make_img(tmp_path)
+    accepted, rejected = filter_reference_paths(
+        [f'"{f}"'], allowed_dirs=[str(tmp_path)], global_mode=False
+    )
+    assert accepted == [f.resolve().as_uri()]
+    assert rejected == []
+
+
+def test_filter_whitelist_rejects_outside(tmp_path):
+    # /etc/passwd 在白名单外
+    etc = Path("/etc/passwd")
+    if not etc.exists():
+        pytest.skip("/etc/passwd 不存在，无法测试越界拒绝")
+    accepted, rejected = filter_reference_paths(
+        [str(etc)], allowed_dirs=[str(tmp_path)], global_mode=False
+    )
+    assert accepted == []
+    assert len(rejected) == 1
+
+
+def test_filter_rejects_traversal_even_in_whitelist(tmp_path):
+    # 含 .. 的路径即便最终落在白名单内也直接拒绝
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    _make_img(sub, "a.png")
+    # 构造含 .. 的等价路径
+    rel_with_dotdot = sub / ".." / "sub" / "a.png"
+    accepted, rejected = filter_reference_paths(
+        [str(rel_with_dotdot)], allowed_dirs=[str(tmp_path)], global_mode=False
+    )
+    assert accepted == []
+    assert len(rejected) == 1
+
+
+def test_filter_rejects_nonexistent(tmp_path):
+    accepted, rejected = filter_reference_paths(
+        [str(tmp_path / "noexist.png")],
+        allowed_dirs=[str(tmp_path)],
+        global_mode=False,
+    )
+    assert accepted == []
+    assert len(rejected) == 1
+
+
+def test_filter_rejects_non_image_even_in_global_mode(tmp_path):
+    f = tmp_path / "not-image.png"
+    f.write_text("secret", encoding="utf-8")
+    accepted, rejected = filter_reference_paths(
+        [str(f)], allowed_dirs=[], global_mode=True
+    )
+    assert accepted == []
+    assert rejected == [str(f)]
+
+
+def test_filter_global_mode_accepts_any_existing_image(tmp_path):
+    f = _make_img(tmp_path)
+    accepted, rejected = filter_reference_paths(
+        [str(f)], allowed_dirs=[], global_mode=True
+    )
+    assert accepted == [f.resolve().as_uri()]
+    assert rejected == []
+
+
+def test_filter_global_mode_still_rejects_traversal(tmp_path):
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    _make_img(sub, "a.png")
+    rel_with_dotdot = str(sub / ".." / "sub" / "a.png")
+    accepted, rejected = filter_reference_paths(
+        [rel_with_dotdot], allowed_dirs=[], global_mode=True
+    )
+    assert accepted == []
+    assert len(rejected) == 1
+
+
+def test_filter_global_mode_rejects_nonexistent():
+    accepted, rejected = filter_reference_paths(
+        ["/this/does/not/exist.png"], allowed_dirs=[], global_mode=True
+    )
+    assert accepted == []
+    assert len(rejected) == 1
+
+
+def test_filter_skips_non_string_and_empty(tmp_path):
+    accepted, rejected = filter_reference_paths(
+        ["", None, "   "],  # type: ignore[list-item]
+        allowed_dirs=[str(tmp_path)],
+        global_mode=False,
+    )
+    assert accepted == []
+    assert len(rejected) == 3
+
+
+# ---------- expand_allowed_dirs ----------
+
+
+def test_expand_default_dirs_always_present():
+    # 默认目录即使不存在也保留
+    resolved = expand_allowed_dirs(None)
+    # ~/.astrbot/data 经 expanduser 后应存在
+    home_data = Path("~/.astrbot/data").expanduser().resolve(strict=False)
+    assert home_data in resolved
+
+
+def test_expand_user_configured_must_exist(tmp_path):
+    resolved = expand_allowed_dirs([str(tmp_path)])
+    assert tmp_path.resolve() in resolved
+    # 不存在的用户目录被跳过
+    resolved2 = expand_allowed_dirs([str(tmp_path / "noexist")])
+    assert tmp_path.resolve() not in resolved2
+
+
+def test_expand_env_var(monkeypatch, tmp_path):
+    monkeypatch.setenv("ASTRBOT_DATA_PATH", str(tmp_path))
+    resolved = expand_allowed_dirs(None)
+    assert tmp_path.resolve() in resolved
+
+
+def test_expand_env_var_skipped_when_empty(monkeypatch):
+    monkeypatch.setenv("ASTRBOT_DATA_PATH", "   ")
+    # 不应抛错
+    resolved = expand_allowed_dirs(None)
+    assert isinstance(resolved, list)
+
+
+# ---------- schema 集成 ----------
+
+
+def test_tool_base_properties_has_reference_image_paths():
+    import sys
+    import types
+
+    if "tl.llm_tools" not in sys.modules:
+        for name in (
+            "astrbot.core",
+            "astrbot.core.agent",
+            "astrbot.core.agent.run_context",
+            "astrbot.core.agent.tool",
+            "astrbot.core.astr_agent_context",
+        ):
+            if name not in sys.modules:
+                sys.modules[name] = types.ModuleType(name)
+        sys.modules["astrbot.core.agent.run_context"].ContextWrapper = type(
+            "ContextWrapper", (), {}
+        )
+        sys.modules["astrbot.core.agent.tool"].FunctionTool = type(
+            "FunctionTool", (), {"__class_getitem__": classmethod(lambda cls, it: cls)}
+        )
+        sys.modules["astrbot.core.agent.tool"].ToolExecResult = type(
+            "ToolExecResult", (), {}
+        )
+        sys.modules["astrbot.core.astr_agent_context"].AstrAgentContext = type(
+            "AstrAgentContext", (), {}
+        )
+        if "mcp" not in sys.modules:
+            mcp_module = types.ModuleType("mcp")
+            mcp_module.types = types.ModuleType("mcp.types")
+            sys.modules["mcp"] = mcp_module
+            sys.modules["mcp.types"] = mcp_module.types
+
+    from tl.llm_tools import _build_tool_base_properties
+
+    props = _build_tool_base_properties()
+    assert "reference_image_paths" in props
+    assert props["reference_image_paths"]["type"] == "array"
+
+
+# ---------- GeminiImageGenerationTool.call 集成 ----------
+
+
+class _FakeAvatarManager:
+    async def cleanup_used_avatars(self):
+        return None
+
+
+class _FakePlugin:
+    def __init__(
+        self,
+        *,
+        allowed_dirs: list[str],
+        generated_path: Path,
+        event_refs: list[str] | None = None,
+    ) -> None:
+        self.cfg = SimpleNamespace(
+            llm_tool_reference_path_mode="whitelist",
+            llm_tool_reference_allowed_dirs=allowed_dirs,
+            provider_candidates=[],
+        )
+        self.api_client = object()
+        self.avatar_manager = _FakeAvatarManager()
+        self.generated_path = generated_path
+        self.event_refs = event_refs or []
+        self.captured_reference_images: list[str] | None = None
+
+    async def _check_and_consume_limit(self, event):
+        return True, None
+
+    async def _fetch_images_from_event(self, event, include_at_avatars=False):
+        return list(self.event_refs), []
+
+    async def _generate_image_core_internal(
+        self,
+        *,
+        event,
+        prompt,
+        reference_images,
+        avatar_reference,
+        override_resolution,
+        override_aspect_ratio,
+        is_tool_call,
+    ):
+        self.captured_reference_images = list(reference_images)
+        return True, ([], [str(self.generated_path)], None, None)
+
+
+def _tool_context():
+    return SimpleNamespace(context=SimpleNamespace(event=SimpleNamespace()))
+
+
+@pytest.mark.asyncio
+async def test_tool_call_uses_reference_image_paths_without_use_reference_images(
+    tmp_path,
+):
+    from tl.llm_tools import GeminiImageGenerationTool
+
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    ref = _make_img(allowed, "ref.png")
+    generated = _make_img(tmp_path, "generated.png")
+    plugin = _FakePlugin(
+        allowed_dirs=[str(allowed)],
+        generated_path=generated,
+        event_refs=["event-ref"],
+    )
+    tool = GeminiImageGenerationTool(plugin=plugin)
+
+    result = await tool.call(
+        _tool_context(),
+        prompt="改成水彩风",
+        reference_image_paths=[str(ref)],
+        use_reference_images=False,
+        for_forum=True,
+    )
+
+    assert "图像生成完成" in result
+    assert plugin.captured_reference_images == [ref.resolve().as_uri()]
+
+
+@pytest.mark.asyncio
+async def test_tool_call_rejects_out_of_whitelist_reference_image_path(tmp_path):
+    from tl.llm_tools import GeminiImageGenerationTool
+
+    allowed = tmp_path / "allowed"
+    outside = tmp_path / "outside"
+    allowed.mkdir()
+    outside.mkdir()
+    ref = _make_img(outside, "ref.png")
+    generated = _make_img(tmp_path, "generated.png")
+    plugin = _FakePlugin(allowed_dirs=[str(allowed)], generated_path=generated)
+    tool = GeminiImageGenerationTool(plugin=plugin)
+
+    result = await tool.call(
+        _tool_context(),
+        prompt="改成水彩风",
+        reference_image_paths=[str(ref)],
+        use_reference_images=False,
+        for_forum=True,
+    )
+
+    assert "图像生成完成" in result
+    assert plugin.captured_reference_images == []

--- a/tests/test_tool_reference_paths.py
+++ b/tests/test_tool_reference_paths.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import base64
+import sys
+import types
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
+import tl.tool_path_guard as path_guard
 from tl.tool_path_guard import (
     expand_allowed_dirs,
     filter_reference_paths,
@@ -135,6 +138,20 @@ def test_is_supported_image_file_rejects_non_image(tmp_path):
     assert is_supported_image_file(f) is False
 
 
+def test_is_supported_image_file_registers_heif_opener_when_available(
+    monkeypatch,
+    tmp_path,
+):
+    calls = []
+    heif_module = types.ModuleType("pillow_heif")
+    heif_module.register_heif_opener = lambda: calls.append("registered")
+    monkeypatch.setitem(sys.modules, "pillow_heif", heif_module)
+    f = _make_img(tmp_path)
+
+    assert is_supported_image_file(f) is True
+    assert calls == ["registered"]
+
+
 def test_filter_whitelist_accepts_inside(tmp_path):
     f = _make_img(tmp_path)
     accepted, rejected = filter_reference_paths(
@@ -163,6 +180,29 @@ def test_filter_whitelist_rejects_outside(tmp_path):
     )
     assert accepted == []
     assert len(rejected) == 1
+
+
+def test_filter_whitelist_rejects_outside_before_image_validation(
+    monkeypatch,
+    tmp_path,
+):
+    allowed = tmp_path / "allowed"
+    outside = tmp_path / "outside"
+    allowed.mkdir()
+    outside.mkdir()
+    ref = _make_img(outside)
+
+    def fail_if_called(path):
+        raise AssertionError(f"不应打开白名单外文件: {path}")
+
+    monkeypatch.setattr(path_guard, "is_supported_image_file", fail_if_called)
+
+    accepted, rejected = path_guard.filter_reference_paths(
+        [str(ref)], allowed_dirs=[str(allowed)], global_mode=False
+    )
+
+    assert accepted == []
+    assert rejected == [str(ref)]
 
 
 def test_filter_rejects_traversal_even_in_whitelist(tmp_path):
@@ -236,6 +276,64 @@ def test_filter_skips_non_string_and_empty(tmp_path):
     )
     assert accepted == []
     assert len(rejected) == 3
+
+
+def test_filter_rejects_non_iterable_raw_paths(tmp_path):
+    accepted, rejected = filter_reference_paths(
+        True,
+        allowed_dirs=[str(tmp_path)],
+        global_mode=False,
+    )
+    assert accepted == []
+    assert rejected == ["True"]
+
+
+def test_filter_rejects_mapping_raw_paths(tmp_path):
+    accepted, rejected = filter_reference_paths(
+        {"path": str(tmp_path / "a.png")},
+        allowed_dirs=[str(tmp_path)],
+        global_mode=False,
+    )
+    assert accepted == []
+    assert len(rejected) == 1
+
+
+def test_filter_rejects_mixed_non_string_items(tmp_path):
+    f = _make_img(tmp_path)
+    accepted, rejected = filter_reference_paths(
+        [str(f), 123, False],
+        allowed_dirs=[str(tmp_path)],
+        global_mode=False,
+    )
+    assert accepted == [f.resolve().as_uri()]
+    assert rejected == ["123", "False"]
+
+
+def test_image_handler_keeps_file_uri_reference_images(monkeypatch):
+    components_module = types.ModuleType("astrbot.api.message_components")
+    components_module.At = type("At", (), {})
+    components_module.Image = type("Image", (), {})
+    components_module.Reply = type("Reply", (), {})
+    monkeypatch.setitem(
+        sys.modules, "astrbot.api.message_components", components_module
+    )
+
+    tl_utils_module = sys.modules["tl.tl_utils"]
+    monkeypatch.setattr(
+        tl_utils_module, "AvatarManager", type("AvatarManager", (), {}), raising=False
+    )
+    monkeypatch.setattr(
+        tl_utils_module, "is_valid_base64_image_str", lambda value: False, raising=False
+    )
+
+    from tl.image_handler import ImageHandler
+
+    image_handler = ImageHandler(log_debug_fn=lambda msg: None)
+    file_uri = "file:///tmp/tool_images/ref.png"
+
+    assert image_handler.filter_valid_reference_images([file_uri], "消息图片") == [
+        file_uri
+    ]
 
 
 # ---------- expand_allowed_dirs ----------

--- a/tl/image_handler.py
+++ b/tl/image_handler.py
@@ -64,7 +64,7 @@ class ImageHandler:
         过滤出合法的参考图像。
 
         支持的格式：
-        - http(s):// URL（由 tl_api 下载转换）
+        - http(s):// URL 或 file:// URI（由 tl_api 统一转换）
         - data:image/xxx;base64,... 格式
         - 纯 base64 字符串（需通过魔数校验为图片）
 
@@ -82,12 +82,12 @@ class ImageHandler:
 
             cleaned = img.strip()
 
-            # URL 形式的图片，交给 tl_api 下载处理
-            if cleaned.lower().startswith("http://") or cleaned.lower().startswith(
-                "https://"
-            ):
+            cleaned_lower = cleaned.lower()
+
+            # URL/file URI 形式的图片，交给 tl_api 统一归一化处理
+            if cleaned_lower.startswith(("http://", "https://", "file://")):
                 valid.append(cleaned)
-                self._log_debug(f"保留 URL 参考图像({source}): {cleaned[:64]}...")
+                self._log_debug(f"保留 URI 参考图像({source}): {cleaned[:64]}...")
                 continue
 
             if self.is_valid_base64_image_str(cleaned):

--- a/tl/llm_tools.py
+++ b/tl/llm_tools.py
@@ -33,6 +33,7 @@ from .provider_settings import (
 )
 from .thought_signature import log_thought_signature_debug
 from .tl_utils import encode_file_to_base64, format_error_message
+from .tool_path_guard import filter_reference_paths
 
 if TYPE_CHECKING:
     from ..main import GeminiImageGenerationPlugin
@@ -91,6 +92,18 @@ def _build_tool_base_properties() -> dict[str, Any]:
             ),
             "default": False,
         },
+        "reference_image_paths": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": (
+                "可选。作为参考图的本地图片路径列表。"
+                "默认白名单模式下，路径必须位于插件配置的允许目录内"
+                "（默认覆盖各系统 AstrBot 数据目录，如 ~/.astrbot/data、/opt/astrbot/data）。"
+                "禁止 .. 穿越。路径不存在、越界、非图片或图片损坏将被静默丢弃并在日志记录。"
+                "典型用途：复用上一次工具调用缓存在 data/temp/tool_images/ 的图片。"
+            ),
+            "default": [],
+        },
     }
 
 
@@ -120,6 +133,8 @@ def _build_tool_description(plugin: Any) -> str:
         "【重要】当当前请求明确要求将生成的图片发到论坛/AstrBook时，设置 for_forum=true。"
         "此时工具会等待图片生成完成后返回图片路径，你需要使用 upload_image 工具将图片上传到论坛图床获取URL，"
         "然后在发帖或回复时使用 Markdown 格式 ![描述](URL) 插入图片。"
+        "【本地路径参考图】如需基于上一轮工具产出的本地图片改图（如 data/temp/tool_images/ 下缓存图），"
+        "用 reference_image_paths 传路径；默认仅允许插件配置的允许目录内文件，禁止 .. 穿越。"
     )
 
 
@@ -685,6 +700,10 @@ class GeminiImageGenerationTool(FunctionTool[AstrAgentContext]):
         resolution = kwargs.get("resolution") or None
         aspect_ratio = kwargs.get("aspect_ratio") or None
         for_forum = kwargs.get("for_forum", False)
+        # 本地路径参考图（独立于 use_reference_images，LLM 显式传路径即生效）
+        raw_ref_paths = kwargs.get("reference_image_paths") or []
+        if isinstance(raw_ref_paths, str):
+            raw_ref_paths = [raw_ref_paths]
 
         # 获取事件上下文
         event = context.context.event
@@ -724,6 +743,26 @@ class GeminiImageGenerationTool(FunctionTool[AstrAgentContext]):
             reference_images = []
         if not include_avatar:
             avatar_reference = []
+
+        # 本地路径参考图：白名单/全局守卫后合并到 reference_images 尾部
+        # 截断由下游 _build_candidate_config per-candidate 完成，这里只保证顺序：
+        # fetch 来的在前（更可信），路径追加在尾，超长时尾部（路径）先被丢。
+        cfg = getattr(plugin, "cfg", None)
+        path_mode = getattr(cfg, "llm_tool_reference_path_mode", "whitelist")
+        allowed_dirs = list(getattr(cfg, "llm_tool_reference_allowed_dirs", []) or [])
+        accepted_paths, rejected_paths = filter_reference_paths(
+            [str(p) for p in raw_ref_paths if isinstance(p, str)],
+            allowed_dirs=allowed_dirs,
+            global_mode=(path_mode == "global"),
+            log_fn=logger.debug,
+        )
+        if rejected_paths:
+            logger.warning(
+                f"[工具调用] reference_image_paths 被拒 {len(rejected_paths)} 条 "
+                f"(mode={path_mode})"
+            )
+        if accepted_paths:
+            reference_images = list(reference_images) + accepted_paths
 
         ref_count = len(reference_images)
         avatar_count = len(avatar_reference)

--- a/tl/llm_tools.py
+++ b/tl/llm_tools.py
@@ -701,7 +701,9 @@ class GeminiImageGenerationTool(FunctionTool[AstrAgentContext]):
         aspect_ratio = kwargs.get("aspect_ratio") or None
         for_forum = kwargs.get("for_forum", False)
         # 本地路径参考图（独立于 use_reference_images，LLM 显式传路径即生效）
-        raw_ref_paths = kwargs.get("reference_image_paths") or []
+        raw_ref_paths = kwargs.get("reference_image_paths")
+        if raw_ref_paths is None:
+            raw_ref_paths = []
         if isinstance(raw_ref_paths, str):
             raw_ref_paths = [raw_ref_paths]
 
@@ -751,7 +753,7 @@ class GeminiImageGenerationTool(FunctionTool[AstrAgentContext]):
         path_mode = getattr(cfg, "llm_tool_reference_path_mode", "whitelist")
         allowed_dirs = list(getattr(cfg, "llm_tool_reference_allowed_dirs", []) or [])
         accepted_paths, rejected_paths = filter_reference_paths(
-            [str(p) for p in raw_ref_paths if isinstance(p, str)],
+            raw_ref_paths,
             allowed_dirs=allowed_dirs,
             global_mode=(path_mode == "global"),
             log_fn=logger.debug,

--- a/tl/plugin_config.py
+++ b/tl/plugin_config.py
@@ -129,6 +129,8 @@ class PluginConfig:
     image_input_mode: str = "force_base64"
     max_inline_image_size_mb: float = 2.0  # 本地图片 base64 编码阈值（MB）
     llm_tool_timeout_reserve_percent: int = 50
+    llm_tool_reference_path_mode: str = "whitelist"  # "whitelist" | "global"
+    llm_tool_reference_allowed_dirs: list[str] = field(default_factory=list)
 
     # 表情包设置
     sticker_grid_rows: int = 4
@@ -607,6 +609,23 @@ class ConfigLoader:
                 config.llm_tool_timeout_reserve_percent = (
                     PluginConfig().llm_tool_timeout_reserve_percent
                 )
+
+        # LLM 工具本地路径参考图：模式与白名单目录
+        ref_path_mode = (
+            str(image_settings.get("llm_tool_reference_path_mode") or "whitelist")
+            .strip()
+            .lower()
+        )
+        config.llm_tool_reference_path_mode = (
+            "global" if ref_path_mode == "global" else "whitelist"
+        )
+        raw_allowed_dirs = image_settings.get("llm_tool_reference_allowed_dirs")
+        if isinstance(raw_allowed_dirs, list):
+            config.llm_tool_reference_allowed_dirs = [
+                item.strip()
+                for item in raw_allowed_dirs
+                if isinstance(item, str) and item.strip()
+            ]
 
         # 表情包网格设置
         grid_raw = str(image_settings.get("sticker_grid") or "4x4").strip()

--- a/tl/tool_path_guard.py
+++ b/tl/tool_path_guard.py
@@ -1,0 +1,209 @@
+"""LLM 工具本地路径参考图的守卫模块。
+
+`gemini_image_generation` 工具的 `reference_image_paths` 参数允许 LLM 提交本地
+文件路径作为参考图。为避免 LLM 读取任意文件（如 `/etc/passwd`、API key），
+默认白名单模式下，路径经规范化后必须落在允许目录内。
+
+安全模型：
+- `raw_has_traversal` 快速预检，拒绝原始串中显式的 `..` 段。
+- `normalize_candidate` 做 expanduser + resolve(strict=False)，跟随符号链接。
+- `is_path_allowed` 用 resolve 后的 `path.parents` 校验是否位于允许目录之下。
+- 图片文件必须通过 Pillow 完整性校验，避免把损坏文件或非图片内容发给供应商。
+- global 模式跳过白名单检查，但仍拒 traversal、不存在文件与无效图片，适用于管理员
+  （权限管控交给 AstrBot webui「插件-管理行为-函数工具」的权限范围）。
+"""
+
+from __future__ import annotations
+
+import os
+import urllib.parse
+import urllib.request
+from collections.abc import Callable, Iterable
+from pathlib import Path
+
+from astrbot.api import logger
+
+# 各系统 AstrBot 数据目录的默认白名单。
+# - Linux/macOS: ~/.astrbot/data
+# - Docker 常见: /opt/astrbot/data、/AstrBot/data、/app/data
+DEFAULT_ALLOWED_DIR_PATTERNS: tuple[str, ...] = (
+    "~/.astrbot/data",
+    "/opt/astrbot/data",
+    "/AstrBot/data",
+    "/app/data",
+)
+
+
+def _log_default(msg: str) -> None:
+    logger.debug(msg)
+
+
+def _resolve_dir(raw: str) -> Path | None:
+    """expanduser + resolve(strict=False)；失败返 None。"""
+    try:
+        return Path(raw).expanduser().resolve(strict=False)
+    except Exception:
+        return None
+
+
+def expand_allowed_dirs(configured: Iterable[str] | None) -> list[Path]:
+    """合并默认目录、ASTRBOT_DATA_PATH 环境变量与用户配置，返回 resolve 后的去重列表。
+
+    默认目录（DEFAULT_ALLOWED_DIR_PATTERNS）即使不存在也保留，以便用户后续创建立即生效；
+    环境变量与用户配置的目录需存在才纳入。
+    """
+    resolved: list[Path] = []
+    seen: set[str] = set()
+
+    def _push(raw: str, *, require_exists: bool) -> None:
+        p = _resolve_dir(raw)
+        if p is None:
+            return
+        if require_exists and not p.exists():
+            return
+        key = str(p)
+        if key not in seen:
+            seen.add(key)
+            resolved.append(p)
+
+    # 1. 默认目录：不要求存在
+    for raw in DEFAULT_ALLOWED_DIR_PATTERNS:
+        _push(raw, require_exists=False)
+
+    # 2. ASTRBOT_DATA_PATH 环境变量（Docker 自定义数据目录）：要求存在
+    env_data_path = os.environ.get("ASTRBOT_DATA_PATH")
+    if env_data_path and env_data_path.strip():
+        _push(env_data_path.strip(), require_exists=True)
+
+    # 3. 用户配置目录：要求存在
+    if configured:
+        for item in configured:
+            if isinstance(item, str) and item.strip():
+                _push(item.strip(), require_exists=True)
+
+    return resolved
+
+
+def raw_has_traversal(raw: str) -> bool:
+    """快速预检：按 sep/os.altsep 分段，过滤空段后任一段为 '..' 即 True。
+
+    os.altsep 为 None 时仅用 os.sep。最终安全由 resolve + is_path_allowed 保证。
+    """
+    if not raw:
+        return False
+    # 统一处理 POSIX 与 Windows 分隔符：backslash 转 / 后按 / 拆分；os.altsep 在
+    # Windows 上是 /，已覆盖。最终安全由 resolve + is_path_allowed 保证。
+    raw = urllib.parse.unquote(raw)
+    segments: list[str] = []
+    for seg in raw.replace("\\", "/").split("/"):
+        if seg:
+            segments.append(seg)
+    return any(seg == ".." for seg in segments)
+
+
+def normalize_candidate(raw: str) -> Path | None:
+    """strip 引号/空白 → expanduser → resolve(strict=False)。失败返 None。"""
+    cleaned = raw.strip().strip("\"'")
+    if not cleaned:
+        return None
+    if cleaned.startswith("file://"):
+        parsed = urllib.parse.urlparse(cleaned)
+        cleaned = urllib.request.url2pathname(parsed.path)
+    try:
+        return Path(cleaned).expanduser().resolve(strict=False)
+    except Exception:
+        return None
+
+
+def is_path_allowed(path: Path, allowed_resolved: list[Path]) -> bool:
+    """path 必须等于或位于某个 allowed 之下（用 path.parents 检查）。"""
+    if not allowed_resolved:
+        return False
+    for allowed in allowed_resolved:
+        if path == allowed or allowed in path.parents:
+            return True
+    return False
+
+
+def is_supported_image_file(path: Path) -> bool:
+    """只放行可作为参考图处理的完整图片文件。"""
+    try:
+        from PIL import Image as PILImage
+    except ImportError:
+        return False
+
+    try:
+        with PILImage.open(path) as image:
+            image.verify()
+        return True
+    except Exception:
+        return False
+
+
+def _path_to_reference_uri(path: Path) -> str:
+    """返回规范化 file:// URI，让下游走参考图校验/转换分支。"""
+    try:
+        return path.as_uri()
+    except ValueError:
+        return str(path)
+
+
+def filter_reference_paths(
+    raw_paths: list[str],
+    *,
+    allowed_dirs: list[str],
+    global_mode: bool,
+    log_fn: Callable[[str], None] | None = None,
+) -> tuple[list[str], list[str]]:
+    """过滤 LLM 提交的本地路径参考图。
+
+    Args:
+        raw_paths: LLM 提交的原始路径字符串列表。
+        allowed_dirs: 用户配置 + 默认的允许目录（未 resolve 的原始串）。
+        global_mode: True 时跳过白名单检查（仍拒 traversal、不存在与无效图片）。
+        log_fn: 日志回调，默认 logger.debug。
+
+    Returns:
+        (accepted_paths, rejected_raw)：接受的规范化 file:// 路径列表与被拒原始串列表。
+        接受项交给下游 _process_reference_image 继续做参考图转换。
+    """
+    log = log_fn or _log_default
+    allowed_resolved = [] if global_mode else expand_allowed_dirs(allowed_dirs)
+
+    accepted: list[str] = []
+    rejected: list[str] = []
+
+    for raw in raw_paths:
+        if not isinstance(raw, str) or not raw.strip():
+            rejected.append(str(raw) if raw else "")
+            continue
+
+        if raw_has_traversal(raw):
+            log(f"[path_guard] 拒绝路径含 '..' 穿越: {raw[:80]}")
+            rejected.append(raw)
+            continue
+
+        path = normalize_candidate(raw)
+        if path is None:
+            log(f"[path_guard] 拒绝路径规范化失败: {raw[:80]}")
+            rejected.append(raw)
+            continue
+
+        if not path.exists() or not path.is_file():
+            log(f"[path_guard] 拒绝路径不存在或非文件: {raw[:80]}")
+            rejected.append(raw)
+            continue
+
+        if not is_supported_image_file(path):
+            log(f"[path_guard] 拒绝非图片文件: {raw[:80]}")
+            rejected.append(raw)
+            continue
+
+        if not global_mode and not is_path_allowed(path, allowed_resolved):
+            log(f"[path_guard] 拒绝路径越出白名单: {raw[:80]}")
+            rejected.append(raw)
+            continue
+
+        accepted.append(_path_to_reference_uri(path))
+
+    return accepted, rejected

--- a/tl/tool_path_guard.py
+++ b/tl/tool_path_guard.py
@@ -20,6 +20,7 @@ import urllib.parse
 import urllib.request
 from collections.abc import Callable, Iterable
 from pathlib import Path
+from typing import Any
 
 from astrbot.api import logger
 
@@ -129,6 +130,15 @@ def is_supported_image_file(path: Path) -> bool:
     """只放行可作为参考图处理的完整图片文件。"""
     try:
         from PIL import Image as PILImage
+
+        try:
+            from pillow_heif import register_heif_opener
+
+            register_heif_opener()
+        except ImportError:
+            pass
+        except Exception as exc:
+            logger.debug(f"[path_guard] 注册 HEIF/HEIC opener 失败: {exc}")
     except ImportError:
         return False
 
@@ -149,7 +159,7 @@ def _path_to_reference_uri(path: Path) -> str:
 
 
 def filter_reference_paths(
-    raw_paths: list[str],
+    raw_paths: Any,
     *,
     allowed_dirs: list[str],
     global_mode: bool,
@@ -158,7 +168,7 @@ def filter_reference_paths(
     """过滤 LLM 提交的本地路径参考图。
 
     Args:
-        raw_paths: LLM 提交的原始路径字符串列表。
+        raw_paths: LLM 提交的原始路径字符串列表；异常形态会统一拒绝并记录。
         allowed_dirs: 用户配置 + 默认的允许目录（未 resolve 的原始串）。
         global_mode: True 时跳过白名单检查（仍拒 traversal、不存在与无效图片）。
         log_fn: 日志回调，默认 logger.debug。
@@ -173,9 +183,24 @@ def filter_reference_paths(
     accepted: list[str] = []
     rejected: list[str] = []
 
-    for raw in raw_paths:
-        if not isinstance(raw, str) or not raw.strip():
-            rejected.append(str(raw) if raw else "")
+    if raw_paths is None:
+        iterable_paths: Iterable[Any] = []
+    elif isinstance(raw_paths, str):
+        iterable_paths = [raw_paths]
+    elif isinstance(raw_paths, (list, tuple)):
+        iterable_paths = raw_paths
+    else:
+        log(f"[path_guard] 拒绝非列表路径参数: {type(raw_paths).__name__}")
+        return [], [str(raw_paths)]
+
+    for raw in iterable_paths:
+        if not isinstance(raw, str):
+            log(f"[path_guard] 拒绝非字符串路径: {type(raw).__name__}")
+            rejected.append(str(raw))
+            continue
+        if not raw.strip():
+            log("[path_guard] 拒绝空路径")
+            rejected.append("")
             continue
 
         if raw_has_traversal(raw):
@@ -194,13 +219,13 @@ def filter_reference_paths(
             rejected.append(raw)
             continue
 
-        if not is_supported_image_file(path):
-            log(f"[path_guard] 拒绝非图片文件: {raw[:80]}")
+        if not global_mode and not is_path_allowed(path, allowed_resolved):
+            log(f"[path_guard] 拒绝路径越出白名单: {raw[:80]}")
             rejected.append(raw)
             continue
 
-        if not global_mode and not is_path_allowed(path, allowed_resolved):
-            log(f"[path_guard] 拒绝路径越出白名单: {raw[:80]}")
+        if not is_supported_image_file(path):
+            log(f"[path_guard] 拒绝非图片文件: {raw[:80]}")
             rejected.append(raw)
             continue
 

--- a/tl/tool_permission.py
+++ b/tl/tool_permission.py
@@ -1,0 +1,70 @@
+"""AstrBot 函数工具权限兼容辅助。"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from astrbot.api import logger
+
+
+TOOL_PERMISSION_SCOPE = "global"
+TOOL_PERMISSION_SCOPE_ID = "global"
+TOOL_PERMISSION_KEY = "tool_permissions"
+
+
+def ensure_admin_default_tool_permission(
+    tool_name: str,
+    *,
+    sp_obj: Any | None = None,
+) -> bool:
+    """在支持的 AstrBot 版本上，为非内置工具写入默认 admin 权限。
+
+    只在该工具没有显式权限配置时写入，避免覆盖管理员在 WebUI 的手动选择。
+    返回 True 表示本次写入了默认权限。
+    """
+    if not tool_name:
+        return False
+
+    if sp_obj is None:
+        try:
+            from astrbot.core import sp as sp_obj
+        except Exception as exc:
+            logger.warning(
+                "当前 AstrBot 版本不支持函数工具权限自动配置；"
+                f"无法将 {tool_name} 默认设为管理员可用: {exc}"
+            )
+            return False
+
+    try:
+        perms_store = sp_obj.get(
+            TOOL_PERMISSION_KEY,
+            {},
+            scope=TOOL_PERMISSION_SCOPE,
+            scope_id=TOOL_PERMISSION_SCOPE_ID,
+        )
+        if not isinstance(perms_store, dict):
+            perms_store = {}
+
+        defaults = perms_store.get("_default", {})
+        if not isinstance(defaults, dict):
+            defaults = {}
+
+        if tool_name in defaults:
+            logger.debug(
+                f"函数工具 {tool_name} 已有显式权限配置：{defaults[tool_name]}"
+            )
+            return False
+
+        defaults[tool_name] = "admin"
+        perms_store["_default"] = defaults
+        sp_obj.put(
+            TOOL_PERMISSION_KEY,
+            perms_store,
+            scope=TOOL_PERMISSION_SCOPE,
+            scope_id=TOOL_PERMISSION_SCOPE_ID,
+        )
+        logger.info(f"已将函数工具 {tool_name} 默认权限设置为管理员")
+        return True
+    except Exception as exc:
+        logger.warning(f"设置函数工具 {tool_name} 默认权限失败: {exc}")
+        return False

--- a/tl/tool_permission.py
+++ b/tl/tool_permission.py
@@ -6,7 +6,6 @@ from typing import Any
 
 from astrbot.api import logger
 
-
 TOOL_PERMISSION_SCOPE = "global"
 TOOL_PERMISSION_SCOPE_ID = "global"
 TOOL_PERMISSION_KEY = "tool_permissions"


### PR DESCRIPTION
## 改动说明

- gemini_image_generation 工具新增 reference_image_paths 参数，LLM 可提交本地图片路径作为参考图
- 新增 tl/tool_path_guard.py 路径白名单守卫，默认覆盖各系统 AstrBot 数据目录，拒绝 .. 穿越
- 新增 llm_tool_reference_path_mode（whitelist/global）与 llm_tool_reference_allowed_dirs 配置
- global 模式下通过 tl/tool_permission.py 自动将工具权限设为管理员
- provider_polling 配置项新增 options 预制供应商列表
- 版本号 v2.1.0 → v2.2.0


## 改动类型

- [ ] Bug 修复
- [x] 新功能
- [ ] 重构 / 代码优化
- [ ] 文档更新
- [ ] 其他

## 关联 Issue

Closes #86 

## 测试情况

- [x] 本地测试通过
- [x] 已测试相关命令（/生图、/改图、/快速 等）
- [x] 已测试 LLM 工具调用

## 补充说明

<!-- 需要 reviewer 特别关注的点、兼容性说明等 -->

## Summary by Sourcery

为 LLM 的参考图像添加本地图像文件路径支持，提供可配置的路径保护与权限控制，并将插件版本升级到 v2.2.0。

New Features:
- 允许 `gemini_image_generation` LLM 工具在拉取参考图像的同时接受本地 `reference_image_paths`。
- 引入路径保护模块，对本地参考图像路径执行白名单和目录遍历检查，并支持可配置的模式和允许的目录。
- 在兼容的 AstrBot 版本上，当使用全局路径模式时，自动将 Gemini 图像生成工具的默认权限设置为管理员（admin）。

Enhancements:
- 扩展插件配置和文档，涵盖本地参考路径模式、允许的目录以及 `provider_polling` 预设选项。
- 更新插件版本元数据和 README 徽章至 v2.2.0。

Tests:
- 为路径保护逻辑、LLM 工具中 `reference_image_paths` 的集成，以及工具权限自动默认设置添加单元测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for using local image file paths as LLM reference images with configurable path guards and permissions, and bump the plugin version to v2.2.0.

New Features:
- Allow the gemini_image_generation LLM tool to accept local reference_image_paths alongside fetched reference images.
- Introduce a path guard module enforcing whitelist and traversal checks for local reference image paths, with configurable modes and allowed directories.
- Automatically set the Gemini image generation tool’s default permission to admin when using global path mode on compatible AstrBot versions.

Enhancements:
- Extend plugin configuration and documentation to cover local reference path modes, allowed directories, and provider_polling preset options.
- Update the plugin version metadata and README badge to v2.2.0.

Tests:
- Add unit tests for the path guard logic, reference_image_paths integration in the LLM tool, and automatic tool permission defaults.

</details>