### PR TITLE
feat: 支持 QQ 官方机器人头像获取

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## [Unreleased]
 
+## [2.4.1] - 2026-08-01
+
+### Added
+
+- 支持 QQ 官方机器人 WebSocket 事件通过 bot client appid 与用户 openid 获取头像，并在元数据中声明对应平台支持；代码兼容但不声明未经实机验证的 Webhook 路径。
+
 ## [2.4.0] - 2026-07-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-![Version](https://img.shields.io/badge/Version-v2.4.0-blue)
+![Version](https://img.shields.io/badge/Version-v2.4.1-blue)
 ![License](https://img.shields.io/badge/License-AGPL--3.0-orange)
 
 **强大的 AstrBot 图像生成插件，支持生图、改图、头像参考、表情包切分和 LLM 工具调用。**
@@ -29,6 +29,10 @@
 - AstrBot 4.10+
 - Python 3.10+
 - NapCat（目前主要适配 NapCat 平台）
+- QQ 官方机器人 WebSocket（`qq_official`，头像参考已通过真实实例验证）
+
+> [!WARNING]
+> 代码同时兼容 QQ 官方机器人 Webhook（`qq_official_webhook`）的头像获取结构，但目前没有真实 Webhook 实例可供验证，因此不在插件元数据中声明支持，也不保证一定可用。
 
 ### 安装方式
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,9 +1,10 @@
 name: astrbot_plugin_gemini_image_generation
 desc: Gemini图像生成插件，支持生图和改图，支持自动获取头像作为参考
 display_name: Gemini 图像生成
-version: v2.4.0
+version: v2.4.1
 author: piexian
 repo: https://github.com/piexian/astrbot_plugin_gemini_image_generation
 astrbot_version: ">=4.10.4"
 support_platforms:
   - aiocqhttp
+  - qq_official

--- a/tests/test_qq_official_avatar.py
+++ b/tests/test_qq_official_avatar.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import base64
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import yaml
+
+
+def _load_tl_utils(monkeypatch: pytest.MonkeyPatch):
+    root = Path(__file__).resolve().parents[1]
+    module_name = "tl._qq_official_avatar_tl_utils"
+    spec = importlib.util.spec_from_file_location(
+        module_name,
+        root / "tl" / "tl_utils.py",
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, module_name, module)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _Response:
+    status = 200
+    reason = "OK"
+    headers = {"Content-Type": "image/jpeg"}
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def read(self) -> bytes:
+        return b"\xff\xd8\xff" + b"avatar" * 200
+
+
+class _Session:
+    def __init__(self) -> None:
+        self.url: str | None = None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def get(self, url: str, **kwargs):
+        self.url = url
+        return _Response()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "platform_name",
+    ["qq_official", "qq_official_webhook"],
+)
+async def test_download_qq_official_avatar_uses_appid_and_openid(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    platform_name: str,
+) -> None:
+    module = _load_tl_utils(monkeypatch)
+    session = _Session()
+    monkeypatch.setattr(module.aiohttp, "ClientSession", lambda: session)
+
+    event = SimpleNamespace(
+        message_obj=SimpleNamespace(raw_message=None, sender=None),
+        bot=SimpleNamespace(platform=SimpleNamespace(appid="1234567890")),
+        get_platform_name=lambda: platform_name,
+    )
+    openid = "openid_abcdefghijklmnopqrstuvwxyz"
+
+    result = await module.download_qq_avatar(
+        openid,
+        "official-avatar",
+        images_dir=tmp_path,
+        event=event,
+    )
+
+    assert session.url == (f"https://q.qlogo.cn/qqapp/1234567890/{openid}/100")
+    assert result is not None
+    assert base64.b64decode(result.split(",", 1)[1]).startswith(b"\xff\xd8\xff")
+
+
+def test_qq_official_avatar_url_ignores_other_platforms(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_tl_utils(monkeypatch)
+    event = SimpleNamespace(
+        bot=SimpleNamespace(platform=SimpleNamespace(appid="1234567890")),
+        get_platform_name=lambda: "aiocqhttp",
+    )
+
+    assert module._build_qq_official_avatar_url(event, "123456789") is None
+
+
+def test_metadata_only_declares_tested_qq_official_transport() -> None:
+    root = Path(__file__).resolve().parents[1]
+    metadata = yaml.safe_load((root / "metadata.yaml").read_text(encoding="utf-8"))
+
+    assert "qq_official" in metadata["support_platforms"]
+    assert "qq_official_webhook" not in metadata["support_platforms"]

--- a/tl/tl_utils.py
+++ b/tl/tl_utils.py
@@ -120,6 +120,33 @@ def _pick_avatar_url(data: dict | None) -> str | None:
     return None
 
 
+_QQ_OFFICIAL_PLATFORMS = {"qq_official", "qq_official_webhook"}
+
+
+def _build_qq_official_avatar_url(event, user_id: str) -> str | None:
+    """Build the QQ Official avatar URL from the bot appid and user openid."""
+    try:
+        platform_name = str(event.get_platform_name() or "").strip()
+    except Exception:
+        platform_name = str(
+            getattr(getattr(event, "platform_meta", None), "name", "") or ""
+        ).strip()
+    if platform_name not in _QQ_OFFICIAL_PLATFORMS:
+        return None
+
+    bot = getattr(event, "bot", None) or getattr(event, "_bot", None)
+    appid = str(getattr(getattr(bot, "platform", None), "appid", "") or "").strip()
+    openid = str(user_id or "").strip()
+    if not appid or not openid:
+        return None
+
+    return (
+        "https://q.qlogo.cn/qqapp/"
+        f"{urllib.parse.quote(appid, safe='')}/"
+        f"{urllib.parse.quote(openid, safe='')}/100"
+    )
+
+
 def _encode_file_to_base64(file_path: Path, chunk_size: int = 65536) -> str:
     """流式编码文件为base64
     注意: chunk_size 必须是 3 的倍数，否则 base64 编码会出错
@@ -485,7 +512,13 @@ async def download_qq_avatar(
         except Exception:
             pass
 
-        # 3. NapCat / OneBot API
+        # 3. QQ 官方 API：从 bot client 读取 appid，并与用户 openid 构造直链。
+        url = _build_qq_official_avatar_url(event, user_id)
+        if url:
+            logger.debug("已构造 QQ 官方用户头像 URL")
+            return url
+
+        # 4. NapCat / OneBot API
         bot = getattr(event, "bot", None) or getattr(event, "_bot", None)
         if bot:
             group_id = None
@@ -554,7 +587,7 @@ async def download_qq_avatar(
             # 回退使用 qlogo 直链（使用 HTTP 协议，更稳定）
             avatar_url = f"http://q4.qlogo.cn/headimg_dl?dst_uin={user_id}&spec=640"
             logger.debug(f"未从事件获取头像URL，回退 qlogo: {avatar_url}")
-        else:
+        elif not avatar_url.startswith("https://q.qlogo.cn/qqapp/"):
             # 将获取到的 URL 转为 HTTP 协议
             avatar_url = avatar_url.replace("https://", "http://")
 


### PR DESCRIPTION
## 改动说明

支持 QQ 官方机器人头像获取

## 改动类型

- [ ] Bug 修复
- [x] 新功能
- [ ] 重构 / 代码优化
- [ ] 文档更新
- [ ] 其他

## 关联 Issue

<!-- 如有关联 Issue 请填写，例如 Fixes #123 -->

## 测试情况

- [x] 本地测试通过
- [x] 已测试相关命令（/生图、/改图、/快速 等）
- [x] 已测试 LLM 工具调用

## 补充说明

<!-- 需要 reviewer 特别关注的点、兼容性说明等 -->

## Summary by Sourcery

为获取 QQ 官方机器人用户头像添加支持，并发布包含更新平台元数据的 2.4.1 版本。

新特性：
- 支持在兼容的传输方式中，使用机器人 `appid` 和用户 `openid` 构造 QQ 官方机器人用户头像 URL。

增强优化：
- 调整头像 URL 回退逻辑，在保持 QQ 官方 `qlogo` 头像为 HTTPS 链接的同时，将其他头像 URL 降级为 HTTP 以提升稳定性。

文档：
- 更新变更日志、README 版本徽章以及支持的平台文档，描述 QQ 官方 WebSocket 头像支持情况，并澄清 Webhook 的兼容状态。

测试：
- 添加测试，用于覆盖 QQ 官方头像 URL 在 WebSocket 和 Webhook 传输下的构造逻辑、平台过滤行为以及元数据中的平台声明。

杂项：
- 将插件版本提升至 v2.4.1，并在元数据中声明 `qq_official` 为受支持平台。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for fetching QQ Official bot user avatars and release version 2.4.1 with updated platform metadata.

New Features:
- Support constructing QQ Official bot user avatar URLs using bot appid and user openid for compatible transports.

Enhancements:
- Adjust avatar URL fallback logic to preserve QQ Official qlogo HTTPS URLs while still downgrading other avatar URLs to HTTP for stability.

Documentation:
- Update changelog, README version badge, and supported platform documentation to describe QQ Official WebSocket avatar support and clarify Webhook compatibility status.

Tests:
- Add tests covering QQ Official avatar URL construction for WebSocket and Webhook transports, platform filtering behavior, and metadata platform declarations.

Chores:
- Bump plugin version to v2.4.1 and declare qq_official as a supported platform in metadata.

</details>