### PR TITLE
fix(tools): 后台失败回灌切换为框架官方 CronMessageEvent 链路

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 - `provider_polling` 预制供应商列表与相关文档同步加入 `modelscope`；`tests/test_provider_registry.py` 纳入 `tl.api.modelscope` 并将 `capability_profile_path` 加入 spec 路径可加载性校验。
 
+### Fixed
+
+- **LLM 工具触发的后台生图任务失败不再向群内直发原始报错**：前台超时转后台后，失败/异常结果改为回灌当前会话的聊天模型（`Context.llm_generate` 单向生成，不带工具避免循环触发生图），由 AI 重新组织语言告知用户；会话历史自动注入、回灌问答写入会话记忆，通知链任何一步失败静默降级仅记日志（状态机 `failed` 记录与 `gemini_image_task_status` 查询不受影响）。批量任务失败汇总与整体异常同样聚合走该出口。新增开关 `image_generation_settings.background_failure_notify_llm`（默认开）；指令触发流程（`/生图` 等）行为不变。
+
 ## [2.7.6] - 2026-09-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### Fixed
 
-- **LLM 工具触发的后台生图任务失败不再向群内直发原始报错**：前台超时转后台后，失败/异常结果改为回灌当前会话的聊天模型（`Context.llm_generate` 单向生成，不带工具避免循环触发生图），由 AI 重新组织语言告知用户；会话历史自动注入、回灌问答写入会话记忆，通知链任何一步失败静默降级仅记日志（状态机 `failed` 记录与 `gemini_image_task_status` 查询不受影响）。批量任务失败汇总与整体异常同样聚合走该出口。新增开关 `image_generation_settings.background_failure_notify_llm`（默认开）；指令触发流程（`/生图` 等）行为不变。
+- **LLM 工具触发的后台生图任务失败不再向群内直发原始报错**：失败/异常结果改走框架官方后台任务回灌链路（`CronMessageEvent` + 主 agent + `send_message_to_user` 工具，仅挂该工具、天然无再次触发生图路径），由 AI 重新组织语言告知用户；官方 API 缺失或通知链异常时静默降级仅记日志（状态机 `failed` 记录与 `gemini_image_task_status` 查询不受影响）。批量任务失败汇总与整体异常同样聚合走该出口。新增开关 `image_generation_settings.background_failure_notify_llm`（默认开）；指令触发流程（`/生图` 等）行为不变。
 
 ## [2.7.6] - 2026-09-01
 

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -1837,6 +1837,12 @@
           "max": 720,
           "step": 1
         }
+      },
+      "background_failure_notify_llm": {
+        "description": "后台失败回灌 LLM",
+        "type": "bool",
+        "hint": "开启后，LLM 工具触发的后台生图任务失败时不再向群内直发原始报错，而是让当前会话的 AI 重新组织语言告知用户；指令触发的流程不受影响。",
+        "default": true
       }
     }
   },

--- a/docs/config.md
+++ b/docs/config.md
@@ -80,7 +80,7 @@ google / gemini_interactions / openai / agnes_ai / xai / minimax / stepfun / ope
 | `batch_max_tasks` | `20` | 一次 `batch_tasks` 允许的命名任务条目上限 |
 | `batch_concurrency` | `3` | 后台批量生成并发数；每个条目内部按供应商单次上限顺序补齐 |
 | `background_task_retention_hours` | `24` | 后台任务状态记录保留时间；插件重启会把未完成任务标记为 `interrupted` |
-| `background_failure_notify_llm` | `true` | LLM 工具触发的后台生图失败时回灌 LLM，由 AI 重新组织语言告知用户；关闭则直发原始报错 |
+| `background_failure_notify_llm` | `true` | LLM 工具触发的后台生图失败时走框架官方回灌链路（CronMessageEvent + 主 agent + send_message_to_user），由 AI 重新组织语言告知用户；关闭或官方 API 不可用时直发原始报错 |
 
 分辨率、长宽比、最大参考图数量、Google 文本响应、Google 搜索接地、OpenAI/OpenAI 兼容参数名等均在 `provider_settings.provider_overrides` 的各供应商条目内配置。
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -80,6 +80,7 @@ google / gemini_interactions / openai / agnes_ai / xai / minimax / stepfun / ope
 | `batch_max_tasks` | `20` | 一次 `batch_tasks` 允许的命名任务条目上限 |
 | `batch_concurrency` | `3` | 后台批量生成并发数；每个条目内部按供应商单次上限顺序补齐 |
 | `background_task_retention_hours` | `24` | 后台任务状态记录保留时间；插件重启会把未完成任务标记为 `interrupted` |
+| `background_failure_notify_llm` | `true` | LLM 工具触发的后台生图失败时回灌 LLM，由 AI 重新组织语言告知用户；关闭则直发原始报错 |
 
 分辨率、长宽比、最大参考图数量、Google 文本响应、Google 搜索接地、OpenAI/OpenAI 兼容参数名等均在 `provider_settings.provider_overrides` 的各供应商条目内配置。
 

--- a/tests/test_llm_routing_and_tasks.py
+++ b/tests/test_llm_routing_and_tasks.py
@@ -44,6 +44,7 @@ sys.modules["astrbot.core.astr_agent_context"].AstrAgentContext = type(
     "AstrAgentContext", (), {}
 )
 
