### PR TITLE
添加其他插件接入核心

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 - **多供应商支持**：Google Gemini、Gemini Interactions（Nano Banana 系列）、Vertex AI（服务账号 JSON / Express API Key 双认证）、OpenAI 兼容、OpenAI Images、Agnes AI、xAI Images、MiniMax、阶跃星辰、豆包、SenseNova、DashScope（通义万相/千问图像/z-image）。
 - **供应商与模型路由**：支持供应商、原始模型或别名选择；未指定时按配置轮询，显式指定时只在匹配候选内重试。
 - **LLM 工具集成**：支持自然语言生图、参数能力查询、后台任务查询和命名批量生成；前台超时后返回任务号并继续生成。
+- **插件接入接口**：其他 AstrBot 插件可获取公开服务实例、查询就绪状态并提交后台生图任务，支持查询、等待及完成回调；会话与使用者信息可选。详见 [其他插件接入指南](docs/plugin-api.md)。
 - **表情包切分**：内置 SmartMemeSplitter v4，默认优先走自适应黑描边贴纸切分，并保留手动网格、视觉识别等兜底路径。
 - **限流与缓存**：支持群白名单/黑名单、全插件共享额度与 UMO 会话限流叠加、KV 持久化；Studio 统一管理群限制模式、群号名单与限流规则，可搜索本体已有会话并即时保存。生成图保留在插件数据目录并按容量自动清理，临时文件统一写入 AstrBot 临时目录。
 - **内置 WebUI 创作台**：Dashboard 插件页「studio」——在线工作台（模型扁平直选、临时生成参数弹窗确认、单图多张与批量生成、参考图上传/画廊拾取）、全来源生成任务实时进度（SSE）、历史画廊（筛选/灯箱/下载/删除/再次生成/用作参考图）；生成历史持久化归档，存量图片自动迁入，运行任务使用的上传参考图受租约保护。详见 [使用指南](docs/usage.md#webui-创作台)。
@@ -57,12 +58,13 @@ https://github.com/piexian/astrbot_plugin_gemini_image_generation
 - 可选配置 `provider_settings.provider_polling`，按列表从上到下自动尝试生成；重复供应商会自动去重，未知供应商会记录错误并跳过；
 - 使用 `openai_images`、`doubao` 或 `dashscope` 且 `size_mode=custom` 时，配置界面只显示 `custom_size`，避免混用通用分辨率字段。
 
-常用配置入口：
+文档索引：
 
 - [完整配置参考](https://github.com/piexian/astrbot_plugin_gemini_image_generation/blob/master/docs/config.md)
 - [使用指南](https://github.com/piexian/astrbot_plugin_gemini_image_generation/blob/master/docs/usage.md)
 - [故障排除](https://github.com/piexian/astrbot_plugin_gemini_image_generation/blob/master/docs/troubleshooting.md)
 - [新增 API 供应商](https://github.com/piexian/astrbot_plugin_gemini_image_generation/blob/master/docs/新增API供应商.md)
+- [其他插件接入指南（API v1）](docs/plugin-api.md)
 
 ## 常用命令
 

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -2103,6 +2103,18 @@
           "step": 1
         }
       },
+      "generation_max_concurrency": {
+        "description": "全入口生成并发上限",
+        "hint": "指令、LLM、Studio 与外部插件共享的生成执行槽。修改后重载插件生效。",
+        "type": "int",
+        "default": 3
+      },
+      "generation_max_queue_size": {
+        "description": "全入口生成队列上限",
+        "hint": "不含执行中的请求。队列满时拒绝新请求；排队不占供应商请求超时。修改后重载插件生效。",
+        "type": "int",
+        "default": 100
+      },
       "background_task_retention_hours": {
         "description": "后台任务记录保留小时数",
         "type": "int",

--- a/docs/config.md
+++ b/docs/config.md
@@ -99,10 +99,14 @@ google / gemini_interactions / vertex / openai / agnes_ai / xai / minimax / step
 | `batch_max_images_per_task` | `10` | 单个命名提示词的目标图片数量上限；供应商原生单次上限更小时自动拆分补齐 |
 | `batch_max_tasks` | `20` | 一次 `batch_tasks` 允许的命名任务条目上限 |
 | `batch_concurrency` | `3` | 后台批量生成并发数；每个条目内部按供应商单次上限顺序补齐 |
+| `generation_max_concurrency` | `3` | 指令、LLM、Studio 与外部插件共用的生成执行槽上限；重载生效 |
+| `generation_max_queue_size` | `100` | 全入口等待队列容量，不含执行请求；排队不占供应商请求超时，满时拒绝提交；重载生效 |
 | `background_task_retention_hours` | `24` | 后台任务状态记录保留时间；插件重启会把未完成任务标记为 `interrupted` |
 | `background_failure_notify_llm` | `true` | 无图片产出的后台生图失败时，由 AI 重新组织语言告知用户；回灌不可用时发送简短失败提示，关闭时直发错误文本。有图片产出的后台结果始终反向激活 AI，要求调用 `send_message_to_user` 发送图片 |
 
 分辨率、长宽比、最大参考图数量、Google 文本响应、Google 搜索接地、OpenAI/OpenAI 兼容参数名等均在 `provider_settings.provider_overrides` 的各供应商条目内配置。
+
+外部插件默认自行限流，显式选择接入后才扣本插件额度：有完整 UMO 时匹配会话规则，无 UMO 时按稳定插件标识独立应用默认限流。全局限流开启时额外叠加，关闭时默认限流仍生效。默认规则无需为每个插件重复配置，详见 [其他插件接入指南](plugin-api.md#限流与并发)。
 
 ### LLM 工具本地路径参考图
 

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -1,0 +1,170 @@
+# 其他插件接入指南（API v1）
+
+本接口供同一 AstrBot 实例内的插件复用已配置的图片供应商。每次提交一个提示词，可生成多张图片；不需要聊天事件，也不自动发送图片或唤醒聊天 Agent。
+
+## 获取服务实例
+
+使用 AstrBot 的插件注册接口获取已启用的插件，再获取公开服务。不要导入 `tl/` 内部模块、读取 API Key 或保存内部客户端。
+
+```python
+async def get_image_service(context):
+    metadata = context.get_registered_star("astrbot_plugin_gemini_image_generation")
+    if metadata is None or metadata.star_cls is None:
+        raise RuntimeError("请先安装并启用 Gemini 图像生成插件")
+    getter = getattr(metadata.star_cls, "get_service", None)
+    if getter is None:
+        raise RuntimeError("当前生图插件版本不支持公开接入接口")
+    service = getter(api_version=1)
+    await service.wait_ready(timeout=10)
+    return service
+```
+
+`get_service()` 在同次加载期间返回同一个实例；不支持的 API 版本会抛出带 `code="unsupported_version"` 的异常。配置缺失时仍能获取实例并查询状态。
+
+`get_status()` 为同步方法，返回：
+
+| 字段 | 含义 |
+| --- | --- |
+| `api_version` / `instance_id` | 协议版本和本次服务加载标识 |
+| `state` | `initializing`、`ready`、`unavailable`、`closing` 或 `closed` |
+| `ready` | 本地服务、供应商配置是否就绪，不代表远端网络或余额正常 |
+| `accepting_tasks` | 此刻是否允许提交；队列满时为 false，但仍可 ready |
+| `reason` | `not_configured`、`configuration_updating`、`configuration_failed`、`queue_full`、`service_closed` 等原因，正常为 null |
+| `active_requests` / `queued_requests` | 全入口生成执行槽占用和等待数量 |
+
+`wait_ready(timeout=None)` 等待就绪；可传秒数限制等待，超时抛出 `TimeoutError`。关闭时返回明确错误。查询状态不初始化客户端、不发起网络请求、不扣额度。状态可能在查询后变化，仍需处理提交失败。
+
+供应商热更新保留服务实例；插件卸载或重载后，旧实例永久关闭。调用方应重新从注册接口获取新实例，不能仅以“持有实例”判断已经就绪。
+
+## 最小提交与等待
+
+```python
+async def generate_cover(context, prompt):
+    service = await get_image_service(context)
+    accepted = await service.submit(
+        plugin_id="astrbot_plugin_my_story",
+        plugin_name="故事插件",
+        prompt=prompt,
+    )
+    result = await service.wait_task(
+        accepted["task_id"], plugin_id="astrbot_plugin_my_story", timeout=180
+    )
+    if result["status"] not in {"succeeded", "partial_success"}:
+        raise RuntimeError(result.get("error") or "图片生成未完成")
+    return result["image_urls"], result["image_paths"]
+```
+
+`wait_task()` 超时或调用方取消等待，不会取消后台生成。之后可再次等待，或使用 `await service.get_task(task_id, plugin_id=...)` 查询。
+
+## 提交参数
+
+`submit()` 为异步方法，所有参数均按名称传递。
+
+| 参数 | 默认值及约定 |
+| --- | --- |
+| `plugin_id` | 必填，稳定插件标识；非空、最多 128 字符，不含控制字符 |
+| `prompt` | 必填，非空提示词 |
+| `plugin_name` | 可选显示名称，最多 200 字符；修改名称不改变任务归属或限流桶 |
+| `umo` | 可选完整会话标识：`平台实例ID:消息类型:会话ID` |
+| `requester` | 可选对象，支持 `user_id`、`user_name`、`group_id`、`chat_type`；仅用于来源展示 |
+| `use_rate_limit` | 默认 false，由调用插件自行限流；true 时接入下文规则 |
+| `reference_images` | 可选 HTTP(S) URL 或存在的本地绝对文件路径列表；支持本地 file URI |
+| `provider` / `model` | 可选供应商和模型／别名；不指定时沿用已配置的轮询候选 |
+| `image_count` | 默认 1，上限取自 `capabilities().max_images_per_task`，不足时按现有逻辑补齐 |
+| `resolution` / `aspect_ratio` | 可选尺寸／分辨率及比例，按供应商能力处理 |
+| `negative_prompt` / `watermark` / `quality` | 可选公共生成参数，只路由到支持它们的候选 |
+| `on_complete` | 可选异步函数，参数为最终任务记录 |
+
+`capabilities()` 同步返回 `api_version`、`max_images_per_task` 和 `candidates`。候选描述复用现有模型能力数据，不包含密钥。不提供临时凭证、覆盖供应商配置或命名批量任务接口。
+
+有 AstrBot 事件时，将 `event.unified_msg_origin` 传入 `umo`；只提供群号或用户 ID 不会推断出完整会话。无会话时只声明插件身份即可调用。插件身份用于同实例协作和追踪，并非针对不可信插件的认证边界。
+
+## 限流与并发
+
+默认不消耗本插件的限流额度，由调用插件自行限制调用频率。所有请求仍受统一生成并发与队列容量约束。
+
+显式传 `use_rate_limit=True` 后：
+
+- 有完整 UMO：匹配现有会话规则，未匹配则使用默认限流，与同 UMO 的其他调用共享计数。
+- 无 UMO：使用默认限流，按 `plugin_id` 独立计数；不额外应用会话规则。
+- 全局限流开启时再叠加全局检查；全局关闭不影响前两项生效。
+- 一次提交按一个逻辑任务计数，多图补齐和重试不重复扣额度。任务已接收后取消不退额度。
+
+例如仅开启“默认每分钟 5 次”：插件 A 和 B 不传 UMO 时各自拥有 5 次额度；传入同一个 UMO 时则共享该会话额度。显示名称变化不会重置额度，计数沿用现有 KV 持久化。
+
+```python
+# 自己限流（默认）
+await service.submit(plugin_id="astrbot_plugin_a", prompt="画一只猫")
+
+# 无会话：默认规则按插件标识计数
+await service.submit(
+    plugin_id="astrbot_plugin_a", prompt="画一只猫", use_rate_limit=True
+)
+
+# 有会话：会话规则/默认规则按 UMO 计数
+await service.submit(
+    plugin_id="astrbot_plugin_a", prompt="画一只猫",
+    umo=event.unified_msg_origin, use_rate_limit=True,
+)
+```
+
+指令、LLM、Studio 和外部插件共享 FIFO 调度。默认同时执行 3 个生成调用，最多等待 100 个；对应配置为 `image_generation_settings.generation_max_concurrency` 和 `image_generation_settings.generation_max_queue_size`，重载后生效。原有 Studio、批量及供应商局部并发限制仍生效。
+
+排队不消耗供应商请求超时，LLM 前台等待仍会按实际时间切到后台。多图补齐的下一次调用重新排队。队列满返回繁忙错误，不自动无限重试。
+
+## 回调与插件卸载
+
+```python
+class ImageConsumer:
+    def __init__(self, context):
+        self.context = context
+        self.subscriptions = []
+
+    async def start(self, prompt, event=None):
+        service = await get_image_service(self.context)
+        accepted = await service.submit(
+            plugin_id="astrbot_plugin_my_story",
+            plugin_name="故事插件",
+            prompt=prompt,
+            umo=event.unified_msg_origin if event else None,
+            requester={"user_id": str(event.get_sender_id())} if event else None,
+            on_complete=self.on_image_ready,
+        )
+        self.subscriptions.append((service, accepted["task_id"]))
+        return accepted["task_id"]
+
+    async def on_image_ready(self, result):
+        # 在这里交给自己的排版、上传或发送流程；不要再次生成同一张图。
+        self.last_result = result
+
+    async def terminate(self):
+        for service, task_id in self.subscriptions:
+            try:
+                await service.remove_callback(
+                    task_id, plugin_id="astrbot_plugin_my_story"
+                )
+            except RuntimeError:
+                # 服务可能已经重载，或任务记录已经过期。
+                pass
+        self.subscriptions.clear()
+```
+
+回调在生成结果保存后运行，不占生成执行槽，最多等待 30 秒。同次运行每个任务最多尝试一次，不自动重试。`remove_callback()` 只解除尚未执行的回调，返回是否成功解除；调用插件需自行结束已经开始的业务处理。
+
+`callback_status` 与生成状态独立，可能为 `none`、`pending`、`running`、`removed`、`succeeded`、`failed` 或 `interrupted`。回调异常不将已成功的生图改成失败，查询结果仍可用于补发。等待任务结果不等待回调执行完毕。
+
+## 任务状态、错误与图片保存
+
+生成状态为 `queued`、`running`、`succeeded`、`partial_success`、`failed`、`interrupted`。结果包含 `task_id`、`plugin_id`、`caller`、`requester`、`requested_images`、`generated_images`、`image_urls`、`image_paths`、`text_content`、`stats`、`error`、`callback_status`，启用历史时还有对应的 `job_id`。
+
+查询、等待和回调共用同一份生成结果。归档完整时优先返回归档后的本地路径；否则保留供应商原始地址或生成路径。路径和 URL 沿用现有保留、配额及清理策略，不保证永久有效，长期使用应及时自行复制或上传。
+
+`await service.cancel_task(task_id, plugin_id=...)` 取消本地排队或执行，终态任务不变。不能保证撤回供应商已经受理的请求或费用。服务关闭会中断未完成任务；重启后可以重新获取实例查询保留的任务记录，不恢复生成、不重放回调。
+
+提交和服务错误为 `RuntimeError` 的子类，提供稳定 `code`，如 `invalid_request`、`not_ready`、`not_configured`、`queue_full`、`rate_limited`、`service_closed`、`task_not_found`。版本不匹配为 `unsupported_version`；访问其他插件任务会抛出 `PermissionError`。生成开始后的失败写入任务 `status/error`，不要求解析用户提示文本来判断成功。
+
+## WebUI 来源记录
+
+任务列表、历史画廊及图片详情显示“插件调用 · 插件名称”和稳定插件标识。可按“插件调用”来源、插件标识筛选，或搜索插件名称／标识。仅显示调用方提供的会话和使用者信息；无需填写群号或用户才能记录来源。
+
+关闭生成历史时不新增插件历史和归档记录，任务查询仍可用。回调结果单独展示，不覆盖生成状态。

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -54,7 +54,9 @@ async def generate_cover(context, prompt):
     return result["image_urls"], result["image_paths"]
 ```
 
-`wait_task()` 超时或调用方取消等待，不会取消后台生成。之后可再次等待，或使用 `await service.get_task(task_id, plugin_id=...)` 查询。
+`wait_task()` 未传 `timeout` 或传入 `None` 时，使用插件的 `total_timeout`（秒）；显式传入则使用调用方指定的等待时长。超时或调用方取消等待，不会取消后台生成。之后可再次等待，或使用 `await service.get_task(task_id, plugin_id=...)` 查询。
+
+结果收尾时若任务或历史持久化失败，仍保留当前进程内可查询的终态和图片结果，释放等待者并尝试完成回调，同时记录诊断日志。磁盘写入失败时不能保证这些结果在重启后恢复。
 
 ## 提交参数
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -33,7 +33,7 @@ v2.0.0 重构了生图供应商配置，`api_settings` 和旧的全局 `api_type
 | 无法获取头像 | 确认使用 NapCat 平台，并检查网络权限 |
 | 切图效果不佳 | 尝试 `/切图 4 4` 手动指定网格，或配置 `vision_provider_id` |
 | 白底透明化不稳定 | 优先使用主体吸附模式；复杂背景建议用专门抠图工具处理 |
-| 中文乱码（local 模式） | 等待字体自动下载，或手动放置 `.ttf` 字体到 `tl/` 目录 |
+| 中文乱码（local 模式） | 字体优先从 `astrdark.cyou` 镜像下载，失败后回退 Noto 官方 GitHub。每个下载源优先使用插件 `proxy`，未设置时使用 HTTPS/HTTP 代理环境变量；代理失败后尝试直连。也可手动放置 `.ttf`、`.otf` 或 `.ttc` 中文字体到 `tl/` 目录 |
 | 网络连接失败 | 在 `provider_settings.proxy` 或具体供应商条目中配置代理地址 |
 | OpenAI Images 尺寸报错 | 检查 `custom_size` 是否为合法 `WxH`，并满足官方尺寸约束 |
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -92,6 +92,10 @@ v2.0.0 起，插件只使用 `供应商配置` 中配置的生图供应商。
 
 ### 前台/后台混合模式
 
+指令、LLM、Studio 与外部插件共用生成执行槽；等待执行槽时工作台显示“排队中”。排队不占供应商请求超时，LLM 前台等待仍按实际时间计算。外部插件任务由调用插件自行使用结果，不默认反向激活聊天 Agent，接入方式见 [其他插件接入指南](plugin-api.md)。
+
+工作台任务、画廊及图片详情会记录外部插件身份；可在画廊选择“插件调用”来源、填写插件标识或搜索名称。会话及使用者只在调用方提供时展示，回调失败不会覆盖生图结果。
+
 LLM 工具会根据当前 `tool_call_timeout` 和 `llm_tool_timeout_reserve_percent` 计算前台等待窗口：
 
 超时取自当前会话绑定的 AstrBot 配置，优先读取 `agent_runner.config.misc.tool_call_timeout`，兼容旧版的 `provider_settings.tool_call_timeout`。例如工具超时为 300 秒、预留比例为 75% 时，前台等待 75 秒。后台生成的总超时仍由插件的 `total_timeout` 控制。

--- a/main.py
+++ b/main.py
@@ -584,7 +584,7 @@ class GeminiImageGenerationPlugin(Star):
     async def _ensure_font_for_local_mode(self):
         """确保 local 渲染模式所需的字体已下载"""
         try:
-            await ensure_font_downloaded()
+            await ensure_font_downloaded(proxy=self.cfg.proxy)
         except Exception as e:
             logger.warning(f"字体下载任务异常: {e}")
 

--- a/main.py
+++ b/main.py
@@ -54,10 +54,12 @@ from .tl.enhanced_prompts import (
     get_style_change_prompt,
     get_wallpaper_prompt,
 )
+from .tl.generation_scheduler import GenerationScheduler
 from .tl.generation_tracker import GenerationTracker, requester_from_event
 from .tl.llm_query_tools import BackgroundTaskStatusTool, ProviderModelQueryTool
 from .tl.llm_tools import GeminiImageGenerationTool
 from .tl.plugin_config import get_session_tool_timeout, max_configured_reference_images
+from .tl.plugin_service import ImageGenerationService, PluginServiceError
 from .tl.provider_capabilities import select_candidates
 from .tl.provider_runtime import ProviderRuntime, provider_operation
 from .tl.provider_settings import candidate_is_keyless
@@ -109,6 +111,10 @@ class GeminiImageGenerationPlugin(Star):
 
         # 加载配置（传入数据目录用于备份）
         self.cfg = ConfigLoader(config or {}, data_dir=self._plugin_data_dir).load()
+        self.generation_scheduler = GenerationScheduler(
+            self.cfg.generation_max_concurrency, self.cfg.generation_max_queue_size
+        )
+        self._public_service = ImageGenerationService(self)
         # 生成图保留区的容量上限（写图时按需清理）
         set_image_cache_max_size_mb(self.cfg.image_cache_max_size_mb)
         self.background_task_manager = BackgroundTaskManager(
@@ -148,6 +154,13 @@ class GeminiImageGenerationPlugin(Star):
 
         # 插件重载不会再次触发 AstrBot 全局 loaded hook，因此必须在构造期注册。
         self._register_web_studio_routes()
+        self._public_service.initialized()
+
+    def get_service(self, api_version: int = 1) -> ImageGenerationService:
+        """获取公开服务；调用前通过 get_status()/wait_ready() 确认可用状态。"""
+        if type(api_version) is not int or api_version != 1:
+            raise PluginServiceError("unsupported_version", "仅支持插件生图接口 v1")
+        return self._public_service
 
     def _cleanup_legacy_cache_dirs(self):
         """清理旧版本插件数据目录下的缓存（已迁移到 AstrBot 临时目录）。
@@ -348,6 +361,9 @@ class GeminiImageGenerationPlugin(Star):
             logger.warning(f"注册 LLM 工具失败: {e}，将使用装饰器方式")
 
     def _provider_jobs_busy(self) -> bool:
+        scheduler = getattr(self, "generation_scheduler", None)
+        if scheduler is not None and scheduler.busy:
+            return True
         for service in (self.web_studio_service, self.background_task_manager):
             if any(not task.done() for task in service._runtime_tasks.values()):
                 return True
@@ -404,6 +420,8 @@ class GeminiImageGenerationPlugin(Star):
         """插件卸载/重载时调用"""
         self._web_closed = True
         self.provider_runtime.closed = True
+        await self._public_service.close()
+        await self.generation_scheduler.close()
         if self.studio_providers is not None:
             await self.studio_providers.close()
         # 已开始的配置事务先完成，避免关闭资源时仍在切换客户端。
@@ -422,13 +440,13 @@ class GeminiImageGenerationPlugin(Star):
             logger.debug(f"[WebUI] 工作台路由注销失败: {e}")
         self._web_routes = []
         try:
-            await self.generation_tracker.close()
-        except Exception as e:
-            logger.debug(f"关闭生成历史追踪器失败: {e}")
-        try:
             await self.background_task_manager.close()
         except Exception as e:
             logger.debug(f"关闭后台任务管理器失败: {e}")
+        try:
+            await self.generation_tracker.close()
+        except Exception as e:
+            logger.debug(f"关闭生成历史追踪器失败: {e}")
         if self.api_client and hasattr(self.api_client, "close"):
             try:
                 await self.api_client.close()
@@ -497,6 +515,7 @@ class GeminiImageGenerationPlugin(Star):
         ):
             self.api_client = get_api_client(all_api_keys)
             self.api_client.provider_runtime = self.provider_runtime
+            self.api_client.generation_scheduler = self.generation_scheduler
             self.api_client.api_keys = all_api_keys
             self.api_client.set_provider_candidates(
                 usable_candidates,

--- a/pages/studio/app.js
+++ b/pages/studio/app.js
@@ -121,7 +121,8 @@ const SafeDOM = {
   },
 
   // 来源标识 -> 中文标签
-  sourceLabel(source) {
+  sourceLabel(source, caller) {
+    if (source === 'plugin') return `插件调用 · ${caller?.plugin_name || caller?.plugin_id || '插件'}`;
     const labels = {
       command: '指令',
       llm_tool: 'LLM 工具',
@@ -201,6 +202,8 @@ const SafeDOM = {
       chatLabel = groupId ? `群聊 · 群号: ${groupId}` : '群聊 · 群号未记录';
     }
     const labels = [chatLabel];
+    if (source === 'plugin' && chatType !== 'private' && chatType !== 'group' && !groupId) labels.length = 0;
+    if (source === 'plugin' && requester?.umo) labels.push(`会话: ${requester.umo}`);
     if (userName && userId) labels.push(`用户: ${userName}（ID: ${userId}）`);
     else if (userId) labels.push(`用户 ID: ${userId}`);
     else if (userName) labels.push(`用户: ${userName}`);
@@ -208,8 +211,12 @@ const SafeDOM = {
   },
 
   requesterMeta(record) {
+    const labels = this.requesterLabels(record.requester, record.source);
+    if (record.source === 'plugin' && record.caller?.plugin_id) labels.unshift(`插件 ID: ${record.caller.plugin_id}`);
+    const callbackLabels = { pending: '待通知', running: '通知中', removed: '已取消通知', succeeded: '已通知', failed: '通知失败', interrupted: '通知已中断' };
+    if (callbackLabels[record.callback_status]) labels.push(callbackLabels[record.callback_status]);
     return this.el('div', { className: 'job-meta-row requester-meta' },
-      this.requesterLabels(record.requester, record.source).map((label) =>
+      labels.map((label) =>
         this.el('span', { className: 'meta-pill' }, [label])
       )
     );
@@ -720,8 +727,9 @@ const Lightbox = {
       this.tagsEl.appendChild(SafeDOM.el('span', { className: 'meta-pill' }, [`耗时: ${(item.duration_ms / 1000).toFixed(1)}s`]));
     }
     if (item.source) {
-      this.tagsEl.appendChild(SafeDOM.el('span', { className: 'meta-pill' }, [`来源: ${SafeDOM.sourceLabel(item.source)}`]));
+      this.tagsEl.appendChild(SafeDOM.el('span', { className: 'meta-pill' }, [`来源: ${SafeDOM.sourceLabel(item.source, item.caller)}`]));
     }
+    if (item.caller?.plugin_id) this.tagsEl.appendChild(SafeDOM.el('span', { className: 'meta-pill' }, [`插件 ID: ${item.caller.plugin_id}`]));
     for (const label of SafeDOM.requesterLabels(item.requester, item.source)) {
       this.tagsEl.appendChild(SafeDOM.el('span', { className: 'meta-pill' }, [label]));
     }
@@ -779,7 +787,8 @@ class Store {
       keyword: '',
       source: '',
       group_id: '',
-      user_id: ''
+      user_id: '',
+      plugin_id: ''
     };
     this.galleryData = {
       items: [],
@@ -836,8 +845,8 @@ class Store {
 
   getJobsList() {
     return Array.from(this.activeJobs.values()).sort((a, b) => {
-      const aRunning = a.status === 'running';
-      const bRunning = b.status === 'running';
+      const aRunning = ['queued', 'running'].includes(a.status);
+      const bRunning = ['queued', 'running'].includes(b.status);
       if (aRunning && !bRunning) return -1;
       if (!aRunning && bRunning) return 1;
       const aTime = new Date(a.created_at || 0).getTime();
@@ -849,7 +858,7 @@ class Store {
   getRunningJobsCount() {
     let count = 0;
     for (const job of this.activeJobs.values()) {
-      if (job.status === 'running') count++;
+      if (['queued', 'running'].includes(job.status)) count++;
     }
     return count;
   }
@@ -2482,6 +2491,7 @@ class ProgressView {
     });
     const dot = SafeDOM.el('span', { className: 'status-dot' });
     const textMap = {
+      queued: '排队中',
       running: '进行中',
       succeeded: '已完成',
       partial_success: '部分成功',
@@ -2508,7 +2518,7 @@ class ProgressView {
     const header = SafeDOM.el('div', { className: 'job-header' });
     const headerLeft = SafeDOM.el('div', { className: 'job-header-left' });
 
-    const sourceTag = SafeDOM.el('span', { className: 'job-source-tag' }, [SafeDOM.sourceLabel(record.source)]);
+    const sourceTag = SafeDOM.el('span', { className: 'job-source-tag' }, [SafeDOM.sourceLabel(record.source, record.caller)]);
     const idSpan = SafeDOM.el('button', {
       type: 'button',
       className: 'job-id-text',
@@ -2528,7 +2538,7 @@ class ProgressView {
     const statusPill = this.createStatusPill(record.status);
 
     let durationText = '00:00';
-    if (record.status === 'running') {
+    if (['queued', 'running'].includes(record.status)) {
       const createdAt = new Date(record.created_at || '').getTime();
       const diff = Number.isFinite(createdAt)
         ? Math.max(0, Math.floor((Date.now() - createdAt) / 1000))
@@ -2609,6 +2619,7 @@ class ProgressView {
               aspect_ratio: p.aspect_ratio,
               duration_ms: record.duration_ms,
               source: record.source,
+              caller: record.caller,
               requester: record.requester
             }));
             Lightbox.open(previewItems, idx);
@@ -2701,7 +2712,7 @@ class ProgressView {
     const statusPill = this.createStatusPill(parent.status);
 
     let durationText = '00:00';
-    if (parent.status === 'running') {
+    if (['queued', 'running'].includes(parent.status)) {
       const createdAt = new Date(parent.created_at || '').getTime();
       const diff = Number.isFinite(createdAt)
         ? Math.max(0, Math.floor((Date.now() - createdAt) / 1000))
@@ -2807,7 +2818,8 @@ class ProgressView {
                 aspect_ratio: child.params?.aspect_ratio,
                 duration_ms: child.duration_ms,
                 source: child.source,
-                requester: child.requester
+                caller: child.caller,
+              requester: child.requester
               }));
               Lightbox.open(previewItems, idx);
             }
@@ -2874,6 +2886,7 @@ class GalleryView {
 
     this.searchInput = document.getElementById('gallery-search-input');
     this.sourceSelect = document.getElementById('gallery-source-select');
+    this.pluginInput = document.getElementById('gallery-plugin-input');
     this.groupInput = document.getElementById('gallery-group-input');
     this.userInput = document.getElementById('gallery-user-input');
     this.btnSearch = document.getElementById('btn-search-gallery');
@@ -2901,6 +2914,7 @@ class GalleryView {
     this.btnSearch.addEventListener('click', () => {
       this.store.galleryQuery.keyword = this.searchInput.value.trim();
       this.store.galleryQuery.source = this.sourceSelect.value;
+      this.store.galleryQuery.plugin_id = this.pluginInput.value.trim();
       this.store.galleryQuery.group_id = this.groupInput.value.trim();
       this.store.galleryQuery.user_id = this.userInput.value.trim();
       this.store.galleryQuery.page = 1;
@@ -2916,10 +2930,12 @@ class GalleryView {
     this.btnReset.addEventListener('click', () => {
       this.searchInput.value = '';
       this.sourceSelect.value = '';
+      this.pluginInput.value = '';
       this.groupInput.value = '';
       this.userInput.value = '';
       this.store.galleryQuery.keyword = '';
       this.store.galleryQuery.source = '';
+      this.store.galleryQuery.plugin_id = '';
       this.store.galleryQuery.group_id = '';
       this.store.galleryQuery.user_id = '';
       this.store.galleryQuery.page = 1;
@@ -3114,7 +3130,8 @@ class GalleryView {
           aspect_ratio: item.params?.aspect_ratio,
           duration_ms: item.duration_ms,
           source: item.source,
-          requester: item.requester
+          caller: item.caller,
+              requester: item.requester
         }));
         Lightbox.open(previewItems, 0);
       });
@@ -3133,7 +3150,7 @@ class GalleryView {
     const promptEl = SafeDOM.el('div', { className: 'gallery-card-prompt' }, [item.prompt || '（历史图片，无提示词记录）']);
 
     const meta = SafeDOM.el('div', { className: 'gallery-card-meta' });
-    const sourceEl = SafeDOM.el('span', {}, [`[${SafeDOM.sourceLabel(item.source)}]`]);
+    const sourceEl = SafeDOM.el('span', {}, [`[${SafeDOM.sourceLabel(item.source, item.caller)}]`]);
     const timeEl = SafeDOM.el('span', {}, [
       item.created_at ? new Date(item.created_at).toLocaleDateString('zh-CN') : ''
     ]);

--- a/pages/studio/index.html
+++ b/pages/studio/index.html
@@ -244,8 +244,14 @@
                 <option value="command">指令触发 (command)</option>
                 <option value="llm_tool">LLM 工具 (llm_tool)</option>
                 <option value="llm_batch">LLM 批量 (llm_batch)</option>
+                <option value="plugin">插件调用 (plugin)</option>
                 <option value="legacy">历史图片 (legacy)</option>
               </select>
+            </div>
+            <div class="filter-item">
+              <label for="gallery-plugin-input" class="form-label">插件标识</label>
+              <input type="text" id="gallery-plugin-input" class="comic-input"
+                     maxlength="128" placeholder="全部插件" aria-label="按插件标识筛选">
             </div>
             <div class="filter-item">
               <label for="gallery-group-input" class="form-label">群组 ID</label>

--- a/pages/studio/style.css
+++ b/pages/studio/style.css
@@ -935,6 +935,7 @@ code, kbd, samp, pre, .mono {
 }
 
 .status-pill--running { background-color: var(--pop); color: var(--pop-ink); }
+.status-pill--queued { background-color: var(--warn); color: var(--status-ink); }
 .status-pill--succeeded { background-color: var(--ok); color: var(--status-ink); }
 .status-pill--partial_success { background-color: var(--warn); color: var(--status-ink); }
 .status-pill--failed { background-color: var(--accent); color: var(--status-ink); }

--- a/tests/test_font_download.py
+++ b/tests/test_font_download.py
@@ -1,0 +1,72 @@
+import pytest
+
+from tl import help_renderer
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("explicit", [True, False])
+@pytest.mark.parametrize("mirror_available", [True, False])
+async def test_font_prefers_mirror_and_falls_back_to_official(
+    tmp_path, monkeypatch, explicit, mirror_available
+):
+    import aiohttp
+
+    target = tmp_path / "font.otf"
+    calls = []
+    data = b"OTTO" + b"0" * 1_000_000
+    monkeypatch.setattr(help_renderer, "_find_existing_font_in_tl", lambda: None)
+    monkeypatch.setattr(help_renderer, "_get_font_path", lambda: target)
+    monkeypatch.setattr(help_renderer.os.path, "exists", lambda path: False)
+    monkeypatch.setenv("HTTPS_PROXY", "http://environment:8080")
+    monkeypatch.setattr(help_renderer.ImageFont, "truetype", lambda *args: object())
+
+    class Response:
+        def __init__(self, url, proxy):
+            self.status = (
+                404
+                if proxy or ("astrdark.cyou" in url and not mirror_available)
+                else 200
+            )
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+        async def read(self):
+            return data
+
+    class Session:
+        def __init__(self, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+        def get(self, url, *, proxy):
+            calls.append((url, proxy))
+            return Response(url, proxy)
+
+    monkeypatch.setattr(aiohttp, "ClientSession", Session)
+    assert await help_renderer.ensure_font_downloaded(
+        "http://configured:8080" if explicit else None
+    )
+    assert target.read_bytes() == data
+    proxy = "http://configured:8080" if explicit else "http://environment:8080"
+    mirror, official = help_renderer.FONT_DOWNLOAD_URLS
+    assert mirror.startswith("https://astrdark.cyou/gh/")
+    expected = [(mirror, proxy), (mirror, None)]
+    if not mirror_available:
+        expected += [(official, proxy), (official, None)]
+    assert calls == expected
+
+
+@pytest.mark.asyncio
+async def test_existing_font_does_not_require_network(tmp_path, monkeypatch):
+    target = tmp_path / "font.otf"
+    monkeypatch.setattr(help_renderer, "_find_existing_font_in_tl", lambda: target)
+    assert await help_renderer.ensure_font_downloaded()

--- a/tests/test_generation_scheduler.py
+++ b/tests/test_generation_scheduler.py
@@ -1,0 +1,72 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from tl.api_types import APIError
+from tl.generation_scheduler import GenerationScheduler, scheduled_generation
+
+
+@pytest.mark.asyncio
+async def test_fifo_bound_cancel_and_exception_release():
+    scheduler = GenerationScheduler(1, 2)
+    entered = []
+    gate = asyncio.Event()
+
+    class Client:
+        generation_scheduler = scheduler
+
+        @scheduled_generation
+        async def generate(self, name):
+            entered.append(name)
+            await gate.wait()
+            if name == "first":
+                raise ValueError("upstream failure")
+            return name
+
+    client = Client()
+    first = asyncio.create_task(client.generate("first"))
+    await asyncio.sleep(0)
+    second = asyncio.create_task(client.generate("second"))
+    third = asyncio.create_task(client.generate("third"))
+    await asyncio.sleep(0)
+    with pytest.raises(APIError, match="队列已满"):
+        await client.generate("overflow")
+    second.cancel()
+    await asyncio.gather(second, return_exceptions=True)
+    fourth = asyncio.create_task(client.generate("fourth"))
+    gate.set()
+    outcomes = await asyncio.gather(first, third, fourth, return_exceptions=True)
+    assert isinstance(outcomes[0], ValueError)
+    assert entered == ["first", "third", "fourth"]
+    assert scheduler.active == 0 and not scheduler.waiters
+
+
+@pytest.mark.asyncio
+async def test_queue_wait_precedes_request_clock_and_close_interrupts():
+    scheduler = GenerationScheduler(1, 5)
+    reserved = scheduler.reserve()
+    client = SimpleNamespace(generation_scheduler=scheduler)
+    started = asyncio.Event()
+
+    @scheduled_generation
+    async def generate(owner):
+        started.set()
+        async with asyncio.timeout(0.01):
+            await asyncio.sleep(0)
+        return "ok"
+
+    task = asyncio.create_task(generate(client))
+    await asyncio.sleep(0.02)
+    assert not started.is_set()
+    reserved.release()
+    assert await task == "ok"
+    reserved = scheduler.reserve()
+    waiting = asyncio.create_task(generate(client))
+    await asyncio.sleep(0)
+    await scheduler.close()
+    assert waiting.cancelled()
+    reserved.release()
+    assert not scheduler.busy
+    with pytest.raises(APIError):
+        scheduler.reserve()

--- a/tests/test_limit_admission.py
+++ b/tests/test_limit_admission.py
@@ -604,6 +604,8 @@ async def test_plugin_closes_limiter_after_request_producers(command_plugin):
     plugin.studio_providers = None
     plugin.provider_runtime = SimpleNamespace(closed=False)
     plugin.configuration_lock = asyncio.Lock()
+    plugin._public_service = module("service")
+    plugin.generation_scheduler = module("scheduler")
     plugin.web_studio_service = module("studio")
     plugin.generation_tracker = module("tracker")
     plugin.background_task_manager = module("background")
@@ -612,7 +614,16 @@ async def test_plugin_closes_limiter_after_request_producers(command_plugin):
     await plugin.terminate()
     assert plugin._web_closed
     assert closed[-1] == "limiter"
-    assert set(closed) == {"studio", "tracker", "background", "api", "limiter"}
+    assert set(closed) == {
+        "service",
+        "scheduler",
+        "studio",
+        "tracker",
+        "background",
+        "api",
+        "limiter",
+    }
+    assert closed.index("background") < closed.index("tracker")
 
 
 @pytest.mark.asyncio

--- a/tests/test_plugin_service.py
+++ b/tests/test_plugin_service.py
@@ -13,6 +13,66 @@ from tl.provider_runtime import ProviderRuntime
 from tl.rate_limiter import RateLimiter
 
 
+@pytest.mark.asyncio
+async def test_wait_uses_configured_timeout_and_explicit_override(tmp_path):
+    service, gate = make_service(tmp_path)
+    gate.clear()
+    service.plugin.cfg.total_timeout = 0.01
+    accepted = await service.submit(plugin_id="a", prompt="draw")
+    task_id = accepted["task_id"]
+    with pytest.raises(TimeoutError):
+        await service.wait_task(task_id, plugin_id="a")
+    assert (await service.get_task(task_id, plugin_id="a"))["status"] == "running"
+    waiting = asyncio.create_task(service.wait_task(task_id, plugin_id="a", timeout=2))
+    await asyncio.sleep(0.03)
+    assert not waiting.done()
+    gate.set()
+    assert (await waiting)["status"] == "succeeded"
+    await service.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", ["history", "task", "both"])
+async def test_finish_storage_failure_releases_waiters_and_runs_callback(
+    tmp_path, failure
+):
+    service, gate = make_service(tmp_path)
+    gate.clear()
+    callbacks = []
+
+    async def callback(result):
+        callbacks.append(result)
+
+    accepted = await service.submit(plugin_id="a", prompt="draw", on_complete=callback)
+    task_id = accepted["task_id"]
+    task = service._tasks[task_id]
+    await service.plugin.api_client.entered.wait()
+    waiting = asyncio.create_task(service.wait_task(task_id, plugin_id="a", timeout=2))
+    await asyncio.sleep(0)
+
+    async def broken_save():
+        raise OSError("disk full")
+
+    manager = service.plugin.background_task_manager
+    tracker = service.plugin.generation_tracker
+    if failure in {"task", "both"}:
+        manager._save = broken_save
+    if failure in {"history", "both"}:
+        tracker._save = broken_save
+    gate.set()
+    result = await waiting
+    await task
+    assert result["status"] == "succeeded"
+    assert result["image_urls"] == ["https://example.org/1.png"]
+    assert len(callbacks) == 1
+    assert callbacks[0]["image_urls"] == result["image_urls"]
+    assert (await service.get_task(task_id, plugin_id="a"))[
+        "callback_status"
+    ] == "succeeded"
+    assert task_id not in service._events
+    await service.close()
+
+
 def make_service(tmp_path, *, history=True):
     cfg = PluginConfig(
         provider_candidates=[
@@ -30,9 +90,11 @@ def make_service(tmp_path, *, history=True):
     class Client:
         generation_scheduler = scheduler
         calls = 0
+        entered = asyncio.Event()
 
         @scheduled_generation
         async def generate_image(self, config, **kwargs):
+            self.entered.set()
             await gate.wait()
             self.calls += 1
             config.successful_provider = "xai"

--- a/tests/test_plugin_service.py
+++ b/tests/test_plugin_service.py
@@ -1,0 +1,324 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from tl.background_tasks import BackgroundTaskManager
+from tl.generation_scheduler import GenerationScheduler, scheduled_generation
+from tl.generation_tracker import GenerationTracker
+from tl.image_generator import ImageGenerator
+from tl.plugin_config import PluginConfig, ProviderCandidate
+from tl.plugin_service import ImageGenerationService, PluginServiceError
+from tl.provider_runtime import ProviderRuntime
+from tl.rate_limiter import RateLimiter
+
+
+def make_service(tmp_path, *, history=True):
+    cfg = PluginConfig(
+        provider_candidates=[
+            ProviderCandidate(
+                id="xai#1",
+                api_type="xai",
+                settings={"model": "grok-imagine-image", "api_keys": ["test"]},
+            )
+        ]
+    )
+    scheduler = GenerationScheduler(1, 3)
+    gate = asyncio.Event()
+    gate.set()
+
+    class Client:
+        generation_scheduler = scheduler
+        calls = 0
+
+        @scheduled_generation
+        async def generate_image(self, config, **kwargs):
+            await gate.wait()
+            self.calls += 1
+            config.successful_provider = "xai"
+            config.successful_model = "grok-imagine-image"
+            return [f"https://example.org/{self.calls}.png"], [], None, None
+
+    tracker = GenerationTracker(tmp_path, 30, enabled=history)
+    client = Client()
+
+    async def archive(urls, paths, **kwargs):
+        return []
+
+    plugin = SimpleNamespace(
+        cfg=cfg,
+        api_client=client,
+        provider_runtime=ProviderRuntime(),
+        generation_scheduler=scheduler,
+        generation_tracker=tracker,
+        background_task_manager=BackgroundTaskManager(tmp_path),
+        rate_limiter=RateLimiter(cfg),
+        image_generator=ImageGenerator(None, client, tracker=tracker),
+        web_studio_service=SimpleNamespace(archive_images=archive),
+    )
+    service = ImageGenerationService(plugin)
+    service.initialized()
+    return service, gate
+
+
+@pytest.mark.asyncio
+async def test_ready_config_recovery_queue_full_and_old_instance(tmp_path):
+    service, _ = make_service(tmp_path)
+    assert service.get_status()["ready"]
+    capability = service.capabilities()["candidates"][0]
+    assert capability["provider"] == "xai"
+    assert capability["model"] == "grok-imagine-image"
+    assert "api_keys" not in capability and "settings" not in capability
+    service.plugin.provider_runtime.updating = True
+    assert service.get_status()["reason"] == "configuration_updating"
+    with pytest.raises(TimeoutError):
+        await service.wait_ready(timeout=0.01)
+    service.plugin.provider_runtime.updating = False
+    service.plugin.api_client = None
+    assert service.get_status()["reason"] == "not_configured"
+    service.plugin.api_client = service.plugin.image_generator.api_client
+    assert (await service.wait_ready(timeout=1))["instance_id"] == service.instance_id
+    tickets = [service.plugin.generation_scheduler.reserve() for _ in range(4)]
+    assert service.get_status()["ready"] and not service.get_status()["accepting_tasks"]
+    with pytest.raises(PluginServiceError) as exc:
+        await service.submit(plugin_id="a", prompt="draw")
+    assert exc.value.code == "queue_full"
+    for ticket in tickets:
+        ticket.release()
+    await service.close()
+    assert service.get_status()["state"] == "closed"
+    with pytest.raises(PluginServiceError):
+        await service.wait_ready()
+
+
+@pytest.mark.asyncio
+async def test_identity_callback_multi_image_and_history(tmp_path):
+    service, _ = make_service(tmp_path)
+    callbacks = []
+
+    async def callback(result):
+        callbacks.append(result)
+        raise RuntimeError("consumer failed")
+
+    accepted = await service.submit(
+        plugin_id="story",
+        plugin_name="故事插件",
+        prompt="draw",
+        image_count=2,
+        on_complete=callback,
+    )
+    task_id = accepted["task_id"]
+    task = service._tasks[task_id]
+    result = await service.wait_task(task_id, plugin_id="story", timeout=2)
+    await task
+    assert result["status"] == "succeeded"
+    assert result["generated_images"] == 2
+    assert callbacks[0]["image_urls"] == result["image_urls"]
+    result = await service.get_task(task_id, plugin_id="story")
+    assert result["callback_status"] == "failed"
+    with pytest.raises(PermissionError):
+        await service.get_task(task_id, plugin_id="other")
+    with pytest.raises(PermissionError):
+        await service.plugin.background_task_manager.get(task_id, "")
+    records = service.plugin.generation_tracker.records_snapshot()
+    assert len(records) == 1
+    assert records[0]["caller"] == {"plugin_id": "story", "plugin_name": "故事插件"}
+    assert records[0]["source"] == "plugin"
+    assert records[0]["callback_status"] == "failed"
+    await service.close()
+
+
+@pytest.mark.asyncio
+async def test_wait_timeout_immediate_cancel_and_shutdown(tmp_path):
+    service, gate = make_service(tmp_path)
+    gate.clear()
+    accepted = await service.submit(plugin_id="a", prompt="draw")
+    task_id = accepted["task_id"]
+    with pytest.raises(TimeoutError):
+        await service.wait_task(task_id, plugin_id="a", timeout=0.01)
+    assert (await service.get_task(task_id, plugin_id="a"))["status"] == "running"
+    queued = await service.submit(plugin_id="b", prompt="draw")
+    result = await service.cancel_task(queued["task_id"], plugin_id="b")
+    assert result["status"] == "interrupted"
+    await service.close()
+    with pytest.raises(PluginServiceError):
+        await service.get_task(task_id, plugin_id="a")
+    recovered = BackgroundTaskManager(tmp_path)
+    assert (await recovered.get_for_plugin(task_id, "a"))["status"] == "interrupted"
+    assert not service.plugin.generation_scheduler.busy
+
+
+@pytest.mark.asyncio
+async def test_default_limits_without_global_and_optional_umo(tmp_path):
+    service, _ = make_service(tmp_path, history=False)
+    service.plugin.cfg.default_rate_limit = {
+        "enabled": True,
+        "period_seconds": 60,
+        "max_requests": 1,
+    }
+    for name in ["a", "b"]:
+        accepted = await service.submit(
+            plugin_id=name, prompt="draw", use_rate_limit=True
+        )
+        await service.wait_task(accepted["task_id"], plugin_id=name)
+    with pytest.raises(PluginServiceError) as exc:
+        await service.submit(
+            plugin_id="a", plugin_name="renamed", prompt="draw", use_rate_limit=True
+        )
+    assert exc.value.code == "rate_limited"
+    accepted = await service.submit(plugin_id="a", prompt="draw")
+    await service.wait_task(accepted["task_id"], plugin_id="a")
+    umo = "qq:GroupMessage:123"
+    accepted = await service.submit(
+        plugin_id="a", prompt="draw", umo=umo, use_rate_limit=True
+    )
+    await service.wait_task(accepted["task_id"], plugin_id="a")
+    with pytest.raises(PluginServiceError):
+        await service.submit(plugin_id="b", prompt="draw", umo=umo, use_rate_limit=True)
+    with pytest.raises(PluginServiceError):
+        await service.submit(plugin_id="b", prompt="draw", umo="invalid")
+    assert service.plugin.generation_tracker.records_snapshot() == []
+    await service.close()
+
+
+@pytest.mark.asyncio
+async def test_callback_removed_and_shutdown_during_submission(tmp_path):
+    service, gate = make_service(tmp_path)
+    gate.clear()
+    called = []
+
+    async def callback(result):
+        called.append(result)
+
+    accepted = await service.submit(plugin_id="a", prompt="draw", on_complete=callback)
+    task_id = accepted["task_id"]
+    assert await service.remove_callback(task_id, plugin_id="a")
+    gate.set()
+    assert (await service.wait_task(task_id, plugin_id="a"))[
+        "callback_status"
+    ] == "removed"
+    assert not called
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    acquire = service.plugin.rate_limiter.acquire
+
+    async def slow_acquire(*args, **kwargs):
+        entered.set()
+        await release.wait()
+        return await acquire(*args, **kwargs)
+
+    service.plugin.rate_limiter.acquire = slow_acquire
+    submission = asyncio.create_task(
+        service.submit(plugin_id="b", prompt="draw", use_rate_limit=True)
+    )
+    await entered.wait()
+    closing = asyncio.create_task(service.close())
+    await asyncio.sleep(0)
+    release.set()
+    with pytest.raises(PluginServiceError) as exc:
+        await submission
+    assert exc.value.code == "service_closed"
+    await closing
+    assert not service.plugin.generation_scheduler.busy
+
+
+@pytest.mark.asyncio
+async def test_plugin_limit_buckets_persist_and_do_not_collide_with_umo():
+    import copy
+
+    saved = {}
+
+    async def get_kv(key, default):
+        return copy.deepcopy(saved.get(key, default))
+
+    async def put_kv(key, value):
+        saved[key] = copy.deepcopy(value)
+
+    config = PluginConfig(
+        default_rate_limit={"enabled": True, "period_seconds": 60, "max_requests": 1}
+    )
+    first = RateLimiter(config, get_kv=get_kv, put_kv=put_kv)
+    assert (await first.acquire(None, plugin_id="GroupMessage:x")).allowed
+    assert (await first.acquire("plugin:GroupMessage:x")).allowed
+    await first.close()
+    second = RateLimiter(config, get_kv=get_kv, put_kv=put_kv)
+    assert not (await second.acquire(None, plugin_id="GroupMessage:x")).allowed
+    assert (await second.acquire(None, plugin_id="other")).allowed
+    await second.close()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_sources_history_filter_and_archived_result(tmp_path):
+    service, _ = make_service(tmp_path)
+
+    async def archive(urls, paths, **kwargs):
+        gallery = service.plugin.generation_tracker.gallery_dir
+        gallery.mkdir(exist_ok=True)
+        name = kwargs["job_id"] + ".png"
+        (gallery / name).write_bytes(b"test artifact")
+        return [name]
+
+    service.plugin.web_studio_service.archive_images = archive
+    submissions = await asyncio.gather(
+        *(
+            service.submit(
+                plugin_id=name,
+                plugin_name=f"名称{name}",
+                prompt="draw",
+                requester={"user_id": name},
+                umo=f"qq:FriendMessage:{name}",
+            )
+            for name in ["a", "b"]
+        )
+    )
+    for name, submission in zip(["a", "b"], submissions):
+        result = await service.wait_task(submission["task_id"], plugin_id=name)
+        assert not result["image_urls"]
+        assert result["image_paths"] == [
+            str(
+                service.plugin.generation_tracker.gallery_dir
+                / (result["job_id"] + ".png")
+            )
+        ]
+        matches = service.plugin.generation_tracker.query_history(
+            page=1,
+            size=20,
+            keyword=f"名称{name}",
+            source="plugin",
+            group_id="",
+            user_id="",
+            plugin_id=name,
+        )
+        assert matches["total"] == 1
+        assert matches["items"][0]["requester"]["user_id"] == name
+        assert matches["items"][0]["requester"]["umo"] == f"qq:FriendMessage:{name}"
+    await service.close()
+
+
+@pytest.mark.asyncio
+async def test_partial_generation_preserves_images_and_restart_does_not_replay_callback(
+    tmp_path,
+):
+    service, _ = make_service(tmp_path)
+    original = service.plugin.image_generator.generate_image_core
+    calls = 0
+
+    async def generate(**kwargs):
+        nonlocal calls
+        calls += 1
+        return await original(**kwargs) if calls == 1 else (False, "供应商拒绝后续请求")
+
+    service.plugin.image_generator.generate_image_core = generate
+    accepted = await service.submit(plugin_id="a", prompt="draw", image_count=2)
+    result = await service.wait_task(accepted["task_id"], plugin_id="a")
+    assert result["status"] == "partial_success" and result["generated_images"] == 1
+    await service.close()
+    # Simulate a process exit between generation completion and callback delivery.
+    await service.plugin.background_task_manager.update(
+        accepted["task_id"], callback_status="pending"
+    )
+    reloaded = BackgroundTaskManager(tmp_path)
+    restored = await reloaded.get_for_plugin(accepted["task_id"], "a")
+    assert restored["status"] == "partial_success"
+    assert restored["callback_status"] == "interrupted"

--- a/tests/test_studio_frontend.py
+++ b/tests/test_studio_frontend.py
@@ -56,6 +56,10 @@ assert.deepEqual(SafeDOM.requesterLabels({user_id: '10001'}, 'command'),
 assert.deepEqual(SafeDOM.requesterLabels({user_name: 'admin'}, 'webui'),
   ['工作台提交', '用户: admin']);
 assert.deepEqual(SafeDOM.requesterLabels(undefined, 'legacy'), ['会话类型未知']);
+assert.deepEqual(SafeDOM.requesterLabels({}, 'plugin'), []);
+assert.deepEqual(SafeDOM.requesterLabels({umo: 'qq:GroupMessage:1', user_name: '小明'}, 'plugin'), ['会话: qq:GroupMessage:1', '用户: 小明']);
+assert.equal(SafeDOM.sourceLabel('plugin', {plugin_id: 'story', plugin_name: '故事插件'}), '插件调用 · 故事插件');
+assert.equal(SafeDOM.sourceLabel('plugin', {plugin_id: 'story'}), '插件调用 · story');
 assert.deepEqual(SafeDOM.requesterLabels({user_name: '<img onerror=alert(1)>'}, 'command'),
   ['会话类型未知', '用户: <img onerror=alert(1)>']);
 """

--- a/tl/README.md
+++ b/tl/README.md
@@ -22,6 +22,8 @@ main.py
 
 ## 稳定内部入口
 
+其他插件应通过主插件的 `get_service(api_version=1)` 获取公开服务，协议见 [其他插件接入指南](../docs/plugin-api.md)。`plugin_service.py` 管理服务就绪、插件任务及回调；`generation_scheduler.py` 在共用 API 入口管理全入口 FIFO 并发，以下内部入口不构成对外兼容承诺。
+
 | 入口 | 位置 | 作用 |
 |------|------|------|
 | `PluginConfig` | `plugin_config.py` | 运行时配置数据对象 |

--- a/tl/background_tasks.py
+++ b/tl/background_tasks.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import json
 import os
 import uuid
@@ -75,6 +76,9 @@ class BackgroundTaskManager:
         changed = False
         now_text = _timestamp()
         for record in self._records.values():
+            if record.get("callback_status") in {"pending", "running"}:
+                record["callback_status"] = "interrupted"
+                changed = True
             if record.get("status") in {"queued", "running"}:
                 record["status"] = "interrupted"
                 record["updated_at"] = now_text
@@ -86,6 +90,11 @@ class BackgroundTaskManager:
         cutoff = _now() - timedelta(hours=self.retention_hours)
         expired: list[str] = []
         for task_id, record in self._records.items():
+            if (
+                record.get("status") in {"queued", "running"}
+                or task_id in self._runtime_tasks
+            ):
+                continue
             value = record.get("updated_at") or record.get("created_at")
             try:
                 updated_at = datetime.fromisoformat(str(value))
@@ -108,6 +117,7 @@ class BackgroundTaskManager:
         routing_mode: str,
         message: str,
         total_items: int = 1,
+        plugin_id: str | None = None,
     ) -> dict[str, Any]:
         async with self._lock:
             self._prune_expired()
@@ -129,9 +139,11 @@ class BackgroundTaskManager:
                 "current_item": None,
                 "items": [],
             }
+            if plugin_id is not None:
+                record["plugin_id"] = plugin_id
             self._records[task_id] = record
             await self._save()
-            return dict(record)
+            return copy.deepcopy(record)
 
     async def update(self, task_id: str, **changes: Any) -> dict[str, Any] | None:
         async with self._lock:
@@ -141,7 +153,7 @@ class BackgroundTaskManager:
             record.update(changes)
             record["updated_at"] = _timestamp()
             await self._save()
-            return dict(record)
+            return copy.deepcopy(record)
 
     async def get(self, task_id: str, session_id: str) -> dict[str, Any] | None:
         async with self._lock:
@@ -151,9 +163,24 @@ class BackgroundTaskManager:
             record = self._records.get(str(task_id or "").strip())
             if record is None:
                 return None
-            if record.get("session_id") != str(session_id or "unknown"):
+            if record.get("plugin_id") or record.get("session_id") != str(
+                session_id or "unknown"
+            ):
                 raise PermissionError("任务不存在或不属于当前会话")
-            return dict(record)
+            return copy.deepcopy(record)
+
+    async def get_for_plugin(
+        self, task_id: str, plugin_id: str
+    ) -> dict[str, Any] | None:
+        async with self._lock:
+            if self._prune_expired():
+                await self._save()
+            record = self._records.get(task_id)
+            if record is None:
+                return None
+            if record.get("plugin_id") != plugin_id:
+                raise PermissionError("任务不属于当前插件")
+            return copy.deepcopy(record)
 
     def attach(
         self,

--- a/tl/background_tasks.py
+++ b/tl/background_tasks.py
@@ -145,14 +145,24 @@ class BackgroundTaskManager:
             await self._save()
             return copy.deepcopy(record)
 
-    async def update(self, task_id: str, **changes: Any) -> dict[str, Any] | None:
+    async def update(
+        self, task_id: str, *, best_effort: bool = False, **changes: Any
+    ) -> dict[str, Any] | None:
         async with self._lock:
             record = self._records.get(task_id)
             if record is None:
                 return None
             record.update(changes)
             record["updated_at"] = _timestamp()
-            await self._save()
+            try:
+                await self._save()
+            except Exception:
+                if not best_effort:
+                    raise
+                logger.error(
+                    f"[后台任务] {task_id} 持久化失败，保留内存中的任务结果",
+                    exc_info=True,
+                )
             return copy.deepcopy(record)
 
     async def get(self, task_id: str, session_id: str) -> dict[str, Any] | None:

--- a/tl/batch_generation.py
+++ b/tl/batch_generation.py
@@ -193,10 +193,9 @@ async def run_batch_job(
             )
             if status == "interrupted":
                 for record in tracker.records_snapshot():
-                    if (
-                        record.get("parent_job_id") == parent_job_id
-                        and record.get("status") == "running"
-                    ):
+                    if record.get("parent_job_id") == parent_job_id and record.get(
+                        "status"
+                    ) in {"queued", "running"}:
                         await tracker.update(
                             record["job_id"], status="interrupted", error=error
                         )

--- a/tl/generation_scheduler.py
+++ b/tl/generation_scheduler.py
@@ -1,0 +1,136 @@
+"""Shared FIFO admission for every image generation entrypoint."""
+
+from __future__ import annotations
+
+import asyncio
+from collections import deque
+from contextlib import contextmanager
+from contextvars import ContextVar
+from functools import wraps
+
+from .api_types import APIError
+
+_PROGRESS = ContextVar("generation_progress", default=None)
+_RESERVATION = ContextVar("generation_reservation", default=None)
+
+
+@contextmanager
+def generation_progress(callback):
+    if callback is None:
+        yield
+        return
+    token = _PROGRESS.set(callback)
+    try:
+        yield
+    finally:
+        _PROGRESS.reset(token)
+
+
+@contextmanager
+def generation_reservation(ticket):
+    token = _RESERVATION.set(ticket)
+    try:
+        yield
+    finally:
+        _RESERVATION.reset(token)
+
+
+class GenerationTicket:
+    def __init__(self, scheduler):
+        self.scheduler = scheduler
+        self.future = asyncio.get_running_loop().create_future()
+        self.granted = False
+        self.released = False
+        self.claimed = False
+
+    def release(self):
+        if self.released:
+            return
+        self.released = True
+        if self.granted:
+            self.scheduler.active -= 1
+        else:
+            self.scheduler.waiters.remove(self)
+        if not self.future.done():
+            self.future.cancel()
+        self.scheduler._advance()
+
+
+class GenerationScheduler:
+    def __init__(self, concurrency=3, queue_size=100):
+        self.concurrency = concurrency
+        self.queue_size = queue_size
+        self.active = 0
+        self.waiters = deque()
+        self.closed = False
+        self.running = set()
+
+    @property
+    def accepting(self):
+        return not self.closed and (
+            self.active < self.concurrency or len(self.waiters) < self.queue_size
+        )
+
+    @property
+    def busy(self):
+        return bool(self.active or self.waiters)
+
+    def reserve(self):
+        if not self.accepting:
+            raise APIError(
+                "生成服务正在关闭" if self.closed else "生成队列已满，请稍后重试",
+                None,
+                "service_closed" if self.closed else "queue_full",
+                retryable=False,
+            )
+        ticket = GenerationTicket(self)
+        self.waiters.append(ticket)
+        self._advance()
+        return ticket
+
+    def _advance(self):
+        while not self.closed and self.waiters and self.active < self.concurrency:
+            ticket = self.waiters.popleft()
+            ticket.granted = True
+            self.active += 1
+            ticket.future.set_result(None)
+
+    async def close(self):
+        self.closed = True
+        for ticket in list(self.waiters):
+            ticket.release()
+        tasks = [task for task in self.running if task is not asyncio.current_task()]
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+
+def scheduled_generation(function):
+    @wraps(function)
+    async def call(owner, *args, **kwargs):
+        scheduler = getattr(owner, "generation_scheduler", None)
+        if scheduler is None:
+            return await function(owner, *args, **kwargs)
+        ticket = _RESERVATION.get()
+        if ticket is None or ticket.claimed:
+            ticket = scheduler.reserve()
+        ticket.claimed = True
+        task = asyncio.current_task()
+        scheduler.running.add(task)
+        progress = _PROGRESS.get()
+        try:
+            if progress and not ticket.granted:
+                await progress("queued")
+            await asyncio.shield(ticket.future)
+            if scheduler.closed:
+                raise asyncio.CancelledError
+            if progress:
+                await progress("running")
+            # Provider retry clocks start inside the wrapped call, after admission.
+            return await function(owner, *args, **kwargs)
+        finally:
+            scheduler.running.discard(task)
+            ticket.release()
+
+    return call

--- a/tl/generation_tracker.py
+++ b/tl/generation_tracker.py
@@ -28,7 +28,7 @@ TERMINAL_STATUSES = {
     "failed",
     "interrupted",
 }
-_KNOWN_SOURCES = {"command", "llm_tool", "llm_batch", "webui"}
+_KNOWN_SOURCES = {"command", "llm_tool", "llm_batch", "webui", "plugin"}
 _SAFE_FILE_NAME = re.compile(r"^[A-Za-z0-9_.-]+$")
 _PARAM_KEYS = (
     "resolution",
@@ -81,6 +81,7 @@ class TrackingContext:
     source: str
     parent_job_id: str | None = None
     item_name: str | None = None
+    managed_externally: bool = False
 
 
 _TRACKING_CONTEXT: ContextVar[TrackingContext | None] = ContextVar(
@@ -94,11 +95,14 @@ def tracking_context(
     source: str,
     parent_job_id: str | None = None,
     item_name: str | None = None,
+    *,
+    managed_externally: bool = False,
 ) -> Iterator[TrackingContext]:
     """在当前异步调用链中传播任务来源和父子关系。"""
     current = _TRACKING_CONTEXT.get()
     value = TrackingContext(
         source=source if source in _KNOWN_SOURCES else "command",
+        managed_externally=managed_externally,
         parent_job_id=_bounded_text(
             parent_job_id
             if parent_job_id is not None
@@ -289,7 +293,7 @@ class GenerationTracker:
         changed: list[dict[str, Any]] = []
         finished_at = _timestamp()
         for record in self._jobs.values():
-            if record.get("status") != "running":
+            if record.get("status") not in {"queued", "running"}:
                 continue
             record["status"] = "interrupted"
             record["finished_at"] = finished_at
@@ -331,7 +335,7 @@ class GenerationTracker:
         for group in ordered_groups:
             if len(self._jobs) <= self.max_records:
                 break
-            if any(record.get("status") == "running" for record in group):
+            if any(record.get("status") in {"queued", "running"} for record in group):
                 continue
             if protected.intersection(
                 name for record in group for name in record.get("images") or []
@@ -385,6 +389,9 @@ class GenerationTracker:
             "user_name": _bounded_text(source.get("user_name"), 200),
             "group_id": group_id,
             "chat_type": chat_type,
+            **(
+                {"umo": _bounded_text(source["umo"], 1024)} if source.get("umo") else {}
+            ),
         }
 
     @staticmethod
@@ -422,6 +429,7 @@ class GenerationTracker:
         parent_job_id: str | None = None,
         item_name: str | None = None,
         requested_images: int = 1,
+        caller: dict[str, str] | None = None,
         reference_names: list[str] | None = None,
     ) -> dict[str, Any]:
         if self._closed:
@@ -433,6 +441,12 @@ class GenerationTracker:
                 "parent_job_id": _bounded_text(parent_job_id, 128) or None,
                 "item_name": _bounded_text(item_name, 64) or None,
                 "source": source if source in _KNOWN_SOURCES else "command",
+                "caller": {
+                    "plugin_id": _bounded_text((caller or {}).get("plugin_id"), 128),
+                    "plugin_name": _bounded_text(
+                        (caller or {}).get("plugin_name"), 200
+                    ),
+                },
                 "status": "running",
                 "prompt": _bounded_text(prompt, 2000),
                 "params": self._clean_params(params),
@@ -492,6 +506,7 @@ class GenerationTracker:
                 "error",
                 "stats",
                 "source_urls",
+                "callback_status",
             }
             for key, value in changes.items():
                 if key not in allowed:
@@ -511,7 +526,12 @@ class GenerationTracker:
                     record[key] = self._clean_images(value)
                 elif key == "source_urls":
                     record[key] = self._clean_source_urls(value)
-                elif key == "status" and value in TERMINAL_STATUSES | {"running"}:
+                elif key == "callback_status":
+                    record[key] = _bounded_text(value, 32)
+                elif key == "status" and value in TERMINAL_STATUSES | {
+                    "queued",
+                    "running",
+                }:
                     record[key] = value
             if record.get("status") in TERMINAL_STATUSES:
                 finished_at = str(record.get("finished_at") or _timestamp())
@@ -600,7 +620,7 @@ class GenerationTracker:
         cutoff = _now() - timedelta(hours=max(int(hours), 1))
         records = []
         for record in self._jobs.values():
-            if record.get("status") == "running":
+            if record.get("status") in {"queued", "running"}:
                 records.append(record)
                 continue
             finished = _parse_timestamp(
@@ -623,6 +643,7 @@ class GenerationTracker:
         source: str,
         group_id: str,
         user_id: str,
+        plugin_id: str = "",
     ) -> dict[str, Any]:
         page = min(max(int(page), 1), 100)
         size = min(max(int(size), 1), 100)
@@ -635,6 +656,9 @@ class GenerationTracker:
             if record.get("status") == "failed":
                 continue
             requester = record.get("requester") or {}
+            caller = record.get("caller") or {}
+            if plugin_id and caller.get("plugin_id") != plugin_id:
+                continue
             if source and record.get("source") != source:
                 continue
             if group_id and str(requester.get("group_id") or "") != group_id:
@@ -649,6 +673,8 @@ class GenerationTracker:
                         record.get("item_name"),
                         requester.get("user_name"),
                         record.get("error"),
+                        caller.get("plugin_id"),
+                        caller.get("plugin_name"),
                     )
                 ).casefold()
                 if keyword not in haystack:
@@ -691,7 +717,9 @@ class GenerationTracker:
                 if not targets:
                     failed.append({"job_id": job_id, "error": "记录不存在"})
                     continue
-                if any(record.get("status") == "running" for record in targets):
+                if any(
+                    record.get("status") in {"queued", "running"} for record in targets
+                ):
                     failed.append({"job_id": job_id, "error": "运行中的任务不能删除"})
                     continue
                 with self.gallery_lock:

--- a/tl/help_renderer.py
+++ b/tl/help_renderer.py
@@ -16,10 +16,8 @@ from PIL import Image, ImageDraw, ImageFont
 # 注意：如果自动下载失败，可手动将字体文件放入 tl 目录（支持 .ttf/.otf/.ttc 格式）
 FONT_FILENAME = "NotoSerifCJKsc-SemiBold.otf"
 FONT_DOWNLOAD_URLS = [
-    # GitHub 加速镜像
-    "https://run.pieixan.icu/https://raw.githubusercontent.com/notofonts/noto-cjk/main/Serif/OTF/SimplifiedChinese/NotoSerifCJKsc-SemiBold.otf",
-    "https://gh-proxy.piexian.workers.dev/https://raw.githubusercontent.com/notofonts/noto-cjk/main/Serif/OTF/SimplifiedChinese/NotoSerifCJKsc-SemiBold.otf",
-    # GitHub 原始链接（备用）
+    # 优先使用 Xget 镜像，失败后回退官方源。
+    "https://astrdark.cyou/gh/notofonts/noto-cjk/raw/main/Serif/OTF/SimplifiedChinese/NotoSerifCJKsc-SemiBold.otf",
     "https://raw.githubusercontent.com/notofonts/noto-cjk/main/Serif/OTF/SimplifiedChinese/NotoSerifCJKsc-SemiBold.otf",
 ]
 
@@ -59,7 +57,7 @@ def _get_font_path() -> Path:
         return Path(__file__).parent / FONT_FILENAME
 
 
-async def ensure_font_downloaded() -> bool:
+async def ensure_font_downloaded(proxy: str | None = None) -> bool:
     """
     确保字体文件已下载（仅在 local 模式下需要）
     返回是否成功获取字体
@@ -104,12 +102,22 @@ async def ensure_font_downloaded() -> bool:
 
         import aiohttp
 
-        for url in FONT_DOWNLOAD_URLS:
+        proxy = (
+            proxy
+            or os.environ.get("HTTPS_PROXY")
+            or os.environ.get("https_proxy")
+            or os.environ.get("HTTP_PROXY")
+            or os.environ.get("http_proxy")
+        )
+        routes = [proxy, None] if proxy else [None]
+        for url, download_proxy in (
+            (url, route) for url in FONT_DOWNLOAD_URLS for route in routes
+        ):
             try:
                 logger.debug(f"尝试下载字体: {url}")
                 timeout = aiohttp.ClientTimeout(total=60, connect=10)
                 async with aiohttp.ClientSession(timeout=timeout) as session:
-                    async with session.get(url) as resp:
+                    async with session.get(url, proxy=download_proxy) as resp:
                         if resp.status != 200:
                             logger.debug(f"下载失败: HTTP {resp.status}")
                             continue
@@ -119,8 +127,12 @@ async def ensure_font_downloaded() -> bool:
                             logger.debug(f"下载的文件过小: {len(data)} bytes")
                             continue
 
-                        with open(font_path, "wb") as f:
-                            f.write(data)
+                        # 镜像/代理错误页可能也返回 200，交给实际渲染器验证。
+                        await asyncio.to_thread(
+                            ImageFont.truetype, io.BytesIO(data), 16
+                        )
+
+                        await asyncio.to_thread(font_path.write_bytes, data)
 
                         logger.info(
                             f"✓ 字体下载成功: {font_path} ({len(data) / 1024 / 1024:.1f}MB)"

--- a/tl/image_generator.py
+++ b/tl/image_generator.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any
 
 from astrbot.api import logger
 
+from .generation_scheduler import generation_progress
 from .generation_tracker import current_tracking_context, requester_from_event
 from .thought_signature import log_thought_signature_debug
 from .tl_api import APIError, ApiRequestConfig
@@ -127,6 +128,8 @@ class ImageGenerator:
         if self.tracker is None:
             return None
         context = current_tracking_context()
+        if context and context.managed_externally:
+            return None
         source = (
             context.source if context else ("llm_tool" if is_tool_call else "command")
         )
@@ -379,17 +382,21 @@ The last {final_avatar_count} image(s) provided are User Avatars (marked as opti
                 f"超时配置: is_tool_call={is_tool_call}, per_retry_timeout={per_retry_timeout}s, max_retries={self.max_attempts_per_key}, max_total_time={max_total_time}s"
             )
 
-            (
-                image_urls,
-                image_paths,
-                text_content,
-                thought_signature,
-            ) = await self.api_client.generate_image(
-                config=request_config,
-                max_retries=self.max_attempts_per_key,
-                per_retry_timeout=per_retry_timeout,
-                max_total_time=max_total_time,
-            )
+            async def progress(status):
+                await self.tracker.update(tracking_job_id, status=status)
+
+            with generation_progress(progress if tracking_job_id else None):
+                (
+                    image_urls,
+                    image_paths,
+                    text_content,
+                    thought_signature,
+                ) = await self.api_client.generate_image(
+                    config=request_config,
+                    max_retries=self.max_attempts_per_key,
+                    per_retry_timeout=per_retry_timeout,
+                    max_total_time=max_total_time,
+                )
             self._set_request_stats(
                 {
                     "retry_count": request_config.retry_count,

--- a/tl/plugin_config.py
+++ b/tl/plugin_config.py
@@ -182,6 +182,8 @@ class PluginConfig:
     batch_max_images_per_task: int = 10
     batch_max_tasks: int = 20
     batch_concurrency: int = 3
+    generation_max_concurrency: int = 3
+    generation_max_queue_size: int = 100
     background_task_retention_hours: int = 24
     background_failure_notify_llm: bool = True
 
@@ -751,6 +753,12 @@ class ConfigLoader:
         )
         config.batch_concurrency = _clean_positive_int(
             image_settings.get("batch_concurrency"), 3
+        )
+        config.generation_max_concurrency = _clean_positive_int(
+            image_settings.get("generation_max_concurrency"), 3
+        )
+        config.generation_max_queue_size = _clean_positive_int(
+            image_settings.get("generation_max_queue_size"), 100
         )
         config.background_task_retention_hours = _clean_positive_int(
             image_settings.get("background_task_retention_hours"), 24

--- a/tl/plugin_service.py
+++ b/tl/plugin_service.py
@@ -350,6 +350,8 @@ class ImageGenerationService:
     async def wait_task(
         self, task_id: str, *, plugin_id: str, timeout: float | None = None
     ):
+        if timeout is None:
+            timeout = self.plugin.cfg.total_timeout
         record = await self.get_task(task_id, plugin_id=plugin_id)
         if record["status"] not in TERMINAL_STATUSES:
             event = self._events.setdefault(task_id, asyncio.Event())
@@ -495,8 +497,22 @@ class ImageGenerationService:
         if len(archived) == len(images) and archived:
             paths = [str(tracker.gallery_dir / name) for name in archived]
             urls = []
-        if job_id:
-            await tracker.update(
+        try:
+            # Publish the terminal task before optional history writes. Failed disk
+            # writes must not hide usable images from callers in this process.
+            result = await manager.update(
+                task_id,
+                best_effort=True,
+                status=status,
+                message=error or "生成完成",
+                error=error,
+                generated_images=len(images),
+                image_urls=urls,
+                image_paths=paths,
+                text_content="\n".join(texts),
+                stats=stats,
+            )
+            await self._update_history(
                 job_id,
                 status=status,
                 generated_images=len(images),
@@ -507,30 +523,16 @@ class ImageGenerationService:
                 text_content="\n".join(texts),
                 stats=stats,
                 error=error,
+                callback_status=result.get("callback_status", "none"),
             )
-        result = await manager.update(
-            task_id,
-            status=status,
-            message=error or "生成完成",
-            error=error,
-            generated_images=len(images),
-            image_urls=urls,
-            image_paths=paths,
-            text_content="\n".join(texts),
-            stats=stats,
-        )
-        if job_id:
-            await tracker.update(
-                job_id, callback_status=result.get("callback_status", "none")
-            )
-        event = self._events.pop(task_id, None)
-        if event:
-            event.set()
+        finally:
+            event = self._events.pop(task_id, None)
+            if event:
+                event.set()
         callback = self._callbacks.pop(task_id, None)
         if callback and self._state == "ready":
-            await manager.update(task_id, callback_status="running")
-            if job_id:
-                await tracker.update(job_id, callback_status="running")
+            await manager.update(task_id, best_effort=True, callback_status="running")
+            await self._update_history(job_id, callback_status="running")
             callback_task = asyncio.create_task(callback(copy.deepcopy(result)))
             self._callback_tasks[task_id] = callback_task
             callback_status = "succeeded"
@@ -543,13 +545,25 @@ class ImageGenerationService:
                 logger.warning(f"[插件接入] 任务 {task_id} 完成回调失败", exc_info=True)
             finally:
                 self._callback_tasks.pop(task_id, None)
-            await manager.update(task_id, callback_status=callback_status)
-            if job_id:
-                await tracker.update(job_id, callback_status=callback_status)
+            await manager.update(
+                task_id, best_effort=True, callback_status=callback_status
+            )
+            await self._update_history(job_id, callback_status=callback_status)
         elif callback:
-            await manager.update(task_id, callback_status="interrupted")
-            if job_id:
-                await tracker.update(job_id, callback_status="interrupted")
+            await manager.update(
+                task_id, best_effort=True, callback_status="interrupted"
+            )
+            await self._update_history(job_id, callback_status="interrupted")
+
+    async def _update_history(self, job_id, **changes):
+        if job_id:
+            try:
+                await self.plugin.generation_tracker.update(job_id, **changes)
+            except Exception:
+                logger.error(
+                    f"[插件接入] 历史记录 {job_id} 更新失败，任务结果仍可查询",
+                    exc_info=True,
+                )
 
     async def close(self):
         self._state = "closing"

--- a/tl/plugin_service.py
+++ b/tl/plugin_service.py
@@ -1,0 +1,567 @@
+"""Versioned, same-process image service for other AstrBot plugins."""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import inspect
+import uuid
+from functools import wraps
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit
+
+from astrbot.api import logger
+
+from .background_tasks import TERMINAL_STATUSES
+from .file_uri import file_uri_to_path
+from .generation_scheduler import generation_progress, generation_reservation
+from .generation_tracker import tracking_context
+from .limit_config import validate_umo
+from .provider_capabilities import (
+    candidate_capability,
+    candidate_reference_limit,
+    routing_mode,
+    select_candidates,
+)
+
+
+class PluginServiceError(RuntimeError):
+    def __init__(self, code: str, message: str):
+        self.code = code
+        super().__init__(message)
+
+
+def _submission(function):
+    @wraps(function)
+    async def call(self, *args, **kwargs):
+        completed = asyncio.Event()
+        self._submissions.add(completed)
+        try:
+            return await function(self, *args, **kwargs)
+        finally:
+            self._submissions.discard(completed)
+            completed.set()
+
+    return call
+
+
+def _text(value, name, maximum=128, required=False):
+    if value is None and not required:
+        return ""
+    if not isinstance(value, str):
+        raise PluginServiceError("invalid_request", f"{name} 必须是字符串")
+    value = value.strip()
+    if (
+        (required and not value)
+        or len(value) > maximum
+        or any(ord(c) < 32 for c in value)
+    ):
+        raise PluginServiceError("invalid_request", f"{name} 为空、过长或含控制字符")
+    return value
+
+
+class ImageGenerationService:
+    api_version = 1
+
+    def __init__(self, plugin):
+        self.plugin = plugin
+        self.instance_id = uuid.uuid4().hex
+        self._state = "initializing"
+        self._callbacks = {}
+        self._callback_tasks = {}
+        self._events = {}
+        self._tasks = {}
+        self._started = {}
+        self._submissions = set()
+
+    def initialized(self):
+        self._state = "ready"
+
+    def get_status(self) -> dict[str, Any]:
+        state, reason = self._state, None
+        if state in {"closing", "closed"}:
+            reason = "service_closed"
+        runtime = self.plugin.provider_runtime
+        scheduler = self.plugin.generation_scheduler
+        if state == "ready":
+            if runtime.closed:
+                state, reason = "closing", "service_closing"
+            elif runtime.failed:
+                state, reason = "unavailable", "configuration_failed"
+            elif runtime.updating:
+                state, reason = "unavailable", "configuration_updating"
+            elif not self.plugin.api_client or not self.plugin.cfg.provider_candidates:
+                state, reason = "unavailable", "not_configured"
+        accepting = state == "ready" and scheduler.accepting
+        if state == "ready" and not accepting:
+            reason = "service_closing" if scheduler.closed else "queue_full"
+        return {
+            "api_version": self.api_version,
+            "instance_id": self.instance_id,
+            "state": state,
+            "ready": state == "ready",
+            "accepting_tasks": accepting,
+            "reason": reason,
+            "active_requests": scheduler.active,
+            "queued_requests": len(scheduler.waiters),
+        }
+
+    async def wait_ready(self, timeout: float | None = None):
+        async with asyncio.timeout(timeout):
+            while True:
+                status = self.get_status()
+                if status["ready"]:
+                    return status
+                if status["state"] in {"closing", "closed"}:
+                    raise PluginServiceError(
+                        "service_closed", "服务实例已关闭，请重新获取"
+                    )
+                # Config transactions can change readiness without replacing this facade.
+                await asyncio.sleep(0.1)
+
+    def capabilities(self):
+        candidates = []
+        for candidate in self.plugin.cfg.provider_candidates:
+            capability = copy.deepcopy(candidate_capability(candidate))
+            capability.pop("request_setting_map", None)
+            candidates.append(
+                {
+                    "id": candidate.id,
+                    "provider": candidate.api_type,
+                    "model": candidate.model,
+                    "alias": candidate.model_alias,
+                    "reference_limit": candidate_reference_limit(candidate),
+                    **capability,
+                }
+            )
+        return {
+            "api_version": self.api_version,
+            "max_images_per_task": self.plugin.cfg.batch_max_images_per_task,
+            "candidates": candidates,
+        }
+
+    def _admit(self):
+        status = self.get_status()
+        if not status["accepting_tasks"]:
+            raise PluginServiceError(
+                status["reason"] or "not_ready", "生图服务暂不可接收任务"
+            )
+
+    @_submission
+    async def submit(
+        self,
+        *,
+        plugin_id: str,
+        prompt: str,
+        plugin_name: str = "",
+        umo: str | None = None,
+        requester: dict | None = None,
+        use_rate_limit: bool = False,
+        reference_images: list[str] | None = None,
+        provider: str | None = None,
+        model: str | None = None,
+        image_count: int = 1,
+        resolution: str | None = None,
+        aspect_ratio: str | None = None,
+        negative_prompt: str | None = None,
+        watermark: bool | None = None,
+        quality: str | None = None,
+        on_complete=None,
+    ) -> dict[str, Any]:
+        self._admit()
+        plugin_id = _text(plugin_id, "plugin_id", required=True)
+        plugin_name = _text(plugin_name, "plugin_name", 200)
+        if not isinstance(prompt, str) or not prompt.strip():
+            raise PluginServiceError("invalid_request", "prompt 必须是非空字符串")
+        if (
+            type(image_count) is not int
+            or not 1 <= image_count <= self.plugin.cfg.batch_max_images_per_task
+        ):
+            raise PluginServiceError("invalid_request", "image_count 超出允许范围")
+        if type(use_rate_limit) is not bool or (
+            watermark is not None and type(watermark) is not bool
+        ):
+            raise PluginServiceError("invalid_request", "限流和水印参数必须是布尔值")
+        if umo is not None:
+            try:
+                umo = validate_umo(umo)
+            except ValueError as exc:
+                raise PluginServiceError("invalid_request", str(exc)) from exc
+        if requester is not None and not isinstance(requester, dict):
+            raise PluginServiceError("invalid_request", "requester 必须是对象")
+        requester = {
+            key: _text(value, key, 200)
+            for key, value in (requester or {}).items()
+            if key in {"user_id", "user_name", "group_id", "chat_type"}
+        }
+        requester["umo"] = umo or ""
+        if on_complete is not None and not (
+            inspect.iscoroutinefunction(on_complete)
+            or inspect.iscoroutinefunction(getattr(on_complete, "__call__", None))
+        ):
+            raise PluginServiceError("invalid_request", "on_complete 必须是异步函数")
+        parameters = {
+            "provider": provider,
+            "model": model,
+            "resolution": resolution,
+            "aspect_ratio": aspect_ratio,
+            "negative_prompt": negative_prompt,
+            "quality": quality,
+        }
+        for name, value in parameters.items():
+            if value is not None and not isinstance(value, str):
+                raise PluginServiceError("invalid_request", f"{name} 必须是字符串")
+        refs = await self._references(reference_images)
+        required = {
+            k
+            for k, v in {
+                "negative_prompt": negative_prompt,
+                "watermark": watermark,
+                "quality": quality,
+            }.items()
+            if v is not None
+        }
+        values = {"quality": quality} if quality is not None else {}
+        if not select_candidates(
+            self.plugin.cfg.provider_candidates,
+            provider=provider,
+            model=model,
+            has_reference_images=bool(refs),
+            required_parameters=required,
+            request_values=values,
+        ):
+            raise PluginServiceError(
+                "invalid_request", "没有符合供应商、模型和参数要求的候选"
+            )
+        self._admit()
+        ticket = self.plugin.generation_scheduler.reserve()
+        token = None
+        record = None
+        try:
+            if use_rate_limit:
+                decision = await self.plugin.rate_limiter.acquire(
+                    umo, plugin_id=plugin_id
+                )
+                if not decision.allowed:
+                    raise PluginServiceError(
+                        "rate_limited", decision.message or "请求超过限流额度"
+                    )
+                token = decision.token
+            # Recheck lifecycle after asynchronous quota/storage operations.
+            if self._state != "ready" or self.plugin.provider_runtime.closed:
+                raise PluginServiceError("service_closed", "服务正在关闭")
+            manager = self.plugin.background_task_manager
+            record = await manager.create(
+                session_id=umo or "",
+                kind="plugin",
+                plugin_id=plugin_id,
+                routing_mode=routing_mode(provider, model),
+                message="任务已接收",
+            )
+            task_id = record["task_id"]
+            await manager.update(
+                task_id,
+                status="queued",
+                caller={"plugin_id": plugin_id, "plugin_name": plugin_name},
+                requester=requester,
+                requested_images=image_count,
+                generated_images=0,
+                image_urls=[],
+                image_paths=[],
+                callback_status="pending" if on_complete else "none",
+            )
+            if self._state != "ready" or self.plugin.provider_runtime.closed:
+                raise PluginServiceError("service_closed", "服务正在关闭")
+            if on_complete:
+                self._callbacks[task_id] = on_complete
+            request = dict(
+                parameters,
+                prompt=prompt,
+                image_count=image_count,
+                watermark=watermark,
+                reference_images=refs,
+                requester=requester,
+                caller={"plugin_id": plugin_id, "plugin_name": plugin_name},
+            )
+            task = manager.attach(task_id, self._run(task_id, request, ticket))
+            self._started[task_id] = asyncio.Event()
+            self._tasks[task_id] = task
+
+            def finished(done):
+                self._tasks.pop(task_id, None)
+                self._started.pop(task_id, None)
+
+            task.add_done_callback(finished)
+            return {
+                "task_id": task_id,
+                "status": "queued",
+                "instance_id": self.instance_id,
+            }
+        except BaseException:
+            ticket.release()
+            await self.plugin.rate_limiter.refund(token)
+            if record:
+                await self.plugin.background_task_manager.update(
+                    record["task_id"], status="interrupted", message="任务提交未完成"
+                )
+            raise
+
+    async def _references(self, refs):
+        if refs is None:
+            return []
+        if not isinstance(refs, list) or any(
+            not isinstance(ref, str) or not ref.strip() for ref in refs
+        ):
+            raise PluginServiceError(
+                "invalid_request", "reference_images 必须是图片 URL 或本地路径列表"
+            )
+        result = []
+        for ref in refs:
+            ref = ref.strip()
+            if ref.startswith(("http://", "https://")):
+                if not urlsplit(ref).hostname:
+                    raise PluginServiceError("invalid_request", "无效参考图 URL")
+            else:
+                path = Path(file_uri_to_path(ref) or ref)
+                if not path.is_absolute() or not await asyncio.to_thread(path.is_file):
+                    raise PluginServiceError(
+                        "invalid_request", "参考图必须是存在的本地绝对路径或 HTTP URL"
+                    )
+                ref = str(path)
+            result.append(ref)
+        return list(dict.fromkeys(result))
+
+    async def get_task(self, task_id: str, *, plugin_id: str):
+        if self._state in {"closing", "closed"}:
+            raise PluginServiceError("service_closed", "服务实例已关闭，请重新获取")
+        if _text(task_id, "task_id", required=True) != task_id:
+            raise PluginServiceError(
+                "invalid_request", "请使用提交时返回的完整 task_id"
+            )
+        plugin_id = _text(plugin_id, "plugin_id", required=True)
+        record = await self.plugin.background_task_manager.get_for_plugin(
+            task_id, plugin_id
+        )
+        if record is None:
+            raise PluginServiceError("task_not_found", "任务不存在或已过期")
+        return record
+
+    async def wait_task(
+        self, task_id: str, *, plugin_id: str, timeout: float | None = None
+    ):
+        record = await self.get_task(task_id, plugin_id=plugin_id)
+        if record["status"] not in TERMINAL_STATUSES:
+            event = self._events.setdefault(task_id, asyncio.Event())
+            await asyncio.wait_for(event.wait(), timeout)
+        return await self.get_task(task_id, plugin_id=plugin_id)
+
+    async def cancel_task(self, task_id: str, *, plugin_id: str):
+        record = await self.get_task(task_id, plugin_id=plugin_id)
+        if record["status"] not in TERMINAL_STATUSES:
+            task = self._tasks.get(task_id)
+            if task:
+                await self._started[task_id].wait()
+                task.cancel()
+                await asyncio.gather(task, return_exceptions=True)
+        return await self.get_task(task_id, plugin_id=plugin_id)
+
+    async def remove_callback(self, task_id: str, *, plugin_id: str):
+        await self.get_task(task_id, plugin_id=plugin_id)
+        removed = self._callbacks.pop(task_id, None) is not None
+        if removed:
+            record = await self.plugin.background_task_manager.update(
+                task_id, callback_status="removed"
+            )
+            if record.get("job_id"):
+                await self.plugin.generation_tracker.update(
+                    record["job_id"], callback_status="removed"
+                )
+        return removed
+
+    async def _run(self, task_id, request, ticket):
+        self._started[task_id].set()
+        manager = self.plugin.background_task_manager
+        tracker = self.plugin.generation_tracker
+        job_id = None
+        images, texts, stats = [], [], {}
+        error = None
+        status = "failed"
+        try:
+            if tracker.enabled:
+                history = await tracker.begin(
+                    source="plugin",
+                    prompt=request["prompt"],
+                    params=request,
+                    requester=request["requester"],
+                    caller=request["caller"],
+                    requested_images=request["image_count"],
+                    reference_names=[
+                        Path(ref).name
+                        for ref in request["reference_images"]
+                        if Path(ref).parent == tracker.gallery_dir
+                    ],
+                )
+                job_id = history["job_id"]
+            await manager.update(task_id, job_id=job_id)
+
+            async def progress(value):
+                await manager.update(task_id, status=value)
+                if job_id:
+                    await tracker.update(job_id, status=value)
+
+            with (
+                generation_reservation(ticket),
+                generation_progress(progress),
+                tracking_context("plugin", managed_externally=True),
+            ):
+                while len(images) < request["image_count"]:
+                    (
+                        success,
+                        result,
+                    ) = await self.plugin.image_generator.generate_image_core(
+                        event=None,
+                        prompt=request["prompt"],
+                        reference_images=request["reference_images"],
+                        avatar_reference=[],
+                        override_resolution=request["resolution"],
+                        override_aspect_ratio=request["aspect_ratio"],
+                        requested_provider=request["provider"],
+                        requested_model=request["model"],
+                        image_count=request["image_count"] - len(images),
+                        is_tool_call=False,
+                        negative_prompt=request["negative_prompt"],
+                        watermark=request["watermark"],
+                        quality=request["quality"],
+                    )
+                    stats = self.plugin.image_generator.get_request_stats()
+                    if not success:
+                        error = str(result)
+                        break
+                    urls, paths, text, _signature = result
+                    fresh = [
+                        value
+                        for value in dict.fromkeys([*urls, *paths])
+                        if value and value not in images
+                    ]
+                    if not fresh:
+                        error = "供应商未返回新的图片"
+                        break
+                    images.extend(fresh[: request["image_count"] - len(images)])
+                    if text:
+                        texts.append(text)
+            status = (
+                "succeeded"
+                if len(images) == request["image_count"]
+                else ("partial_success" if images else "failed")
+            )
+        except asyncio.CancelledError:
+            status, error = "interrupted", "任务已取消或服务已关闭"
+        except Exception:
+            logger.error(f"[插件接入] 任务 {task_id} 执行失败", exc_info=True)
+            status = "partial_success" if images else "failed"
+            error = "图像生成失败，请查看插件日志"
+        finally:
+            ticket.release()
+
+        finish = asyncio.create_task(
+            self._finish(task_id, job_id, images, texts, stats, status, error)
+        )
+        try:
+            await asyncio.shield(finish)
+        except asyncio.CancelledError:
+            callback_task = self._callback_tasks.get(task_id)
+            if callback_task:
+                callback_task.cancel()
+            await finish
+
+    async def _finish(self, task_id, job_id, images, texts, stats, status, error):
+        manager = self.plugin.background_task_manager
+        tracker = self.plugin.generation_tracker
+        urls = [value for value in images if value.startswith(("http://", "https://"))]
+        paths = [value for value in images if value not in urls]
+        archived = []
+        if images and tracker.enabled and status != "interrupted":
+            try:
+                archived = await self.plugin.web_studio_service.archive_images(
+                    urls,
+                    paths,
+                    job_id=job_id,
+                    candidate_id=stats.get("successful_candidate_id"),
+                )
+            except Exception:
+                logger.warning(f"[插件接入] 任务 {task_id} 图片归档失败", exc_info=True)
+        # Prefer the archived local artifacts only when the entire result was preserved.
+        if len(archived) == len(images) and archived:
+            paths = [str(tracker.gallery_dir / name) for name in archived]
+            urls = []
+        if job_id:
+            await tracker.update(
+                job_id,
+                status=status,
+                generated_images=len(images),
+                images=archived,
+                source_urls=[
+                    v for v in images if v.startswith(("http://", "https://"))
+                ],
+                text_content="\n".join(texts),
+                stats=stats,
+                error=error,
+            )
+        result = await manager.update(
+            task_id,
+            status=status,
+            message=error or "生成完成",
+            error=error,
+            generated_images=len(images),
+            image_urls=urls,
+            image_paths=paths,
+            text_content="\n".join(texts),
+            stats=stats,
+        )
+        if job_id:
+            await tracker.update(
+                job_id, callback_status=result.get("callback_status", "none")
+            )
+        event = self._events.pop(task_id, None)
+        if event:
+            event.set()
+        callback = self._callbacks.pop(task_id, None)
+        if callback and self._state == "ready":
+            await manager.update(task_id, callback_status="running")
+            if job_id:
+                await tracker.update(job_id, callback_status="running")
+            callback_task = asyncio.create_task(callback(copy.deepcopy(result)))
+            self._callback_tasks[task_id] = callback_task
+            callback_status = "succeeded"
+            try:
+                await asyncio.wait_for(callback_task, 30)
+            except asyncio.CancelledError:
+                callback_status = "interrupted"
+            except Exception:
+                callback_status = "failed"
+                logger.warning(f"[插件接入] 任务 {task_id} 完成回调失败", exc_info=True)
+            finally:
+                self._callback_tasks.pop(task_id, None)
+            await manager.update(task_id, callback_status=callback_status)
+            if job_id:
+                await tracker.update(job_id, callback_status=callback_status)
+        elif callback:
+            await manager.update(task_id, callback_status="interrupted")
+            if job_id:
+                await tracker.update(job_id, callback_status="interrupted")
+
+    async def close(self):
+        self._state = "closing"
+        await asyncio.gather(*(event.wait() for event in list(self._submissions)))
+        await asyncio.gather(*(event.wait() for event in list(self._started.values())))
+        tasks = list(self._tasks.values())
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+        self._callbacks.clear()
+        for event in self._events.values():
+            event.set()
+        self._events.clear()
+        self._state = "closed"

--- a/tl/provider_application.py
+++ b/tl/provider_application.py
@@ -171,6 +171,7 @@ class ProviderApplication:
         client = plugin.api_client or get_api_client(keys)
         plugin.api_client = client
         client.provider_runtime = plugin.provider_runtime
+        client.generation_scheduler = getattr(plugin, "generation_scheduler", None)
         client.api_keys = keys
         client.current_key_index = 0
         client._candidate_key_indices = {}

--- a/tl/rate_limiter.py
+++ b/tl/rate_limiter.py
@@ -12,6 +12,7 @@ from collections.abc import Callable, Coroutine
 from contextlib import suppress
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
+from urllib.parse import quote
 
 from astrbot.api import logger
 
@@ -93,7 +94,10 @@ class RateLimiter:
                 if not isinstance(buckets, dict):
                     raise ValueError("Invalid rate-limit buckets")
                 for key, bucket in buckets.items():
-                    if key != self.GLOBAL_KEY:
+                    if key.startswith("plugin/") and ":" not in key:
+                        if not key.removeprefix("plugin/").strip():
+                            raise ValueError("Invalid plugin rate-limit key")
+                    elif key != self.GLOBAL_KEY:
                         validate_umo(key)
                     if not isinstance(bucket, list):
                         raise ValueError("Invalid rate-limit bucket")
@@ -209,8 +213,9 @@ class RateLimiter:
         *,
         cost: int = 1,
         event: AstrMessageEvent | None = None,
+        plugin_id: str | None = None,
     ) -> LimitDecision:
-        """预留逻辑任务额度；None 仅供无聊天事件的 Studio 使用。"""
+        """预留逻辑任务额度；无 UMO 的插件按稳定标识使用默认规则。"""
         if type(cost) is not int or not 1 <= cost <= MAX_REQUESTS:
             return LimitDecision(False, "无效的生成任务数量", "input")
         if umo is not None:
@@ -262,13 +267,23 @@ class RateLimiter:
             ]
             if umo is not None:
                 policies.append((umo, "session", self._session_policy(umo)))
+            elif plugin_id:
+                policies.append(
+                    (
+                        f"plugin/{quote(plugin_id, safe='')}",
+                        "plugin",
+                        self.config.default_rate_limit,
+                    )
+                )
             active = [
                 (key, scope, p) for key, scope, p in policies if p.get("enabled", False)
             ]
             denials = []
             for key, scope, policy in active:
                 period, maximum = policy["period_seconds"], policy["max_requests"]
-                label = "全局" if scope == "global" else "当前会话"
+                label = {"global": "全局", "session": "当前会话", "plugin": "当前插件"}[
+                    scope
+                ]
                 if cost > maximum:
                     return LimitDecision(
                         False,

--- a/tl/tl_api.py
+++ b/tl/tl_api.py
@@ -29,6 +29,7 @@ from .api import (
 )
 from .api_headers import apply_api_key_to_headers, extract_api_key_from_headers
 from .api_types import APIError, ApiRequestConfig
+from .generation_scheduler import scheduled_generation
 from .provider_capabilities import (
     apply_request_overrides,
     explicit_runtime_parameters,
@@ -727,6 +728,7 @@ class GeminiAPIClient:
         return req.url, req.headers, req.payload
 
     @provider_operation("api")
+    @scheduled_generation
     async def generate_image(
         self,
         config: ApiRequestConfig,

--- a/tl/web_api.py
+++ b/tl/web_api.py
@@ -295,6 +295,7 @@ class WebStudioAPI:
             source = self._query_text("source", 32)
             group_id = self._query_text("group_id", 128)
             user_id = self._query_text("user_id", 128)
+            plugin_id = self._query_text("plugin_id", 128)
         except StudioServiceError as exc:
             return self._service_error(exc)
         return self._ok(
@@ -305,6 +306,7 @@ class WebStudioAPI:
                 source=source,
                 group_id=group_id,
                 user_id=user_id,
+                **({"plugin_id": plugin_id} if plugin_id else {}),
             )
         )
 

--- a/tl/web_studio_service.py
+++ b/tl/web_studio_service.py
@@ -25,6 +25,7 @@ from PIL import Image, ImageOps, UnidentifiedImageError
 
 from .api_types import ApiRequestConfig
 from .file_uri import file_uri_to_path
+from .generation_scheduler import generation_progress
 from .generation_tracker import (
     TERMINAL_STATUSES,
     GenerationTracker,
@@ -824,7 +825,7 @@ class WebStudioService:
             )
             for child_job_id, _ in child_jobs:
                 record = self.tracker.get(child_job_id)
-                if record and record.get("status") == "running":
+                if record and record.get("status") in {"queued", "running"}:
                     await self.tracker.update(
                         child_job_id,
                         status="interrupted",
@@ -871,19 +872,24 @@ class WebStudioService:
                     generation_settings=payload.get("generation_settings") or None,
                     image_count=remaining,
                 )
+
+                async def progress(status):
+                    await self.tracker.update(job_id, status=status)
+
                 async with self._api_semaphore:
-                    result = await self.api_client.generate_image(
-                        config=request_config,
-                        max_retries=_positive_int(
-                            getattr(self.config, "max_attempts_per_key", 3), 3
-                        ),
-                        per_retry_timeout=_positive_int(
-                            getattr(self.config, "total_timeout", 120), 120
-                        ),
-                        max_total_time=_positive_int(
-                            getattr(self.config, "total_timeout", 120), 120
-                        ),
-                    )
+                    with generation_progress(progress):
+                        result = await self.api_client.generate_image(
+                            config=request_config,
+                            max_retries=_positive_int(
+                                getattr(self.config, "max_attempts_per_key", 3), 3
+                            ),
+                            per_retry_timeout=_positive_int(
+                                getattr(self.config, "total_timeout", 120), 120
+                            ),
+                            max_total_time=_positive_int(
+                                getattr(self.config, "total_timeout", 120), 120
+                            ),
+                        )
                 image_urls, image_paths, text_content, _signature = result
                 # 部分供应商会把同一本地文件同时放入两个列表，计数前先去重。
                 returned = dict.fromkeys(
@@ -1314,7 +1320,7 @@ class WebStudioService:
             names = {
                 str(name) for record in group for name in record.get("images") or []
             }
-            if any(record.get("status") == "running" for record in group):
+            if any(record.get("status") in {"queued", "running"} for record in group):
                 protected.update(names)
         for group in ordered:
             if total <= maximum:


### PR DESCRIPTION
## 改动说明

<!-- 简要描述本次 PR 的改动内容和目的 -->

## 改动类型

- [ ] Bug 修复
- [x] 新功能
- [ ] 重构 / 代码优化
- [ ] 文档更新
- [ ] 其他

## 关联 Issue

<!-- 如有关联 Issue 请填写，例如 Fixes #123 -->

## 测试情况

- [ ] 本地测试通过
- [ ] 已测试相关命令（/生图、/改图、/快速 等）
- [ ] 已测试 LLM 工具调用

## 补充说明

<!-- 需要 reviewer 特别关注的点、兼容性说明等 -->

## Summary by Sourcery

为其他 AstrBot 插件提供可复用的生图服务，并统一管理所有入口的生成调度、任务状态和调用来源。

New Features:
- 新增面向其他 AstrBot 插件的版本化生图服务接口，支持服务状态查询、能力发现、任务提交、等待、查询、取消及完成回调。
- 支持外部插件提交多图生成、参考图、供应商或模型选择、请求来源与使用者信息，并在 WebUI 中展示和筛选插件调用记录。

Bug Fixes:
- 改进中文字体下载流程，支持镜像、官方源及配置或环境代理回退，并在保存前校验字体有效性。

Enhancements:
- 为指令、LLM、Studio 和外部插件统一增加 FIFO 生成并发与队列调度，支持排队状态、队列容量控制及关闭时中断。
- 完善外部插件任务的权限隔离、限流计数、任务持久化、部分成功处理、回调状态管理和服务重载恢复行为。

Documentation:
- 新增其他插件接入 API v1 指南，并补充配置、使用指南及文档索引。

Tests:
- 新增字体下载、统一生成调度器和插件生图服务的覆盖测试，并更新服务关闭及 Studio 前端展示测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为其他 AstrBot 插件提供可复用的生图服务，并统一管理所有入口的生成调度、任务状态和调用来源。

New Features:
- 新增面向其他 AstrBot 插件的版本化生图服务接口，支持服务状态查询、能力发现、任务提交、等待、查询、取消及完成回调。
- 支持外部插件提交多图生成、参考图、供应商或模型选择、请求来源与使用者信息，并在 WebUI 中展示和筛选插件调用记录。

Bug Fixes:
- 改进中文字体下载流程，支持镜像、官方源及配置或环境代理回退，并在保存前校验字体有效性。

Enhancements:
- 为指令、LLM、Studio 和外部插件统一增加 FIFO 生成并发与队列调度，支持排队状态、队列容量控制及关闭时中断。
- 完善外部插件任务的权限隔离、限流计数、任务持久化、部分成功处理、回调状态管理和服务重载恢复行为。

Documentation:
- 新增其他插件接入 API v1 指南，并补充配置、使用指南及文档索引。

Tests:
- 新增字体下载、统一生成调度器和插件生图服务的覆盖测试，并更新服务关闭及 Studio 前端展示测试。

</details>

<details>
<summary>Original summary in English</summary>



</details>