### PR TITLE
feat(agnes_ai): 适配 agnes-image-2.5-flash，尺寸走档位+ratio 原生输出

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 > **升级提示**：v1.9.0 以后的配置文件格式不兼容旧版本。升级后如遇配置模板显示错误，请查看 [配置迁移说明](https://github.com/piexian/astrbot_plugin_gemini_image_generation/blob/master/docs/troubleshooting.md#配置迁移说明)。
 
+## [2.7.6] - 2026-09-01
+
+### Added
+
+- **Agnes AI 适配 `agnes-image-2.5-flash` 并设为默认**：尺寸改走官方档位式 `size`（1K/2K/3K/4K，新增 3K）+ 顶层 `ratio` 原生输出；非白名单比例或显式像素尺寸回退本地精确尺寸，旧配置行为不变。
+
+### Changed
+
+- **`xai` / `minimax` / `stepfun` 模板 `model` 字段解锁为自由填写**；`dashscope` / `sensenova` 模型分层需代码适配，保持下拉。
+
 ## [2.7.5] - 2026-08-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-![Version](https://img.shields.io/badge/Version-v2.7.5-blue)
+![Version](https://img.shields.io/badge/Version-v2.7.6-blue)
 ![License](https://img.shields.io/badge/License-AGPL--3.0-orange)
 
 **强大的 AstrBot 图像生成插件，支持生图、改图、头像参考、表情包切分和 LLM 工具调用。**

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -437,8 +437,8 @@
               "model": {
                 "description": "模型名称",
                 "type": "string",
-                "hint": "Agnes AI 图片模型名称，支持 agnes-image-2.0-flash / agnes-image-2.1-flash",
-                "default": "agnes-image-2.1-flash"
+                "hint": "Agnes AI 图片模型名称，支持 agnes-image-2.5-flash / agnes-image-2.1-flash",
+                "default": "agnes-image-2.5-flash"
               },
               "api_base": {
                 "description": "API 端点地址",
@@ -460,6 +460,7 @@
                 "options": [
                   "1K",
                   "2K",
+                  "3K",
                   "4K"
                 ]
               },
@@ -548,10 +549,7 @@
                 "description": "模型名称",
                 "type": "string",
                 "hint": "grok-imagine-image-2.0（当前模型，quality 仅 low/medium）；旧模型名仍可手填但可能已被官方退役",
-                "default": "grok-imagine-image-2.0",
-                "options": [
-                  "grok-imagine-image-2.0"
-                ]
+                "default": "grok-imagine-image-2.0"
               },
               "api_base": {
                 "description": "API 端点地址",
@@ -671,11 +669,7 @@
                 "description": "模型名称",
                 "type": "string",
                 "hint": "image-01（全能力，支持 21:9 与显式宽高）；image-01-live（快速，仅 aspect_ratio，不支持 21:9）",
-                "default": "image-01",
-                "options": [
-                  "image-01",
-                  "image-01-live"
-                ]
+                "default": "image-01"
               },
               "api_base": {
                 "description": "API 端点地址",
@@ -851,11 +845,7 @@
                 "description": "模型名称",
                 "type": "string",
                 "hint": "step-image-edit-2（推荐，文生图+编辑）；step-2x-large（快速文生图，不支持编辑/负向提示词/text_mode）",
-                "default": "step-image-edit-2",
-                "options": [
-                  "step-image-edit-2",
-                  "step-2x-large"
-                ]
+                "default": "step-image-edit-2"
               },
               "api_base": {
                 "description": "API 端点地址",

--- a/docs/config.md
+++ b/docs/config.md
@@ -271,7 +271,7 @@ WebUI 中切换为 `size_mode=custom` 后，`resolution` 和 `aspect_ratio` 会�
 |--------|--------|------|
 | `api_keys` | `[]` | Agnes AI API Key 列表，支持多 Key 轮换 |
 | `daily_limit_per_key` | `0` | 每个 Key 每日调用上限，`0` 表示不限制 |
-| `model` | `agnes-image-2.1-flash` | Agnes AI 图片模型，可填写 `agnes-image-2.0-flash` / `agnes-image-2.1-flash` |
+| `model` | `agnes-image-2.5-flash` | Agnes AI 图片模型，可填写 `agnes-image-2.5-flash` / `agnes-image-2.1-flash` |
 | `api_base` | `https://apihub.agnes-ai.com` | API 端点地址，插件会统一调用 `/v1/images/generations` |
 | `response_format` | `url` | 响应格式：`url` / `b64_json` |
 | `reference_image_mode` | `base64` | 参考图传递方式：`base64` / `auto` / `url` |
@@ -281,6 +281,7 @@ WebUI 中切换为 `size_mode=custom` 后，`resolution` 和 `aspect_ratio` 会�
 
 - 文生图：`POST /v1/images/generations`
 - 图生图：同一端点，通过 `extra_body.image` 传入参考图 URL 或 data URI
+- 尺寸：默认下发档位 `size`（`1K`/`2K`/`3K`/`4K`）+ 顶层 `ratio` 获得原生分辨率；`ratio` 官方白名单为 `1:1`/`3:4`/`4:3`/`16:9`/`9:16`/`2:3`/`3:2`/`21:9`，非白名单比例或显式像素尺寸时回退为本地计算的精确尺寸
 
 当 `response_format=b64_json` 且没有参考图时，插件会按 Agnes AI 文生图格式发送 `return_base64=true`；带参考图时会在 `extra_body.response_format` 中请求 `b64_json`。默认 `reference_image_mode=base64` 会把本地图片和 URL 参考图统一转成 data URI；如确认参考图是公开可访问 URL，可改为 `auto` 或 `url`。
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,7 +1,7 @@
 name: astrbot_plugin_gemini_image_generation
 desc: Gemini图像生成插件，支持生图和改图，支持自动获取头像作为参考
 display_name: Gemini 图像生成
-version: v2.7.5
+version: v2.7.6
 author: piexian
 repo: https://github.com/piexian/astrbot_plugin_gemini_image_generation
 astrbot_version: ">=4.10.4"

--- a/tests/test_agnes_ai_provider.py
+++ b/tests/test_agnes_ai_provider.py
@@ -50,7 +50,8 @@ async def test_agnes_ai_text_to_image_url_payload() -> None:
     assert request.payload == {
         "model": "agnes-image-2.1-flash",
         "prompt": "draw a cat",
-        "size": "1024x768",
+        "size": "1K",
+        "ratio": "4:3",
         "extra_body": {"response_format": "url"},
     }
 
@@ -147,6 +148,7 @@ async def test_agnes_ai_text_to_image_b64_uses_return_base64() -> None:
 
     assert request.payload["model"] == "agnes-image-2.0-flash"
     assert request.payload["size"] == "1024x768"
+    assert "ratio" not in request.payload
     assert request.payload["return_base64"] is True
     assert "extra_body" not in request.payload
     assert "response_format" not in request.payload
@@ -176,7 +178,8 @@ async def test_agnes_ai_reference_payload_uses_extra_body_image() -> None:
 
     assert client.normalized == [("/tmp/ref.png", "force_base64")]
     assert request.payload["model"] == "agnes-image-2.0-flash"
-    assert request.payload["size"] == "1024x1024"
+    assert request.payload["size"] == "1K"
+    assert request.payload["ratio"] == "1:1"
     assert request.payload["extra_body"] == {
         "image": ["data:image/png;base64,BASE64DATA"],
         "response_format": "b64_json",
@@ -204,6 +207,7 @@ async def test_agnes_ai_reference_payload_omits_size_when_suppressed() -> None:
     request = await provider.build_request(client=client, config=config)
 
     assert "size" not in request.payload
+    assert "ratio" not in request.payload
     assert request.payload["extra_body"] == {
         "image": ["data:image/png;base64,BASE64DATA"],
         "response_format": "url",
@@ -269,3 +273,77 @@ async def test_agnes_ai_parse_b64_response(monkeypatch: pytest.MonkeyPatch) -> N
     assert image_paths == ["/tmp/generated.png"]
     assert text_content is None
     assert thought_signature is None
+
+
+@pytest.mark.asyncio
+async def test_agnes_ai_default_model_is_25_flash() -> None:
+    provider = AgnesAIProvider()
+    config = ApiRequestConfig(
+        model="",
+        prompt="draw a cat",
+        api_type="agnes_ai",
+        api_key="test-key",
+        resolution="1K",
+        provider_settings={"response_format": "url"},
+    )
+
+    request = await provider.build_request(client=_FakeClient(), config=config)
+
+    assert request.payload["model"] == "agnes-image-2.5-flash"
+
+
+@pytest.mark.asyncio
+async def test_agnes_ai_3k_tier_and_wide_ratio_passthrough() -> None:
+    provider = AgnesAIProvider()
+    config = ApiRequestConfig(
+        model="agnes-image-2.5-flash",
+        prompt="draw a cat",
+        api_type="agnes_ai",
+        api_key="test-key",
+        resolution="3K",
+        aspect_ratio="21:9",
+        provider_settings={"response_format": "url"},
+    )
+
+    request = await provider.build_request(client=_FakeClient(), config=config)
+
+    assert request.payload["size"] == "3K"
+    assert request.payload["ratio"] == "21:9"
+
+
+@pytest.mark.asyncio
+async def test_agnes_ai_non_whitelisted_ratio_falls_back_to_pixels() -> None:
+    provider = AgnesAIProvider()
+    config = ApiRequestConfig(
+        model="agnes-image-2.5-flash",
+        prompt="draw a cat",
+        api_type="agnes_ai",
+        api_key="test-key",
+        resolution="1K",
+        aspect_ratio="4:5",
+        provider_settings={"response_format": "url"},
+    )
+
+    request = await provider.build_request(client=_FakeClient(), config=config)
+
+    assert request.payload["size"] == "816x1024"
+    assert "ratio" not in request.payload
+
+
+@pytest.mark.asyncio
+async def test_agnes_ai_unknown_resolution_falls_back_to_1k_tier() -> None:
+    provider = AgnesAIProvider()
+    config = ApiRequestConfig(
+        model="agnes-image-2.5-flash",
+        prompt="draw a cat",
+        api_type="agnes_ai",
+        api_key="test-key",
+        resolution="8K",
+        aspect_ratio="16:9",
+        provider_settings={"response_format": "url"},
+    )
+
+    request = await provider.build_request(client=_FakeClient(), config=config)
+
+    assert request.payload["size"] == "1K"
+    assert request.payload["ratio"] == "16:9"

--- a/tests/test_plugin_config_openai_images.py
+++ b/tests/test_plugin_config_openai_images.py
@@ -495,7 +495,7 @@ def test_schema_contains_agnes_ai_template() -> None:
         "agnes_ai"
     ]
 
-    assert template["items"]["model"]["default"] == "agnes-image-2.1-flash"
+    assert template["items"]["model"]["default"] == "agnes-image-2.5-flash"
     assert template["items"]["api_base"]["default"] == "https://apihub.agnes-ai.com"
     assert template["items"]["response_format"]["options"] == ["url", "b64_json"]
     assert template["items"]["reference_image_mode"]["default"] == "base64"

--- a/tests/test_provider_capabilities.py
+++ b/tests/test_provider_capabilities.py
@@ -223,3 +223,8 @@ def test_dashscope_zimage_omits_watermark_capability() -> None:
 
     candidates = [_candidate("dashscope", "z-image-turbo")]
     assert select_candidates(candidates, required_parameters={"watermark"}) == []
+
+
+def test_agnes_ai_capability_declares_3k_resolution() -> None:
+    cap = candidate_capability(_candidate("agnes_ai", "agnes-image-2.5-flash"))
+    assert cap["parameters"]["resolution"]["enum"] == ["1K", "2K", "3K", "4K"]

--- a/tl/api/agnes_ai.py
+++ b/tl/api/agnes_ai.py
@@ -15,10 +15,15 @@ from .base import ProviderRequest
 from .data_uri import format_data_uri
 
 _DEFAULT_API_BASE = "https://apihub.agnes-ai.com"
-_DEFAULT_MODEL = "agnes-image-2.1-flash"
+_DEFAULT_MODEL = "agnes-image-2.5-flash"
 _SUPPORTED_RESPONSE_FORMATS: frozenset[str] = frozenset({"url", "b64_json"})
 _REFERENCE_IMAGE_MODES: frozenset[str] = frozenset({"auto", "base64", "url"})
-_RESOLUTION_MAP: dict[str, int] = {"1K": 1024, "2K": 2048, "4K": 3840}
+_SUPPORTED_SIZES: frozenset[str] = frozenset({"1K", "2K", "3K", "4K"})
+_SUPPORTED_RATIOS: frozenset[str] = frozenset(
+    {"1:1", "3:4", "4:3", "16:9", "9:16", "2:3", "3:2", "21:9"}
+)
+# 档位不可用（非白名单比例/显式像素尺寸）时的本地像素回退：长边=档位像素并按 16 对齐
+_RESOLUTION_MAP: dict[str, int] = {"1K": 1024, "2K": 2048, "3K": 3072, "4K": 3840}
 _SIZE_RE = re.compile(r"^\s*(\d{2,5})\s*[xX×]\s*(\d{2,5})\s*$")
 
 
@@ -171,10 +176,13 @@ class AgnesAIProvider:
             "prompt": config.prompt,
         }
         if not config.suppress_resolution:
-            payload["size"] = self._resolve_size(
+            size, ratio = self._resolve_size_and_ratio(
                 settings.get("size") or config.resolution,
                 config.aspect_ratio or settings.get("aspect_ratio"),
             )
+            payload["size"] = size
+            if ratio:
+                payload["ratio"] = ratio
 
         response_format = self._normalize_response_format(
             settings.get("response_format")
@@ -282,25 +290,47 @@ class AgnesAIProvider:
         return "base64"
 
     @staticmethod
-    def _resolve_size(resolution: Any, aspect_ratio: Any) -> str:
-        size = AgnesAIProvider._normalize_explicit_size(resolution)
-        if size:
-            return size
+    def _resolve_size_and_ratio(
+        resolution: Any, aspect_ratio: Any
+    ) -> tuple[str, str | None]:
+        explicit = AgnesAIProvider._normalize_explicit_size(resolution)
+        if explicit:
+            return explicit, None
 
-        resolution_key = str(resolution or "1K").strip().upper()
-        long_edge = _RESOLUTION_MAP.get(resolution_key)
-        if long_edge is None:
-            if resolution_key:
+        size = str(resolution or "1K").strip().upper()
+        if size not in _SUPPORTED_SIZES:
+            if size:
                 logger.warning(f"[agnes_ai] 未知 resolution={resolution}，已回退为 1K")
-            long_edge = _RESOLUTION_MAP["1K"]
+            size = "1K"
 
-        ratio = AgnesAIProvider._parse_ratio(aspect_ratio or "1:1")
+        ratio = AgnesAIProvider._parse_ratio(aspect_ratio)
         if ratio is None:
-            logger.warning(
-                f"[agnes_ai] 无法解析 aspect_ratio={aspect_ratio}，已回退为 1:1"
-            )
+            if aspect_ratio:
+                logger.warning(
+                    f"[agnes_ai] 无法解析 aspect_ratio={aspect_ratio}，已回退为 1:1"
+                )
             ratio = (1.0, 1.0)
-        width, height = AgnesAIProvider._compute_dimensions(ratio, long_edge)
+        canonical = AgnesAIProvider._format_ratio(ratio)
+        if canonical in _SUPPORTED_RATIOS:
+            return size, canonical
+
+        logger.warning(
+            f"[agnes_ai] ratio={canonical} 不在官方白名单，已回退为本地像素计算"
+        )
+        return AgnesAIProvider._fallback_pixel_size(size, ratio), None
+
+    @staticmethod
+    def _format_ratio(ratio: tuple[float, float]) -> str:
+        def _fmt(value: float) -> str:
+            return str(int(value)) if value.is_integer() else str(value)
+
+        return f"{_fmt(ratio[0])}:{_fmt(ratio[1])}"
+
+    @staticmethod
+    def _fallback_pixel_size(size: str, ratio: tuple[float, float]) -> str:
+        width, height = AgnesAIProvider._compute_dimensions(
+            ratio, _RESOLUTION_MAP[size]
+        )
         return f"{width}x{height}"
 
     @staticmethod

--- a/tl/provider_capabilities.py
+++ b/tl/provider_capabilities.py
@@ -110,6 +110,20 @@ def _profile(
     }
 
 
+def agnes_ai_capability(candidate: Any) -> dict[str, Any]:
+    # 档位式 size + ratio 原生输出，分辨率枚举比全局默认多 3K
+    return _profile(
+        candidate,
+        parameters={
+            "resolution": {
+                "type": "string",
+                "enum": ["1K", "2K", "3K", "4K"],
+                "default_source": "provider_config",
+            },
+        },
+    )
+
+
 def xai_capability(candidate: Any) -> dict[str, Any]:
     # 官方白名单与全局并集不同（含 auto，无 4:5/5:4/21:9），按渠道精确声明
     from .api.xai import SUPPORTED_ASPECT_RATIOS

--- a/tl/provider_metadata.py
+++ b/tl/provider_metadata.py
@@ -39,6 +39,7 @@ _PROVIDER_SPECS: Final[tuple[ProviderSpec, ...]] = (
         "agnes_ai",
         "tl.api.agnes_ai.AgnesAIProvider",
         settings_attr="agnes_ai_settings",
+        capability_profile_path="tl.provider_capabilities.agnes_ai_capability",
     ),
     ProviderSpec(
         "xai",


### PR DESCRIPTION
## 改动说明

- 默认模型切至 agnes-image-2.5-flash，新增 3K 档；官方白名单比例下发 size+ratio，非白名单比例或显式像素尺寸回退本地精确尺寸，旧配置行为不变
- xai/minimax/stepfun 模板 model 字段解锁为自由填写；dashscope/sensenova 模型分层需代码适配，保持下拉

## 改动类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 重构 / 代码优化
- [ ] 文档更新
- [ ] 其他

## 关联 Issue

<!-- 如有关联 Issue 请填写，例如 Fixes #123 -->

## 测试情况

- [x] 本地测试通过
- [ ] 已测试相关命令（/生图、/改图、/快速 等）
- [x] 已测试 LLM 工具调用

## 补充说明

<!-- 需要 reviewer 特别关注的点、兼容性说明等 -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/piexian/astrbot_plugin_gemini_image_generation/pull/98" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

## Sourcery 摘要

升级图像生成模型配置并增强 Agnes AI 的分辨率与比例处理能力。

新功能：
- 适配 Agnes AI `agnes-image-2.5-flash` 并将其设为默认模型，支持 1K/2K/3K/4K 分辨率档位及官方比例原生输出。

错误修复：
- 为非官方支持比例和显式像素尺寸提供本地精确尺寸回退，同时保留旧模型配置的兼容行为。

增强功能：
- 解锁 xai、minimax 和 stepfun 模板的模型自由填写，并为 Agnes AI 声明独立的分辨率能力配置。

文档：
- 更新版本信息及 Agnes AI 模型、分辨率和比例配置说明。

测试：
- 补充 Agnes AI 默认模型、3K 档位、比例透传、尺寸回退和能力声明测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

升级图像生成模型配置并增强 Agnes AI 的分辨率与比例处理能力。

New Features:
- 适配 Agnes AI `agnes-image-2.5-flash` 并将其设为默认模型，支持 1K/2K/3K/4K 分辨率档位及官方比例原生输出。

Bug Fixes:
- 为非官方支持比例和显式像素尺寸提供本地精确尺寸回退，同时保留旧模型配置的兼容行为。

Enhancements:
- 解锁 xai、minimax 和 stepfun 模板的模型自由填写，并为 Agnes AI 声明独立的分辨率能力配置。

Documentation:
- 更新版本信息及 Agnes AI 模型、分辨率和比例配置说明。

Tests:
- 补充 Agnes AI 默认模型、3K 档位、比例透传、尺寸回退和能力声明测试。

</details>