+from tl import batch_generation  # noqa: E402
 from tl.background_tasks import BackgroundTaskManager  # noqa: E402
 from tl.batch_generation import run_batch_job  # noqa: E402
 from tl.llm_query_tools import (  # noqa: E402
@@ -478,3 +479,217 @@ async def test_single_background_task_marks_delivery_failure_partial(tmp_path) -
     assert result is not None
     assert result["status"] == "partial_success"
     assert result["items"][0]["delivery_success"] is False
+
+
+def _notify_plugin(
+    manager, event, *, llm_text="图片生成失败，请稍后重试", llm_error=None
+):
+    """构造带可 mock 聊天模型 context 的插件替身，返回 (plugin, llm_prompts)。"""
+    llm_prompts: list[str] = []
+
+    class _Context:
+        async def get_current_chat_provider_id(self, umo: str) -> str:
+            return "chat-provider"
+
+        async def llm_generate(
+            self, *, chat_provider_id, prompt, contexts=None, **kwargs
+        ):
+            if llm_error is not None:
+                raise llm_error
+            llm_prompts.append(prompt)
+            return SimpleNamespace(completion_text=llm_text)
+
+    plugin = SimpleNamespace(
+        background_task_manager=manager,
+        message_sender=_MessageSender(),
+        avatar_manager=_AvatarManager(),
+        api_client=None,
+        context=_Context(),
+        cfg=SimpleNamespace(background_failure_notify_llm=True),
+    )
+    return plugin, llm_prompts
+
+
+@pytest.mark.asyncio
+async def test_background_failure_feeds_back_to_llm(tmp_path) -> None:
+    manager = BackgroundTaskManager(tmp_path)
+    event = _Event()
+    plugin, llm_prompts = _notify_plugin(manager, event)
+    record = await manager.create(
+        session_id=event.unified_msg_origin,
+        kind="single",
+        routing_mode="full_polling",
+        message="running",
+    )
+
+    async def failed_generation():
+        return False, "供应商 5xx", {}
+
+    await _await_generation_task_and_send(
+        plugin,
+        event,
+        asyncio.create_task(failed_generation()),
+        scene="test",
+        task_id=record["task_id"],
+        notify_llm=True,
+    )
+    result = await manager.get(record["task_id"], event.unified_msg_origin)
+
+    assert llm_prompts and "供应商 5xx" in llm_prompts[0]
+    assert event.sent == ["图片生成失败，请稍后重试"]
+    assert result is not None
+    assert result["status"] == "failed"
+    assert result["items"][0]["delivery_success"] is True
+
+
+@pytest.mark.asyncio
+async def test_background_exception_feeds_back_to_llm(tmp_path) -> None:
+    manager = BackgroundTaskManager(tmp_path)
+    event = _Event()
+    plugin, llm_prompts = _notify_plugin(manager, event)
+    record = await manager.create(
+        session_id=event.unified_msg_origin,
+        kind="single",
+        routing_mode="full_polling",
+        message="running",
+    )
+
+    async def raising_generation():
+        raise RuntimeError("APIError boom")
+
+    await _await_generation_task_and_send(
+        plugin,
+        event,
+        asyncio.create_task(raising_generation()),
+        scene="test",
+        task_id=record["task_id"],
+        notify_llm=True,
+    )
+    result = await manager.get(record["task_id"], event.unified_msg_origin)
+
+    assert event.sent == ["图片生成失败，请稍后重试"]
+    assert result is not None
+    assert result["status"] == "failed"
+    assert result["message"] == "后台生成异常: APIError boom"
+
+
+@pytest.mark.asyncio
+async def test_background_failure_notify_degrades_silently(tmp_path) -> None:
+    manager = BackgroundTaskManager(tmp_path)
+    event = _Event()
+    plugin, _ = _notify_plugin(manager, event, llm_error=RuntimeError("provider down"))
+    record = await manager.create(
+        session_id=event.unified_msg_origin,
+        kind="single",
+        routing_mode="full_polling",
+        message="running",
+    )
+
+    async def failed_generation():
+        return False, "供应商 5xx", {}
+
+    await _await_generation_task_and_send(
+        plugin,
+        event,
+        asyncio.create_task(failed_generation()),
+        scene="test",
+        task_id=record["task_id"],
+        notify_llm=True,
+    )
+    result = await manager.get(record["task_id"], event.unified_msg_origin)
+
+    assert event.sent == []
+    assert result is not None
+    assert result["status"] == "failed"
+
+
+@pytest.mark.asyncio
+async def test_background_failure_default_keeps_direct_send(tmp_path) -> None:
+    manager = BackgroundTaskManager(tmp_path)
+    event = _Event()
+    plugin, llm_prompts = _notify_plugin(manager, event)
+    record = await manager.create(
+        session_id=event.unified_msg_origin,
+        kind="single",
+        routing_mode="full_polling",
+        message="running",
+    )
+
+    async def failed_generation():
+        return False, "供应商 5xx", {}
+
+    await _await_generation_task_and_send(
+        plugin,
+        event,
+        asyncio.create_task(failed_generation()),
+        scene="test",
+        task_id=record["task_id"],
+    )
+    result = await manager.get(record["task_id"], event.unified_msg_origin)
+
+    assert llm_prompts == []
+    assert event.sent == ["供应商 5xx"]
+    assert result is not None
+    assert result["status"] == "failed"
+
+
+@pytest.mark.asyncio
+async def test_background_failure_switch_off_keeps_direct_send(tmp_path) -> None:
+    manager = BackgroundTaskManager(tmp_path)
+    event = _Event()
+    plugin, llm_prompts = _notify_plugin(manager, event)
+    plugin.cfg.background_failure_notify_llm = False
+    record = await manager.create(
+        session_id=event.unified_msg_origin,
+        kind="single",
+        routing_mode="full_polling",
+        message="running",
+    )
+
+    async def failed_generation():
+        return False, "供应商 5xx", {}
+
+    await _await_generation_task_and_send(
+        plugin,
+        event,
+        asyncio.create_task(failed_generation()),
+        scene="test",
+        task_id=record["task_id"],
+        notify_llm=True,
+    )
+
+    assert llm_prompts == []
+    assert event.sent == ["供应商 5xx"]
+
+
+@pytest.mark.asyncio
+async def test_batch_failure_summary_feeds_back_to_llm(tmp_path, monkeypatch) -> None:
+    manager = BackgroundTaskManager(tmp_path)
+    event = _Event()
+    plugin, llm_prompts = _notify_plugin(manager, event)
+    plugin.cfg = SimpleNamespace(
+        batch_concurrency=2,
+        background_failure_notify_llm=True,
+    )
+    plugin.image_generator = SimpleNamespace(get_request_stats=lambda: {})
+    record = await manager.create(
+        session_id=event.unified_msg_origin,
+        kind="batch",
+        routing_mode="provider_retry",
+        message="running",
+    )
+    item = {"name": "set-a", "prompt": "draw", "image_count": 2}
+
+    async def _fail(plugin=None, **kwargs):
+        return False, "boom"
+
+    monkeypatch.setattr(batch_generation, "invoke_generation_core", _fail)
+
+    await run_batch_job(plugin, event, record["task_id"], [item])
+    result = await manager.get(record["task_id"], event.unified_msg_origin)
+
+    assert llm_prompts and "boom" in llm_prompts[0]
+    assert event.sent == ["图片生成失败，请稍后重试"]
+    assert plugin.message_sender.deliveries == []
+    assert result is not None
+    assert result["status"] == "failed"

--- a/tests/test_llm_routing_and_tasks.py
+++ b/tests/test_llm_routing_and_tasks.py
@@ -481,40 +481,135 @@ async def test_single_background_task_marks_delivery_failure_partial(tmp_path) -
     assert result["items"][0]["delivery_success"] is False
 
 
-def _notify_plugin(
-    manager, event, *, llm_text="图片生成失败，请稍后重试", llm_error=None
-):
-    """构造带可 mock 聊天模型 context 的插件替身，返回 (plugin, llm_prompts)。"""
-    llm_prompts: list[str] = []
+def _install_official_wake_fakes(monkeypatch, *, build_error=None) -> dict:
+    """把 tl.background_notify 的官方回灌符号替换为可断言的假实现。"""
+    import tl.background_notify as background_notify
 
-    class _Context:
-        async def get_current_chat_provider_id(self, umo: str) -> str:
-            return "chat-provider"
+    calls: dict = {"builds": 0, "agent_reqs": [], "tools": [], "persists": []}
 
-        async def llm_generate(
-            self, *, chat_provider_id, prompt, contexts=None, **kwargs
-        ):
-            if llm_error is not None:
-                raise llm_error
-            llm_prompts.append(prompt)
-            return SimpleNamespace(completion_text=llm_text)
+    class _Session:
+        def __init__(self, raw: str):
+            platform_id, message_type, session_id = raw.split(":", 2)
+            self.platform_id = platform_id
+            self.message_type = message_type
+            self.session_id = session_id
 
-    plugin = SimpleNamespace(
+        @classmethod
+        def from_str(cls, raw: str):
+            return cls(raw)
+
+    class _CronEvent:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            session = kwargs["session"]
+            self.unified_msg_origin = (
+                f"{session.platform_id}:{session.message_type}:{session.session_id}"
+            )
+            self.role = None
+
+        def get_platform_id(self) -> str:
+            return self.kwargs["session"].platform_id
+
+    class _ProviderRequest:
+        def __init__(self):
+            self.system_prompt = ""
+            self.contexts: list | None = None
+            self.conversation = None
+            self.prompt: str | None = None
+            self.func_tool = None
+
+        def _print_friendly_context(self) -> str:
+            return "HIST"
+
+    class _ToolSet:
+        def add_tool(self, tool) -> None:
+            calls["tools"].append(tool)
+
+    class _Runner:
+        async def step_until_done(self, limit: int):
+            for i in range(2):
+                yield i
+
+    class _BuildResult:
+        agent_runner = _Runner()
+
+    async def _fake_get_session_conv(event=None, plugin_context=None):
+        return SimpleNamespace(history="[]")
+
+    async def _fake_build_main_agent(
+        event=None, plugin_context=None, config=None, req=None
+    ):
+        calls["builds"] += 1
+        if build_error is not None:
+            raise build_error
+        calls["agent_reqs"].append(req)
+        return _BuildResult()
+
+    async def _fake_persist(
+        conversation_manager, event=None, req=None, summary_note=""
+    ):
+        calls["persists"].append(summary_note)
+
+    monkeypatch.setattr(background_notify, "_OFFICIAL_API_READY", True, raising=False)
+    monkeypatch.setattr(background_notify, "MessageSession", _Session, raising=False)
+    monkeypatch.setattr(
+        background_notify, "CronMessageEvent", _CronEvent, raising=False
+    )
+    monkeypatch.setattr(
+        background_notify, "ProviderRequest", _ProviderRequest, raising=False
+    )
+    monkeypatch.setattr(background_notify, "ToolSet", _ToolSet, raising=False)
+    monkeypatch.setattr(
+        background_notify,
+        "BACKGROUND_TASK_RESULT_WOKE_SYSTEM_PROMPT",
+        "BG:{background_task_result}",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        background_notify, "SendMessageToUserTool", object(), raising=False
+    )
+    monkeypatch.setattr(
+        background_notify,
+        "MainAgentBuildConfig",
+        lambda **kw: SimpleNamespace(**kw),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        background_notify, "_get_session_conv", _fake_get_session_conv, raising=False
+    )
+    monkeypatch.setattr(
+        background_notify, "build_main_agent", _fake_build_main_agent, raising=False
+    )
+    monkeypatch.setattr(
+        background_notify, "persist_agent_history", _fake_persist, raising=False
+    )
+    return calls
+
+
+def _notify_plugin(manager, event):
+    """构造带官方回灌所需 context 的插件替身。"""
+    return SimpleNamespace(
         background_task_manager=manager,
         message_sender=_MessageSender(),
         avatar_manager=_AvatarManager(),
         api_client=None,
-        context=_Context(),
+        context=SimpleNamespace(
+            get_config=lambda umo=None: {},
+            get_llm_tool_manager=lambda: SimpleNamespace(
+                get_builtin_tool=lambda tool: ("SendMessageToUserTool", tool)
+            ),
+            conversation_manager=SimpleNamespace(),
+        ),
         cfg=SimpleNamespace(background_failure_notify_llm=True),
     )
-    return plugin, llm_prompts
 
 
 @pytest.mark.asyncio
-async def test_background_failure_feeds_back_to_llm(tmp_path) -> None:
+async def test_background_failure_wakes_official_agent(tmp_path, monkeypatch) -> None:
     manager = BackgroundTaskManager(tmp_path)
     event = _Event()
-    plugin, llm_prompts = _notify_plugin(manager, event)
+    plugin = _notify_plugin(manager, event)
+    calls = _install_official_wake_fakes(monkeypatch)
     record = await manager.create(
         session_id=event.unified_msg_origin,
         kind="single",
@@ -535,18 +630,25 @@ async def test_background_failure_feeds_back_to_llm(tmp_path) -> None:
     )
     result = await manager.get(record["task_id"], event.unified_msg_origin)
 
-    assert llm_prompts and "供应商 5xx" in llm_prompts[0]
-    assert event.sent == ["图片生成失败，请稍后重试"]
+    assert calls["builds"] == 1
+    req = calls["agent_reqs"][0]
+    assert "send_message_to_user" in req.prompt
+    assert "供应商 5xx" in req.system_prompt
+    assert len(calls["tools"]) == 1
+    assert len(calls["persists"]) == 1
+    assert record["task_id"] in calls["persists"][0]
+    assert event.sent == []
     assert result is not None
     assert result["status"] == "failed"
     assert result["items"][0]["delivery_success"] is True
 
 
 @pytest.mark.asyncio
-async def test_background_exception_feeds_back_to_llm(tmp_path) -> None:
+async def test_background_exception_wakes_official_agent(tmp_path, monkeypatch) -> None:
     manager = BackgroundTaskManager(tmp_path)
     event = _Event()
-    plugin, llm_prompts = _notify_plugin(manager, event)
+    plugin = _notify_plugin(manager, event)
+    calls = _install_official_wake_fakes(monkeypatch)
     record = await manager.create(
         session_id=event.unified_msg_origin,
         kind="single",
@@ -567,17 +669,21 @@ async def test_background_exception_feeds_back_to_llm(tmp_path) -> None:
     )
     result = await manager.get(record["task_id"], event.unified_msg_origin)
 
-    assert event.sent == ["图片生成失败，请稍后重试"]
+    assert calls["builds"] == 1
+    assert event.sent == []
     assert result is not None
     assert result["status"] == "failed"
     assert result["message"] == "后台生成异常: APIError boom"
 
 
 @pytest.mark.asyncio
-async def test_background_failure_notify_degrades_silently(tmp_path) -> None:
+async def test_background_wake_error_degrades_silently(tmp_path, monkeypatch) -> None:
     manager = BackgroundTaskManager(tmp_path)
     event = _Event()
-    plugin, _ = _notify_plugin(manager, event, llm_error=RuntimeError("provider down"))
+    plugin = _notify_plugin(manager, event)
+    calls = _install_official_wake_fakes(
+        monkeypatch, build_error=RuntimeError("agent down")
+    )
     record = await manager.create(
         session_id=event.unified_msg_origin,
         kind="single",
@@ -598,6 +704,44 @@ async def test_background_failure_notify_degrades_silently(tmp_path) -> None:
     )
     result = await manager.get(record["task_id"], event.unified_msg_origin)
 
+    assert calls["builds"] == 1
+    assert event.sent == []
+    assert result is not None
+    assert result["status"] == "failed"
+
+
+@pytest.mark.asyncio
+async def test_background_wake_api_missing_degrades_silently(tmp_path) -> None:
+    import tl.background_notify as background_notify
+
+    manager = BackgroundTaskManager(tmp_path)
+    event = _Event()
+    plugin = _notify_plugin(manager, event)
+    record = await manager.create(
+        session_id=event.unified_msg_origin,
+        kind="single",
+        routing_mode="full_polling",
+        message="running",
+    )
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(background_notify, "_OFFICIAL_API_READY", False, raising=False)
+    try:
+
+        async def failed_generation():
+            return False, "供应商 5xx", {}
+
+        await _await_generation_task_and_send(
+            plugin,
+            event,
+            asyncio.create_task(failed_generation()),
+            scene="test",
+            task_id=record["task_id"],
+            notify_llm=True,
+        )
+    finally:
+        monkeypatch.undo()
+    result = await manager.get(record["task_id"], event.unified_msg_origin)
+
     assert event.sent == []
     assert result is not None
     assert result["status"] == "failed"
@@ -607,7 +751,7 @@ async def test_background_failure_notify_degrades_silently(tmp_path) -> None:
 async def test_background_failure_default_keeps_direct_send(tmp_path) -> None:
     manager = BackgroundTaskManager(tmp_path)
     event = _Event()
-    plugin, llm_prompts = _notify_plugin(manager, event)
+    plugin = _notify_plugin(manager, event)
     record = await manager.create(
         session_id=event.unified_msg_origin,
         kind="single",
@@ -627,7 +771,6 @@ async def test_background_failure_default_keeps_direct_send(tmp_path) -> None:
     )
     result = await manager.get(record["task_id"], event.unified_msg_origin)
 
-    assert llm_prompts == []
     assert event.sent == ["供应商 5xx"]
     assert result is not None
     assert result["status"] == "failed"
@@ -637,7 +780,7 @@ async def test_background_failure_default_keeps_direct_send(tmp_path) -> None:
 async def test_background_failure_switch_off_keeps_direct_send(tmp_path) -> None:
     manager = BackgroundTaskManager(tmp_path)
     event = _Event()
-    plugin, llm_prompts = _notify_plugin(manager, event)
+    plugin = _notify_plugin(manager, event)
     plugin.cfg.background_failure_notify_llm = False
     record = await manager.create(
         session_id=event.unified_msg_origin,
@@ -658,15 +801,17 @@ async def test_background_failure_switch_off_keeps_direct_send(tmp_path) -> None
         notify_llm=True,
     )
 
-    assert llm_prompts == []
     assert event.sent == ["供应商 5xx"]
 
 
 @pytest.mark.asyncio
-async def test_batch_failure_summary_feeds_back_to_llm(tmp_path, monkeypatch) -> None:
+async def test_batch_failure_summary_wakes_official_agent(
+    tmp_path, monkeypatch
+) -> None:
     manager = BackgroundTaskManager(tmp_path)
     event = _Event()
-    plugin, llm_prompts = _notify_plugin(manager, event)
+    plugin = _notify_plugin(manager, event)
+    calls = _install_official_wake_fakes(monkeypatch)
     plugin.cfg = SimpleNamespace(
         batch_concurrency=2,
         background_failure_notify_llm=True,
@@ -688,8 +833,10 @@ async def test_batch_failure_summary_feeds_back_to_llm(tmp_path, monkeypatch) ->
     await run_batch_job(plugin, event, record["task_id"], [item])
     result = await manager.get(record["task_id"], event.unified_msg_origin)
 
-    assert llm_prompts and "boom" in llm_prompts[0]
-    assert event.sent == ["图片生成失败，请稍后重试"]
+    assert calls["builds"] == 1
+    assert "boom" in calls["agent_reqs"][0].system_prompt
+    assert len(calls["persists"]) == 1
+    assert event.sent == []
     assert plugin.message_sender.deliveries == []
     assert result is not None
     assert result["status"] == "failed"

--- a/tests/test_provider_capabilities.py
+++ b/tests/test_provider_capabilities.py
@@ -107,6 +107,7 @@ def test_config_loader_parses_alias_and_batch_limits() -> None:
                 "batch_max_tasks": 30,
                 "batch_concurrency": 4,
                 "background_task_retention_hours": 48,
+                "background_failure_notify_llm": False,
             },
         }
     ).load()
@@ -116,6 +117,7 @@ def test_config_loader_parses_alias_and_batch_limits() -> None:
     assert config.batch_max_tasks == 30
     assert config.batch_concurrency == 4
     assert config.background_task_retention_hours == 48
+    assert config.background_failure_notify_llm is False
 
 
 @pytest.mark.parametrize(

--- a/tl/background_notify.py
+++ b/tl/background_notify.py
@@ -1,7 +1,8 @@
-"""后台生图失败时，将结果回灌给发起调用的 LLM 会话。
+"""后台生图失败时，走 AstrBot 官方后台任务回灌链路通知用户。
 
-工具触发且转后台的任务失败时，不再向群内直发原始报错，而是让当前会话的
-聊天模型重新组织语言告知用户；通知链任何一步失败仅记日志（静默降级）。
+复用框架 _wake_main_agent_for_background_result 的形态：CronMessageEvent +
+主 agent（仅挂 send_message_to_user 工具）+ persist_agent_history。
+任何一步失败仅记日志（静默降级）；开关关闭或官方 API 缺失时回退直发。
 """
 
 from __future__ import annotations
@@ -11,76 +12,41 @@ from typing import Any
 
 from astrbot.api import logger
 
-# 注入给回灌请求的会话历史上限，避免长对话撑爆通知请求
-_CONTEXT_HISTORY_LIMIT = 10
+try:  # 官方内部 API（_get_session_conv 为私有函数），版本漂移风险防御
+    from astrbot.core.agent.tool import ToolSet
+    from astrbot.core.astr_main_agent import (
+        MainAgentBuildConfig,
+        _get_session_conv,
+        build_main_agent,
+    )
+    from astrbot.core.astr_main_agent_resources import (
+        BACKGROUND_TASK_RESULT_WOKE_SYSTEM_PROMPT,
+    )
+    from astrbot.core.cron.events import CronMessageEvent
+    from astrbot.core.platform.message_session import MessageSession
+    from astrbot.core.provider.entites import ProviderRequest
+    from astrbot.core.tools.message_tools import SendMessageToUserTool
+    from astrbot.core.utils.history_saver import persist_agent_history
+
+    _OFFICIAL_API_READY = True
+except ImportError as e:  # pragma: no cover - 仅低版本框架触发
+    logger.warning(f"[后台失败回灌] AstrBot 官方回灌 API 导入失败，通知将静默降级: {e}")
+    _OFFICIAL_API_READY = False
+    # except 分支显式绑 None：保证模块符号恒存在，便于调用方/测试安全引用
+    ToolSet = MainAgentBuildConfig = _get_session_conv = build_main_agent = None
+    BACKGROUND_TASK_RESULT_WOKE_SYSTEM_PROMPT = CronMessageEvent = None
+    MessageSession = ProviderRequest = SendMessageToUserTool = None
+    persist_agent_history = None
 
 
 def _build_notice_prompt(task_id: str | None, failure_summary: str) -> str:
     tid = f"（任务号 {task_id}）" if task_id else ""
-    return (
-        f"你之前代表用户发起的后台图片生成任务{tid}已失败。失败摘要：{failure_summary}\n"
-        "请用一两句简短友好的中文告知用户生成失败，可建议稍后重试或调整参数；"
-        "不要复述内部错误细节。"
-    )
+    return f"后台图片生成任务{tid}失败。失败摘要：{failure_summary}"
 
 
 def notify_llm_enabled(plugin: Any) -> bool:
     cfg = getattr(plugin, "cfg", None)
     return bool(getattr(cfg, "background_failure_notify_llm", True))
-
-
-async def _load_conversation_contexts(
-    context: Any, umo: str
-) -> list[dict[str, Any]] | None:
-    """尽力取当前会话历史作为回灌上下文；API 形态不符时返回 None 跳过。"""
-    try:
-        conv_mgr = getattr(context, "conversation_manager", None)
-        if conv_mgr is None:
-            return None
-        cid = await conv_mgr.get_curr_conversation_id(umo)
-        if not cid:
-            return None
-        conv = await conv_mgr.get_conversation(umo, cid)
-        if conv is None:
-            return None
-        # v1 Conversation.history 为 OpenAI 格式消息列表的 JSON 字符串
-        raw = getattr(conv, "history", None)
-        history = json.loads(raw) if isinstance(raw, str) else raw
-        if not isinstance(history, list):
-            return None
-        msgs = [
-            m
-            for m in history
-            if isinstance(m, dict) and m.get("role") in ("user", "assistant")
-        ]
-        tail = msgs[-_CONTEXT_HISTORY_LIMIT:]
-        return tail or None
-    except Exception as e:
-        logger.debug(f"[后台失败回灌] 会话历史注入跳过: {e}")
-        return None
-
-
-async def _persist_notice_exchange(
-    context: Any,
-    umo: str,
-    prompt: str,
-    reply: str,
-) -> None:
-    """把回灌一问一答写入会话记忆，让 AI 后续轮次记得该失败；不符则跳过。"""
-    try:
-        conv_mgr = getattr(context, "conversation_manager", None)
-        if conv_mgr is None or not hasattr(conv_mgr, "add_message_pair"):
-            return
-        cid = await conv_mgr.get_curr_conversation_id(umo)
-        if not cid:
-            return
-        await conv_mgr.add_message_pair(
-            cid=cid,
-            user_message={"role": "user", "content": prompt},
-            assistant_message={"role": "assistant", "content": reply},
-        )
-    except Exception as e:
-        logger.debug(f"[后台失败回灌] 会话记忆写入跳过: {e}")
 
 
 async def notify_llm_background_failure(
@@ -91,31 +57,85 @@ async def notify_llm_background_failure(
     scene: str,
     task_id: str | None = None,
 ) -> bool:
-    """回灌失败通知：LLM 生成用户友好文案后发送；返回是否实际送达。"""
-    prompt = _build_notice_prompt(task_id, failure_summary)
+    """走官方回灌链路把失败结果交给主 agent 告知用户；返回是否送达。"""
+    notice = _build_notice_prompt(task_id, failure_summary)
     try:
+        if not _OFFICIAL_API_READY:
+            raise RuntimeError("AstrBot 官方回灌 API 不可用")
         context = getattr(plugin, "context", None)
         umo = getattr(event, "unified_msg_origin", None)
         if context is None or not umo:
             raise RuntimeError("缺少插件 context 或会话标识")
-        provider_id = await context.get_current_chat_provider_id(umo)
-        if not provider_id:
-            raise RuntimeError("当前会话未配置聊天模型")
-        contexts = await _load_conversation_contexts(context, umo)
-        # 单向生成、不带任何工具，避免 AI 再次触发生图形成循环
-        resp = await context.llm_generate(
-            chat_provider_id=provider_id,
-            prompt=prompt,
-            contexts=contexts,
+
+        task_result = {"task_id": task_id or "", "result": failure_summary}
+        extras = {"background_task_result": task_result}
+
+        session = MessageSession.from_str(umo)
+        cron_event = CronMessageEvent(
+            context=context,
+            session=session,
+            message=notice,
+            extras=extras,
+            message_type=session.message_type,
         )
-        text = str(getattr(resp, "completion_text", "") or "").strip()
-        if not text:
-            raise RuntimeError("回灌生成结果为空")
-        await event.send(event.plain_result(text))
-        await _persist_notice_exchange(context, umo, prompt, text)
+        cron_event.role = getattr(event, "role", None)
+
+        cfg = context.get_config(umo=umo) or {}
+        provider_settings = cfg.get("provider_settings") or {}
+        config = MainAgentBuildConfig(
+            tool_call_timeout=60,
+            streaming_response=False,
+            provider_settings=provider_settings,
+        )
+
+        req = ProviderRequest()
+        conv = await _get_session_conv(event=cron_event, plugin_context=context)
+        req.conversation = conv
+        history = json.loads(conv.history)
+        if history:
+            req.contexts = history
+            context_dump = req._print_friendly_context()
+            req.contexts = []
+            req.system_prompt += (
+                "\n\nBellow is you and user previous conversation history:\n"
+                f"{context_dump}"
+            )
+        req.system_prompt += BACKGROUND_TASK_RESULT_WOKE_SYSTEM_PROMPT.format(
+            background_task_result=json.dumps(
+                extras["background_task_result"], ensure_ascii=False
+            )
+        )
+        req.prompt = (
+            "请按照系统指令行事，用与用户历史对话一致的语言。"
+            "你必须调用 `send_message_to_user` 工具，把这条后台任务的失败结果简短告知用户，"
+            "否则用户将看不到任何结果。"
+            "若同一任务已连续多次失败，请先询问用户是否继续，再决定是否重试。"
+        )
+        req.func_tool = ToolSet()
+        req.func_tool.add_tool(
+            context.get_llm_tool_manager().get_builtin_tool(SendMessageToUserTool)
+        )
+
+        result = await build_main_agent(
+            event=cron_event, plugin_context=context, config=config, req=req
+        )
+        if not result:
+            raise RuntimeError("主 agent 构建失败")
+        runner = result.agent_runner
+        async for _ in runner.step_until_done(30):
+            # agent 通过 send_message_to_user 工具把结果发给用户
+            pass
+        await persist_agent_history(
+            context.conversation_manager,
+            event=cron_event,
+            req=req,
+            summary_note=(
+                f"[BackgroundTask] 图像生成任务 {task_id or '-'} 失败：{failure_summary}"
+            ),
+        )
         return True
     except Exception as e:
-        logger.warning(f"[{scene}] 后台失败回灌 LLM 未送达，已静默降级: {e}")
+        logger.warning(f"[{scene}] 后台失败回灌未送达，已静默降级: {e}")
         return False
 
 

--- a/tl/background_notify.py
+++ b/tl/background_notify.py
@@ -1,0 +1,140 @@
+"""后台生图失败时，将结果回灌给发起调用的 LLM 会话。
+
+工具触发且转后台的任务失败时，不再向群内直发原始报错，而是让当前会话的
+聊天模型重新组织语言告知用户；通知链任何一步失败仅记日志（静默降级）。
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from astrbot.api import logger
+
+# 注入给回灌请求的会话历史上限，避免长对话撑爆通知请求
+_CONTEXT_HISTORY_LIMIT = 10
+
+
+def _build_notice_prompt(task_id: str | None, failure_summary: str) -> str:
+    tid = f"（任务号 {task_id}）" if task_id else ""
+    return (
+        f"你之前代表用户发起的后台图片生成任务{tid}已失败。失败摘要：{failure_summary}\n"
+        "请用一两句简短友好的中文告知用户生成失败，可建议稍后重试或调整参数；"
+        "不要复述内部错误细节。"
+    )
+
+
+def notify_llm_enabled(plugin: Any) -> bool:
+    cfg = getattr(plugin, "cfg", None)
+    return bool(getattr(cfg, "background_failure_notify_llm", True))
+
+
+async def _load_conversation_contexts(
+    context: Any, umo: str
+) -> list[dict[str, Any]] | None:
+    """尽力取当前会话历史作为回灌上下文；API 形态不符时返回 None 跳过。"""
+    try:
+        conv_mgr = getattr(context, "conversation_manager", None)
+        if conv_mgr is None:
+            return None
+        cid = await conv_mgr.get_curr_conversation_id(umo)
+        if not cid:
+            return None
+        conv = await conv_mgr.get_conversation(umo, cid)
+        if conv is None:
+            return None
+        # v1 Conversation.history 为 OpenAI 格式消息列表的 JSON 字符串
+        raw = getattr(conv, "history", None)
+        history = json.loads(raw) if isinstance(raw, str) else raw
+        if not isinstance(history, list):
+            return None
+        msgs = [
+            m
+            for m in history
+            if isinstance(m, dict) and m.get("role") in ("user", "assistant")
+        ]
+        tail = msgs[-_CONTEXT_HISTORY_LIMIT:]
+        return tail or None
+    except Exception as e:
+        logger.debug(f"[后台失败回灌] 会话历史注入跳过: {e}")
+        return None
+
+
+async def _persist_notice_exchange(
+    context: Any,
+    umo: str,
+    prompt: str,
+    reply: str,
+) -> None:
+    """把回灌一问一答写入会话记忆，让 AI 后续轮次记得该失败；不符则跳过。"""
+    try:
+        conv_mgr = getattr(context, "conversation_manager", None)
+        if conv_mgr is None or not hasattr(conv_mgr, "add_message_pair"):
+            return
+        cid = await conv_mgr.get_curr_conversation_id(umo)
+        if not cid:
+            return
+        await conv_mgr.add_message_pair(
+            cid=cid,
+            user_message={"role": "user", "content": prompt},
+            assistant_message={"role": "assistant", "content": reply},
+        )
+    except Exception as e:
+        logger.debug(f"[后台失败回灌] 会话记忆写入跳过: {e}")
+
+
+async def notify_llm_background_failure(
+    plugin: Any,
+    event: Any,
+    failure_summary: str,
+    *,
+    scene: str,
+    task_id: str | None = None,
+) -> bool:
+    """回灌失败通知：LLM 生成用户友好文案后发送；返回是否实际送达。"""
+    prompt = _build_notice_prompt(task_id, failure_summary)
+    try:
+        context = getattr(plugin, "context", None)
+        umo = getattr(event, "unified_msg_origin", None)
+        if context is None or not umo:
+            raise RuntimeError("缺少插件 context 或会话标识")
+        provider_id = await context.get_current_chat_provider_id(umo)
+        if not provider_id:
+            raise RuntimeError("当前会话未配置聊天模型")
+        contexts = await _load_conversation_contexts(context, umo)
+        # 单向生成、不带任何工具，避免 AI 再次触发生图形成循环
+        resp = await context.llm_generate(
+            chat_provider_id=provider_id,
+            prompt=prompt,
+            contexts=contexts,
+        )
+        text = str(getattr(resp, "completion_text", "") or "").strip()
+        if not text:
+            raise RuntimeError("回灌生成结果为空")
+        await event.send(event.plain_result(text))
+        await _persist_notice_exchange(context, umo, prompt, text)
+        return True
+    except Exception as e:
+        logger.warning(f"[{scene}] 后台失败回灌 LLM 未送达，已静默降级: {e}")
+        return False
+
+
+async def report_background_failure(
+    plugin: Any,
+    event: Any,
+    failure_summary: str,
+    *,
+    scene: str,
+    task_id: str | None = None,
+) -> bool:
+    """工具触发的后台失败统一出口：按配置回灌 LLM，否则沿用直发。"""
+    if notify_llm_enabled(plugin):
+        return await notify_llm_background_failure(
+            plugin, event, failure_summary, scene=scene, task_id=task_id
+        )
+    try:
+        await event.send(event.plain_result(failure_summary))
+    except Exception as e:
+        logger.warning(f"[{scene}] 发送错误消息失败: {e}")
+        return False
+    return True

--- a/tl/batch_generation.py
+++ b/tl/batch_generation.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from astrbot.api import logger
 
+from .background_notify import report_background_failure
 from .generation_call import invoke_generation_core
 
 
@@ -146,7 +147,18 @@ async def _send_batch_results(
                 f"{result['generated_images']}/{result['requested_images']} 张，"
                 f"{result.get('error') or '未知错误'}"
             )
-    await event.send(event.plain_result("\n".join(summary_lines)))
+    summary = "\n".join(summary_lines)
+    if any(not result["success"] for result in results):
+        # 有失败项：聚合走失败通知出口（回灌 LLM 或按配置直发）
+        await report_background_failure(
+            plugin,
+            event,
+            summary,
+            scene=f"批量任务/{task_id}",
+            task_id=task_id,
+        )
+    else:
+        await event.send(event.plain_result(summary))
 
     for result in results:
         if not result["image_urls"] and not result["image_paths"]:
@@ -269,6 +281,12 @@ async def run_batch_job(
             items=[_public_item(value) for value in final_results],
         )
         try:
-            await event.send(event.plain_result(f"批量生图任务 {task_id} 失败：{exc}"))
+            await report_background_failure(
+                plugin,
+                event,
+                f"批量生图任务 {task_id} 失败：{exc}",
+                scene=f"批量任务/{task_id}",
+                task_id=task_id,
+            )
         except Exception:
             pass

--- a/tl/llm_tools.py
+++ b/tl/llm_tools.py
@@ -22,6 +22,7 @@ from astrbot.core.astr_agent_context import AstrAgentContext
 from pydantic import Field
 from pydantic.dataclasses import dataclass
 
+from .background_notify import report_background_failure
 from .batch_generation import run_batch_job
 from .generation_call import invoke_generation_core
 from .openai_image_size import (
@@ -648,6 +649,8 @@ async def _dispatch_generation_result(
     scene: str,
     fallback_text: str | None = None,
     force_text_response: bool = False,
+    notify_llm: bool = False,
+    task_id: str | None = None,
 ) -> bool:
     if success and isinstance(result_data, tuple):
         image_urls, image_paths, text_content, thought_signature = result_data
@@ -714,6 +717,14 @@ async def _dispatch_generation_result(
         return True
 
     error_msg = result_data if isinstance(result_data, str) else "❌ 图像生成失败"
+    if notify_llm:
+        return await report_background_failure(
+            plugin,
+            event,
+            error_msg,
+            scene=scene,
+            task_id=task_id,
+        )
     try:
         await event.send(event.plain_result(error_msg))
     except Exception as exc:
@@ -729,6 +740,7 @@ async def _await_generation_task_and_send(
     *,
     scene: str,
     task_id: str | None = None,
+    notify_llm: bool = False,
 ) -> None:
     try:
         success, result_data, stats = await generation_task
@@ -738,6 +750,8 @@ async def _await_generation_task_and_send(
             success=success,
             result_data=result_data,
             scene=scene,
+            notify_llm=notify_llm,
+            task_id=task_id,
         )
         if task_id:
             item = {
@@ -769,10 +783,19 @@ async def _await_generation_task_and_send(
             )
     except Exception as exc:
         logger.error(f"[{scene}] 后台图像生成异常: {exc}", exc_info=True)
-        try:
-            await event.send(event.plain_result(format_error_message(exc)))
-        except Exception as send_error:
-            logger.warning(f"[{scene}] 发送异常消息失败: {send_error}")
+        if notify_llm:
+            await report_background_failure(
+                plugin,
+                event,
+                format_error_message(exc),
+                scene=scene,
+                task_id=task_id,
+            )
+        else:
+            try:
+                await event.send(event.plain_result(format_error_message(exc)))
+            except Exception as send_error:
+                logger.warning(f"[{scene}] 发送异常消息失败: {send_error}")
         if task_id:
             await plugin.background_task_manager.update(
                 task_id,
@@ -790,6 +813,7 @@ def _schedule_generation_delivery(
     *,
     scene: str,
     task_id: str | None = None,
+    notify_llm: bool = False,
 ) -> asyncio.Task:
     coroutine = _await_generation_task_and_send(
         plugin=plugin,
@@ -797,6 +821,7 @@ def _schedule_generation_delivery(
         generation_task=generation_task,
         scene=scene,
         task_id=task_id,
+        notify_llm=notify_llm,
     )
     sender_task = (
         plugin.background_task_manager.attach(task_id, coroutine)
@@ -1343,6 +1368,7 @@ class GeminiImageGenerationTool(FunctionTool[AstrAgentContext]):
                     generation_task=generation_task,
                     scene="后台任务",
                     task_id=task_id,
+                    notify_llm=True,
                 )
                 return _background_json(task_id, request_routing_mode, message)
 
@@ -1404,6 +1430,7 @@ class GeminiImageGenerationTool(FunctionTool[AstrAgentContext]):
                         generation_task=done_task,
                         scene="后台任务(代理下载超时回退)",
                         task_id=task_id,
+                        notify_llm=True,
                     )
                     if config_value_notice:
                         result_message += f"\n{config_value_notice}"
@@ -1441,37 +1468,12 @@ class GeminiImageGenerationTool(FunctionTool[AstrAgentContext]):
                 generation_task=generation_task,
                 scene="后台任务",
                 task_id=task_id,
+                notify_llm=True,
             )
             return _background_json(task_id, request_routing_mode, message)
         except Exception as e:
             logger.error(f"[前台等待] 图像生成异常：{e}", exc_info=True)
             return f"❌ 图片生成过程中出错：{str(e)}"
-
-
-async def _background_generate_and_send(
-    plugin: GeminiImageGenerationPlugin,
-    event: Any,
-    prompt: str,
-    reference_images: list[str],
-    avatar_reference: list[str],
-    override_resolution: str | None = None,
-    override_aspect_ratio: str | None = None,
-) -> None:
-    generation_task = _create_generation_task(
-        plugin=plugin,
-        event=event,
-        prompt=prompt,
-        reference_images=reference_images,
-        avatar_reference=avatar_reference,
-        override_resolution=override_resolution,
-        override_aspect_ratio=override_aspect_ratio,
-    )
-    await _await_generation_task_and_send(
-        plugin=plugin,
-        event=event,
-        generation_task=generation_task,
-        scene="后台任务",
-    )
 
 
 # 保留旧的辅助函数以保持向后兼容（已弃用）

--- a/tl/plugin_config.py
+++ b/tl/plugin_config.py
@@ -138,6 +138,7 @@ class PluginConfig:
     batch_max_tasks: int = 20
     batch_concurrency: int = 3
     background_task_retention_hours: int = 24
+    background_failure_notify_llm: bool = True
 
     # 表情包设置
     sticker_grid_rows: int = 4
@@ -666,6 +667,9 @@ class ConfigLoader:
         )
         config.background_task_retention_hours = _clean_positive_int(
             image_settings.get("background_task_retention_hours"), 24
+        )
+        config.background_failure_notify_llm = bool(
+            image_settings.get("background_failure_notify_llm", True)
         )
 
         # 表情包网格设置


### PR DESCRIPTION
## 改动说明

<!-- 简要描述本次 PR 的改动内容和目的 -->

## 改动类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 重构 / 代码优化
- [ ] 文档更新
- [ ] 其他

## 关联 Issue

<!-- 如有关联 Issue 请填写，例如 Fixes #123 -->

## 测试情况

- [ ] 本地测试通过
- [ ] 已测试相关命令（/生图、/改图、/快速 等）
- [ ] 已测试 LLM 工具调用

## 补充说明

<!-- 需要 reviewer 特别关注的点、兼容性说明等 -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/piexian/astrbot_plugin_gemini_image_generation/pull/100" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

## Sourcery 总结

将 LLM 触发的后台图像生成失败通过框架的官方通知流程进行处理，同时保留可配置的直接消息回退行为。

错误修复：
- 将 LLM 触发的后台图像生成任务中的失败和异常通过框架官方的代理通知路径进行处理，而不是直接将原始错误发送到聊天中。
- 通过相同的用户通知路径汇总批量生成失败，同时保留任务失败状态跟踪和状态查询功能。

增强功能：
- 添加配置选项，用于启用或禁用由 LLM 介导的后台生成失败通知；禁用通知或官方 API 不可用时，保留现有的直接错误处理行为。

文档：
- 记录新的后台失败通知设置，并在变更日志中说明更新后的失败处理行为。

测试：
- 增加对官方通知成功、生成异常、优雅回退、禁用通知、框架 API 缺失以及批量失败摘要的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Route LLM-triggered background image-generation failures through the framework’s official notification workflow while retaining configurable direct-message fallback behavior.

Bug Fixes:
- Route failures and exceptions from LLM-triggered background image-generation tasks through the framework’s official agent notification path instead of sending raw errors directly to the chat.
- Aggregate batch-generation failures through the same user-notification path while preserving task failure status tracking and status queries.

Enhancements:
- Add a configuration option to enable or disable LLM-mediated notifications for background generation failures, with the existing direct-error behavior retained when disabled or when the official API is unavailable.

Documentation:
- Document the new background failure notification setting and record the updated failure behavior in the changelog.

Tests:
- Add coverage for successful official notification, generation exceptions, graceful fallback, disabled notifications, missing framework APIs, and batch failure summaries.

</details>