### PR TITLE
feat: 新增 SenseAudio 图片生成供应商

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 > **升级提示**：v1.9.0 以后的配置文件格式不兼容旧版本。升级后如遇配置模板显示错误，请查看 [配置迁移说明](https://github.com/piexian/astrbot_plugin_gemini_image_generation/blob/master/docs/troubleshooting.md#配置迁移说明)。
 
+## [Unreleased]
+
+### Added
+
+- 新增 `senseaudio` 供应商：接入 SenseAudio 同步图片生成与异步提交/查询协议，支持官方列出的 4 个模型、单张参考图、随机种子和模型尺寸白名单；Studio 能力与参考图上限由后端提供。异步查询受剩余总预算约束，轮询失败不在当前候选内重新提交任务。
+
 ## [3.0.1] - 2026-09-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 - **多模式图像生成**：纯文本生图、参考图改图、风格转换、手办化、表情包生成。
 - **快速预设**：头像、海报、壁纸、卡片、手机壁纸、手办化、表情包一键生成。
 - **智能参考图**：自动读取消息图片、引用图片、合并转发、群文件，以及用户头像和 @ 对象头像。
-- **多供应商支持**：Google Gemini、Gemini Interactions（Nano Banana 系列）、Vertex AI（服务账号 JSON / Express API Key 双认证）、OpenAI 兼容、OpenAI Images、Agnes AI、xAI Images、MiniMax、阶跃星辰、豆包、SenseNova、DashScope（通义万相/千问图像/z-image）。
+- **多供应商支持**：Google Gemini、Gemini Interactions（Nano Banana 系列）、Vertex AI（服务账号 JSON / Express API Key 双认证）、OpenAI 兼容、OpenAI Images、Agnes AI、xAI Images、MiniMax、阶跃星辰、豆包、SenseNova、SenseAudio（同步 / 异步图片生成）、DashScope（通义万相/千问图像/z-image）。
 - **供应商与模型路由**：支持供应商、原始模型或别名选择；未指定时按配置轮询，显式指定时只在匹配候选内重试。
 - **LLM 工具集成**：支持自然语言生图、参数能力查询、后台任务查询和命名批量生成；前台超时后返回任务号并继续生成。
 - **插件接入接口**：其他 AstrBot 插件可获取公开服务实例、查询就绪状态并提交后台生图任务，支持查询、等待及完成回调；会话与使用者信息可选。详见 [其他插件接入指南](docs/plugin-api.md)。
@@ -58,6 +58,8 @@ https://github.com/piexian/astrbot_plugin_gemini_image_generation
 - 可选配置 `provider_settings.provider_polling`，按列表从上到下自动尝试生成；重复供应商会自动去重，未知供应商会记录错误并跳过；
 - 使用 `openai_images`、`doubao` 或 `dashscope` 且 `size_mode=custom` 时，配置界面只显示 `custom_size`，避免混用通用分辨率字段。
 
+接入 SenseAudio 时，添加 `senseaudio` 模板并填入 `api_keys` 即可使用默认 Image 2.0 模型；`request_mode` 可选同步或异步。模型尺寸限制和配置示例见 [SenseAudio 配置](docs/config.md#senseaudio图片生成专用配置)。
+
 文档索引：
 
 - [完整配置参考](https://github.com/piexian/astrbot_plugin_gemini_image_generation/blob/master/docs/config.md)
@@ -90,7 +92,7 @@ https://github.com/piexian/astrbot_plugin_gemini_image_generation
 各供应商的端点、参数、尺寸适配规则等完整说明见 [完整配置参考](https://github.com/piexian/astrbot_plugin_gemini_image_generation/blob/master/docs/config.md)：
 
 ```text
-google / gemini_interactions / vertex / openai / agnes_ai / xai / minimax / stepfun / openai_images / doubao / sensenova / dashscope / modelscope / siliconflow
+google / gemini_interactions / vertex / openai / agnes_ai / xai / minimax / stepfun / openai_images / doubao / sensenova / senseaudio / dashscope / modelscope / siliconflow
 ```
 
 ## 项目结构

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -20,6 +20,7 @@
           "openai_images",
           "doubao",
           "sensenova",
+          "senseaudio",
           "dashscope",
           "modelscope",
           "siliconflow"
@@ -1586,6 +1587,135 @@
                   "b64_json",
                   "url"
                 ]
+              }
+            }
+          },
+          "senseaudio": {
+            "description": "SenseAudio 图片生成",
+            "hint": "同步 / 异步图像接口，支持单张参考图和模型专属固定尺寸。",
+            "items": {
+              "enabled": {
+                "description": "启用此条配置",
+                "type": "bool",
+                "default": true
+              },
+              "priority": {
+                "description": "优先级",
+                "type": "int",
+                "hint": "同类型多条配置按优先级从高到低尝试。",
+                "default": 0
+              },
+              "api_keys": {
+                "description": "API Key 列表",
+                "type": "list",
+                "hint": "填写 SenseAudio 开放平台密钥，支持多 Key 轮换。",
+                "default": []
+              },
+              "daily_limit_per_key": {
+                "description": "每个 Key 每日限额",
+                "type": "int",
+                "hint": "0 表示不限制。",
+                "default": 0
+              },
+              "model_alias": {
+                "description": "模型别名（可选）",
+                "type": "string",
+                "default": ""
+              },
+              "model": {
+                "description": "模型名称",
+                "type": "string",
+                "hint": "SenseAudio 图像接口支持的模型；同名模型使用本平台协议和尺寸表。",
+                "default": "senseaudio-image-2.0-260319",
+                "options": [
+                  "senseaudio-image-2.0-260319",
+                  "senseaudio-image-1.0-260319",
+                  "doubao-seedream-5-0-260128",
+                  "sensenova-u1-fast"
+                ]
+              },
+              "api_base": {
+                "description": "API 端点地址",
+                "type": "string",
+                "hint": "填写基址，可带 /v1；不要填写完整生成端点。",
+                "default": "https://api.senseaudio.cn"
+              },
+              "proxy": {
+                "description": "代理地址",
+                "type": "string",
+                "hint": "留空使用全局代理或环境变量。",
+                "default": ""
+              },
+              "request_mode": {
+                "description": "生成模式",
+                "type": "string",
+                "hint": "sync 直接返回图片；async 创建任务后自动查询结果。",
+                "default": "sync",
+                "options": [
+                  "sync",
+                  "async"
+                ]
+              },
+              "resolution": {
+                "description": "图像分辨率档位",
+                "type": "string",
+                "hint": "从官方尺寸白名单选择：先匹配比例，再匹配长边档位。Image 1.0 / U1 Fast 只有固定尺寸；Image 2.0 方图仅 1024。",
+                "default": "1K",
+                "options": [
+                  "1K",
+                  "2K",
+                  "4K"
+                ]
+              },
+              "aspect_ratio": {
+                "description": "长宽比",
+                "type": "string",
+                "hint": "自动匹配当前模型最接近的官方比例。",
+                "default": "1:1",
+                "options": [
+                  "1:1",
+                  "16:9",
+                  "9:16",
+                  "4:3",
+                  "3:4",
+                  "3:2",
+                  "2:3",
+                  "4:5",
+                  "5:4",
+                  "21:9",
+                  "2:1",
+                  "1:2"
+                ]
+              },
+              "size": {
+                "description": "固定像素尺寸（可选）",
+                "type": "string",
+                "hint": "如 1536x864；必须在当前模型官方白名单内，填写后覆盖比例和档位。参考图保留原尺寸时不发送。",
+                "default": ""
+              },
+              "max_reference_images": {
+                "description": "最大参考图片数量",
+                "type": "int",
+                "hint": "接口最多接受 1 张参考图，多张按顺序截断。",
+                "default": 1
+              },
+              "seed": {
+                "description": "随机种子",
+                "type": "string",
+                "hint": "留空由服务端随机生成；填写整数固定种子，0 也是有效种子。",
+                "default": ""
+              },
+              "poll_interval": {
+                "description": "轮询间隔（秒）",
+                "type": "float",
+                "hint": "仅 async 生效，范围 0.1–30 秒。",
+                "default": 3
+              },
+              "poll_timeout": {
+                "description": "轮询超时（秒）",
+                "type": "int",
+                "hint": "仅 async 生效，受插件总超时约束；超时不重新提交当前候选任务。",
+                "default": 100
               }
             }
           },

--- a/docs/config.md
+++ b/docs/config.md
@@ -79,7 +79,7 @@ google / openai_images / minimax
 支持的模板：
 
 ```text
-google / gemini_interactions / vertex / openai / agnes_ai / xai / minimax / stepfun / openai_images / doubao / sensenova / dashscope / modelscope / siliconflow
+google / gemini_interactions / vertex / openai / agnes_ai / xai / minimax / stepfun / openai_images / doubao / sensenova / senseaudio / dashscope / modelscope / siliconflow
 ```
 
 下方 `doubao_settings`、`openai_images_settings`、`agnes_ai_settings`、`xai_settings`、`minimax_settings`、`stepfun_settings`、`sensenova_settings`、`dashscope_settings`、`modelscope_settings`、`siliconflow_settings` 章节对应这些模板的专用字段；`gemini_interactions` 无历史投影字段，全部配置都在模板内。代码中的同名 `*_settings` 字段仅作为兼容旧调用的首个候选投影；多候选场景以 `provider_settings.provider_overrides` 和运行时派生的 `provider_settings_by_type` 为准。
@@ -501,6 +501,66 @@ WebUI 中切换为 `size_mode=custom` 后，`resolution` 和 `aspect_ratio` 会�
 官方文档：
 
 - <https://platform.sensenova.cn/docs>
+
+## senseaudio（图片生成专用配置）
+
+在 `provider_settings.provider_overrides` 中添加 `senseaudio` 模板并填写 API Key。此模板接入 SenseAudio 开放平台的独立图片协议，与 `sensenova` 模板分别配置密钥和端点。
+
+| 字段 | 默认值 | 说明 |
+|------|--------|------|
+| `api_keys` | `[]` | SenseAudio API Key，支持多 Key 轮换 |
+| `model` | `senseaudio-image-2.0-260319` | 可选模型见下表 |
+| `api_base` | `https://api.senseaudio.cn` | 基址，可带 `/v1`，不填完整生成路径 |
+| `request_mode` | `sync` | `sync` 同步返回图片；`async` 提交后自动轮询 |
+| `resolution` | `1K` | 自动尺寸的长边目标档位；按模型白名单取最接近值，不保证精确达到档位 |
+| `aspect_ratio` | `1:1` | 自动尺寸优先匹配最接近比例，再比较长边档位 |
+| `size` | 空 | 固定 `宽x高`，必须在当前模型的官方白名单内；覆盖自动比例与档位 |
+| `max_reference_images` | `1` | 最多 1 张参考图，超出按顺序截断；支持 URL / Data URI，本地文件沿用共享转换管道 |
+| `seed` | 空 | 留空由服务端随机生成；填写整数固定种子，`0` 也会发送 |
+| `poll_interval` | `3` | 异步查询间隔，0.1–30 秒 |
+| `poll_timeout` | `100` | 异步查询预算，1–3600 秒，同时受插件剩余总超时约束 |
+
+`enabled`、`priority`、`daily_limit_per_key`、`model_alias`、`proxy` 沿用公共候选配置。
+
+| 模型 | 提示词上限（Unicode 码位） | 自动档位 | 固定尺寸特点 |
+|------|---------------------------|----------|--------------|
+| `senseaudio-image-2.0-260319` | 6000 | 1K / 2K / 4K | 方图仅 `1024x1024`；横竖图最大长边 3840 |
+| `senseaudio-image-1.0-260319` | 2000 | 1K | 7 种尺寸，方图 `1328x1328` |
+| `doubao-seedream-5-0-260128` | 2000 | 2K / 4K | 16 种尺寸；方图 `2048x2048` / `3072x3072` |
+| `sensenova-u1-fast` | 2000 | 2K | 11 种尺寸，方图 `2048x2048` |
+
+尺寸表完整来源为 [同步图片生成文档](https://docs.senseaudio.cn/api-reference/endpoint/image/sync)。例如 Image 2.0 的 `2K + 16:9` 发送 `2048x1152`，`4K + 1:1` 仍发送 `1024x1024`。自动映射不能精确表达的尺寸可填写 `size`。改图启用“保留参考图尺寸”时省略 `size`，由服务端适配，不保证原始像素尺寸（Image 2.0 实测 1024 方图输入返回 2048 方图）；文生图始终发送尺寸。单个上游任务返回一张图，多张生成沿用插件调度。
+
+协议与错误处理：
+
+- 同步：`POST /v1/image/sync`，读取顶层 `url`。
+- 异步：`POST /v1/image/async` 返回 `task_id`；携带同一 Key 查询 `GET /v1/image/pending?task_id=...`，直到 `completed` 或 `failed`。
+- 查询网络故障、HTTP 429/5xx 只继续查询原任务；查询失败或超时不在当前候选内重新提交。插件仍可能按原有路由尝试下一候选，服务端原任务不会被取消。
+- 配置代理时通过候选代理下载生成图；响应缺少图片或下载失败均不重试生成。
+
+最小配置示例：
+
+```json
+{
+  "provider_settings": {
+    "provider_polling": ["senseaudio"],
+    "provider_overrides": [
+      {
+        "__template_key": "senseaudio",
+        "api_keys": ["你的 SenseAudio API Key"],
+        "model": "senseaudio-image-2.0-260319",
+        "api_base": "https://api.senseaudio.cn",
+        "request_mode": "sync",
+        "resolution": "1K",
+        "aspect_ratio": "1:1",
+        "max_reference_images": 1
+      }
+    ]
+  }
+}
+```
+
+文档核对日期：2026-09-08。已读取 [完整目录](https://docs.senseaudio.cn/llms.txt)、[接口概览](https://docs.senseaudio.cn/api-reference/introduction)、[图片能力介绍](https://docs.senseaudio.cn/guides/image/overview)、[模型列表](https://docs.senseaudio.cn/guides/account/model-list)、同步/异步/查询三个图片端点及 [图片 OpenAPI](https://docs.senseaudio.cn/api-reference/endpoint/image/image.openapi.json)。参考图字段按该平台协议处理，不复用其他供应商同名模型的能力限制。平台的语音、音乐、视频和文本接口不属于本插件接入范围。
 
 ## dashscope_settings（DashScope 阿里云百炼专用配置）
 

--- a/docs/新增API供应商.md
+++ b/docs/新增API供应商.md
@@ -24,6 +24,7 @@ tl/
     ├── minimax.py          # MiniMax 图片生成接口
     ├── doubao.py           # 火山引擎 Ark / 豆包 Seedream
     ├── sensenova.py        # SenseNova(商汤日日新)
+    ├── senseaudio.py       # SenseAudio 同步/异步图片生成
     ├── stepfun.py          # StepFun
     ├── modelscope.py       # ModelScope 魔搭社区（异步任务制：提交+轮询）
     ├── siliconflow.py      # SiliconFlow 硅基流动（同步单端点：文生图 + 编辑共用）
@@ -50,6 +51,7 @@ tl/
 | `openai_images` | `OpenAIImagesProvider` | OpenAI `/v1/images/generations` 与 `/v1/images/edits` |
 | `doubao` | `DoubaoProvider` | 火山引擎 Ark / 豆包图片接口（支持 official / Agent Plan 端点） |
 | `sensenova` | `SenseNovaProvider` | SenseNova（商汤日日新）`/v1/images/generations`（仅文生图，11 种固定尺寸） |
+| `senseaudio` | `SenseAudioProvider` | SenseAudio `/v1/image/sync` 或 `/v1/image/async` + `/v1/image/pending`，单参考图、模型专属固定尺寸 |
 | `dashscope` | `DashScopeProvider` | DashScope 原生 multimodal-generation 同步端点（wan2.7 / qwen-image-2.0） |
 | `modelscope` | `ModelScopeProvider` | 魔搭社区 API-Inference 异步任务制（提交 `/v1/images/generations` + 轮询 `/v1/tasks/{id}`，免费单并发兜底渠道） |
 | `siliconflow` | `SiliconFlowProvider` | 硅基流动同步单端点（`/v1/images/generations` 文生图 + 编辑共用，URL 1h 有效即刻下载落盘，Kolors 批量/Qwen-Image 预设/Edit 系列不传尺寸） |

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -134,12 +134,13 @@ def test_all_existing_provider_metadata_remains():
         "openai_images",
         "doubao",
         "sensenova",
+        "senseaudio",
         "dashscope",
         "modelscope",
         "siliconflow",
     ]
     capabilities = catalog_capabilities()
-    assert len(capabilities) == 14
+    assert len(capabilities) == 15
     assert sum(item["supported"] for item in capabilities.values()) == 11
     for api_type in ("agnes_ai", "minimax", "stepfun", "modelscope", "doubao"):
         assert capabilities[api_type]["supported"] is True
@@ -148,7 +149,7 @@ def test_all_existing_provider_metadata_remains():
         next(spec for spec in specs if spec.api_type == "modelscope").max_concurrency
         == 1
     )
-    for api_type in ("sensenova", "dashscope"):
+    for api_type in ("sensenova", "senseaudio", "dashscope"):
         assert capabilities[api_type]["supported"] is False
         assert "暂未接入" in capabilities[api_type]["message"]
         with pytest.raises(ModelCatalogError, match="暂未接入") as error:

--- a/tests/test_provider_config_frontend.py
+++ b/tests/test_provider_config_frontend.py
@@ -194,8 +194,8 @@ await view.open(); assert.equal(calls.filter(call => call.method === 'get').leng
 
 
 def test_all_real_schema_templates_types_enums_conditions_and_new_key_actions():
-    assert len(TEMPLATES) == 14
-    assert sum(len(template["fields"]) for template in TEMPLATES.values()) == 240
+    assert len(TEMPLATES) == 15
+    assert sum(len(template["fields"]) for template in TEMPLATES.values()) == 256
     _run(r"""
 const view = create(); await view.open();
 for (const [type, template] of Object.entries(TEMPLATES)) {

--- a/tests/test_provider_registry.py
+++ b/tests/test_provider_registry.py
@@ -18,6 +18,7 @@ _PROVIDER_MODULES = (
     "tl.api.openai_images",
     "tl.api.doubao",
     "tl.api.sensenova",
+    "tl.api.senseaudio",
     "tl.api.dashscope",
     "tl.api.modelscope",
     "tl.api.siliconflow",

--- a/tests/test_senseaudio_provider.py
+++ b/tests/test_senseaudio_provider.py
@@ -1,0 +1,404 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import aiohttp
+import pytest
+
+from tl.api.senseaudio import (
+    DEFAULT_MODEL,
+    MODEL_SIZES,
+    SenseAudioProvider,
+    _resolve_size,
+)
+from tl.api_types import APIError, ApiRequestConfig
+from tl.provider_capabilities import candidate_capability, candidate_reference_limit
+
+
+def _config(**kwargs):
+    return ApiRequestConfig(
+        **{
+            "model": DEFAULT_MODEL,
+            "prompt": "画一只猫",
+            "api_type": "senseaudio",
+            "api_key": "test-key",
+            "resolution": "1K",
+            "aspect_ratio": "1:1",
+            **kwargs,
+        }
+    )
+
+
+def _client(proxy=None):
+    return SimpleNamespace(
+        _request_has_proxy=lambda config: bool(proxy),
+        _request_http_proxy=lambda config: proxy,
+        _download_image=AsyncMock(return_value=(None, "/tmp/result.png")),
+    )
+
+
+class _Response:
+    def __init__(self, data, status=200):
+        self.data, self.status = data, status
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+    async def text(self):
+        return json.dumps(self.data)
+
+
+class _Session:
+    def __init__(self, *responses):
+        self.responses = list(responses)
+        self.calls = []
+
+    def get(self, url, **kwargs):
+        self.calls.append((url, kwargs))
+        response = self.responses.pop(0)
+        if isinstance(response, BaseException):
+            raise response
+        return response
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["sync", "async"])
+async def test_request_protocol(mode):
+    request = await SenseAudioProvider().build_request(
+        client=_client(),
+        config=_config(
+            api_base="https://relay.example/v1/",
+            resolution="2K",
+            aspect_ratio="16:9",
+            provider_settings={"request_mode": mode, "seed": "0"},
+        ),
+    )
+    assert request.url == f"https://relay.example/v1/image/{mode}"
+    assert request.headers == {
+        "Authorization": "Bearer test-key",
+        "Content-Type": "application/json",
+    }
+    assert request.payload == {
+        "model": DEFAULT_MODEL,
+        "prompt": "画一只猫",
+        "size": "2048x1152",
+        "seed": 0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_default_and_request_seed_override():
+    provider = SenseAudioProvider()
+    request = await provider.build_request(client=_client(), config=_config())
+    assert request.url == "https://api.senseaudio.cn/v1/image/sync"
+    assert request.payload["size"] == "1024x1024"
+    assert "seed" not in request.payload
+    request = await provider.build_request(
+        client=_client(), config=_config(seed=0, provider_settings={"seed": 42})
+    )
+    assert request.payload["seed"] == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "reference,mode",
+    [
+        ("https://cdn.example/ref.png", "url"),
+        ("data:image/png;base64,QUJD", "force_base64"),
+    ],
+)
+async def test_single_reference_and_preserve_size(reference, mode):
+    request = await SenseAudioProvider().build_request(
+        client=_client(),
+        config=_config(
+            reference_images=[reference, "https://cdn.example/ignored.png"],
+            image_input_mode=mode,
+            suppress_resolution=True,
+            provider_settings={"size": "1536x864"},
+        ),
+    )
+    assert request.payload["reference"] == reference
+    assert "size" not in request.payload
+
+
+@pytest.mark.asyncio
+async def test_local_reference_uses_shared_conversion_and_proxy():
+    client = _client()
+    client._normalize_reference_image_input = AsyncMock(
+        return_value=("image/png", "QUJD")
+    )
+    request = await SenseAudioProvider().build_request(
+        client=client,
+        config=_config(
+            reference_images=["/tmp/reference.png"],
+            proxy="http://proxy:8080",
+        ),
+    )
+    assert request.payload["reference"] == "data:image/png;base64,QUJD"
+    assert (
+        client._normalize_reference_image_input.call_args.kwargs["request_proxy"]
+        == "http://proxy:8080"
+    )
+
+
+@pytest.mark.asyncio
+async def test_text_generation_still_requires_size_when_suppressed():
+    request = await SenseAudioProvider().build_request(
+        client=_client(), config=_config(suppress_resolution=True)
+    )
+    assert request.payload["size"] == "1024x1024"
+
+
+@pytest.mark.parametrize(
+    "model,expected",
+    [
+        (DEFAULT_MODEL, "1024x1024"),
+        ("senseaudio-image-1.0-260319", "1328x1328"),
+        ("doubao-seedream-5-0-260128", "3072x3072"),
+        ("sensenova-u1-fast", "2048x2048"),
+    ],
+)
+def test_model_specific_square_sizes(model, expected):
+    assert _resolve_size(model, "4K", "1:1") == expected
+
+
+@pytest.mark.parametrize("model", list(MODEL_SIZES))
+def test_auto_sizes_always_use_documented_presets(model):
+    for resolution in ("1K", "2K", "4K"):
+        for ratio in ("1:1", "16:9", "9:16", "21:9", "1:8", "8:1", "4:5"):
+            assert _resolve_size(model, resolution, ratio) in MODEL_SIZES[model]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "overrides,error",
+    [
+        ({"model": "unsupported"}, "invalid_model"),
+        ({"api_key": None}, "missing_api_key"),
+        ({"prompt": " "}, "empty_prompt"),
+        ({"prompt": "猫" * 6001}, "prompt_too_long"),
+        ({"model": "sensenova-u1-fast", "prompt": "猫" * 2001}, "prompt_too_long"),
+        ({"provider_settings": {"size": "2048x2048"}}, "invalid_size"),
+        ({"provider_settings": {"request_mode": "other"}}, "invalid_request"),
+        ({"provider_settings": {"seed": "1.5"}}, "invalid_request"),
+        ({"reference_images": [""]}, "invalid_reference_image"),
+    ],
+)
+async def test_invalid_input_is_not_retryable(overrides, error):
+    with pytest.raises(APIError) as exc:
+        await SenseAudioProvider().build_request(
+            client=_client(), config=_config(**overrides)
+        )
+    assert exc.value.error_type == error
+    assert exc.value.retryable is False
+
+
+@pytest.mark.asyncio
+async def test_fixed_size_overrides_mapping():
+    request = await SenseAudioProvider().build_request(
+        client=_client(), config=_config(provider_settings={"size": "3840x1648"})
+    )
+    assert request.payload["size"] == "3840x1648"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("proxy", [None, "http://proxy:8080"])
+async def test_sync_url_response(proxy):
+    client = _client(proxy)
+    result = await SenseAudioProvider().parse_response(
+        client=client,
+        session=object(),
+        response_data={"url": "https://cdn.example/output.png"},
+        http_status=200,
+        request_config=_config(),
+    )
+    assert result == (
+        (["/tmp/result.png"], ["/tmp/result.png"], None, None)
+        if proxy
+        else (["https://cdn.example/output.png"], [], None, None)
+    )
+    if proxy:
+        assert client._download_image.call_args.kwargs["proxy"] == proxy
+
+
+@pytest.mark.asyncio
+async def test_async_pending_then_completed_keeps_task_key_and_proxy(monkeypatch):
+    monkeypatch.setattr("tl.api.senseaudio.asyncio.sleep", AsyncMock())
+    session = _Session(
+        _Response({"status": "pending"}),
+        _Response({}, 500),
+        aiohttp.ClientConnectionError(),
+        _Response({}, 429),
+        _Response({"status": "completed", "url": "https://cdn.example/a.png"}),
+    )
+    config = _config(
+        api_key="submission-key",
+        api_base="https://relay.example/v1",
+        provider_settings={"request_mode": "async"},
+    )
+    result = await SenseAudioProvider().parse_response(
+        client=_client("http://proxy:8080"),
+        session=session,
+        response_data={"task_id": "task&1"},
+        request_config=config,
+        http_status=200,
+    )
+    assert result[1] == ["/tmp/result.png"]
+    assert len(session.calls) == 5
+    for url, kwargs in session.calls:
+        assert url == "https://relay.example/v1/image/pending"
+        assert kwargs["params"] == {"task_id": "task&1"}
+        assert kwargs["headers"]["Authorization"] == "Bearer submission-key"
+        assert kwargs["proxy"] == "http://proxy:8080"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "response,error_type",
+    [
+        (_Response({"status": "failed", "error_message": "生成失败"}), "api_error"),
+        (_Response({"message": "不存在", "ref_code": "404000"}, 404), "api_error"),
+        (_Response({"message": "未认证"}, 401), "api_error"),
+        (_Response({"status": "unknown"}), "invalid_response"),
+        (_Response([]), "invalid_response"),
+        (_Response({"status": "completed"}), "no_image"),
+    ],
+)
+async def test_poll_failure_does_not_resubmit(response, error_type):
+    with pytest.raises(APIError) as exc:
+        await SenseAudioProvider().parse_response(
+            client=_client(),
+            session=_Session(response),
+            response_data={"task_id": "task"},
+            request_config=_config(provider_settings={"request_mode": "async"}),
+        )
+    assert exc.value.error_type == error_type
+    assert exc.value.retryable is False
+
+
+@pytest.mark.asyncio
+async def test_poll_obeys_total_deadline():
+    session = _Session(_Response({"status": "pending"}))
+    config = _config(
+        provider_settings={"request_mode": "async"},
+        request_deadline=asyncio.get_running_loop().time() + 0.02,
+    )
+    with pytest.raises(APIError) as exc:
+        await SenseAudioProvider().parse_response(
+            client=_client(),
+            session=session,
+            response_data={"task_id": "task"},
+            request_config=config,
+        )
+    assert exc.value.error_type == "timeout"
+    assert exc.value.retryable is False
+    assert len(session.calls) == 1
+    assert session.calls[0][1]["timeout"].total <= 0.02
+
+
+@pytest.mark.asyncio
+async def test_download_failure_does_not_repeat_generation():
+    client = _client("http://proxy:8080")
+    client._download_image.return_value = (None, None)
+    with pytest.raises(APIError) as exc:
+        await SenseAudioProvider().parse_response(
+            client=client,
+            session=object(),
+            response_data={"url": "https://cdn.example/a.png"},
+            request_config=_config(),
+        )
+    assert exc.value.error_type == "download_error"
+    assert exc.value.retryable is False
+
+
+@pytest.mark.asyncio
+async def test_poll_cancellation_propagates():
+    with pytest.raises(asyncio.CancelledError):
+        await SenseAudioProvider().parse_response(
+            client=_client(),
+            session=_Session(asyncio.CancelledError()),
+            response_data={"task_id": "task"},
+            request_config=_config(provider_settings={"request_mode": "async"}),
+        )
+
+
+@pytest.mark.asyncio
+async def test_submit_error_retains_code():
+    with pytest.raises(APIError) as exc:
+        await SenseAudioProvider().parse_response(
+            client=_client(),
+            session=object(),
+            response_data={"message": "繁忙", "ref_code": "500000"},
+            http_status=500,
+        )
+    assert exc.value.error_code == "500000"
+    assert exc.value.status_code == 500
+    assert exc.value.retryable is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("async_mode", [False, True])
+async def test_missing_submit_result_does_not_resubmit(async_mode):
+    with pytest.raises(APIError) as exc:
+        await SenseAudioProvider().parse_response(
+            client=_client(),
+            session=object(),
+            response_data={},
+            request_config=_config(
+                provider_settings={"request_mode": "async" if async_mode else "sync"}
+            ),
+        )
+    assert exc.value.retryable is False
+
+
+@pytest.mark.asyncio
+async def test_schema_defaults_load_as_candidate_and_build_request():
+    from tl.api.registry import get_api_provider
+    from tl.plugin_config import ConfigLoader
+    from tl.studio_parameters import generation_fields
+
+    schema = json.loads(
+        (Path(__file__).resolve().parents[1] / "_conf_schema.json").read_text()
+    )
+    settings_schema = schema["provider_settings"]["items"]
+    fields = settings_schema["provider_overrides"]["templates"]["senseaudio"]["items"]
+    settings = {key: value["default"] for key, value in fields.items()}
+    settings["api_keys"] = ["test-key"]
+    settings["__template_key"] = "senseaudio"
+    cfg = ConfigLoader(
+        {
+            "provider_settings": {
+                "provider_polling": ["senseaudio"],
+                "provider_overrides": [settings],
+            }
+        }
+    ).load()
+    assert not cfg.provider_config_errors
+    candidate = cfg.provider_candidates[0]
+    assert candidate.api_type == "senseaudio"
+    assert candidate.supports_image_edit
+    assert candidate_reference_limit(candidate) == 1
+    candidate.settings["max_reference_images"] = 99
+    assert candidate_reference_limit(candidate) == 1
+    assert "senseaudio" in settings_schema["provider_polling"]["options"]
+    request = await get_api_provider("senseaudio").build_request(
+        client=_client(),
+        config=_config(model=candidate.model, provider_settings=candidate.settings),
+    )
+    assert request.payload["size"] == "1024x1024"
+    assert "seed" not in request.payload
+    cap = candidate_capability(candidate)
+    assert cap["native_batch_limit"] == 1
+    assert cap["parameters"]["resolution"]["enum"] == ["1K", "2K", "4K"]
+    assert generation_fields(candidate)["max_reference_images"]["maximum"] == 1
+    candidate.settings["model"] = "senseaudio-image-1.0-260319"
+    assert generation_fields(candidate)["resolution"]["enum"] == ["1K"]
+    candidate.settings["size"] = "1328x1328"
+    assert "resolution" not in generation_fields(candidate)

--- a/tests/test_studio_parameters.py
+++ b/tests/test_studio_parameters.py
@@ -44,6 +44,7 @@ def test_schema_covers_all_generation_fields_without_exposing_connection_values(
         "endpoint_id",
         "model_capability",
         "endpoint_mode",
+        "request_mode",
         "poll_interval",
         "poll_timeout",
         "service_account_files",

--- a/tests/test_studio_providers.py
+++ b/tests/test_studio_providers.py
@@ -212,7 +212,7 @@ async def test_sensitive_urls_are_masked_for_entries_and_common(url):
 async def test_schema_is_complete_and_unconstrained_models_remain_free_text():
     svc = service()
     result = await svc.get_config()
-    assert len(result["templates"]) == 14
+    assert len(result["templates"]) == 15
     assert set(result["common_fields"]) == {
         "proxy",
         "vision_model",

--- a/tl/api/provider_limits.py
+++ b/tl/api/provider_limits.py
@@ -19,6 +19,8 @@ MAX_REFERENCE_IMAGES_MINIMAX: Final[int] = 9
 MAX_REFERENCE_IMAGES_DASHSCOPE_QWEN3: Final[int] = 3
 # sensenova-u1.5-lite 编辑接口官方未给出上限，保守截取
 MAX_REFERENCE_IMAGES_SENSENOVA_U15: Final[int] = 4
+# SenseAudio 的 reference 字段为单个 URL / Data URI。
+MAX_REFERENCE_IMAGES_SENSEAUDIO: Final[int] = 1
 # ModelScope 编辑接口官方仅证实单图输入，保守默认 1 张（用户可在配置调高）
 MAX_REFERENCE_IMAGES_MODELSCOPE: Final[int] = 1
 MAX_REFERENCE_IMAGES_DASHSCOPE: Final[int] = 9

--- a/tl/api/senseaudio.py
+++ b/tl/api/senseaudio.py
@@ -1,0 +1,348 @@
+"""SenseAudio 图片同步生成与异步任务协议（2026-09 核对官方文档）。"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import math
+from typing import Any
+
+import aiohttp
+from astrbot.api import logger
+
+from ..api_types import APIError, ApiRequestConfig
+from .base import ProviderRequest
+from .param_utils import coerce_float, ensure_prompt_length
+from .provider_limits import MAX_REFERENCE_IMAGES_SENSEAUDIO
+from .reference_values import resolve_reference_api_values
+
+DEFAULT_MODEL = "senseaudio-image-2.0-260319"
+DEFAULT_API_BASE = "https://api.senseaudio.cn"
+# 固定白名单来自 image/sync 与 image/async；不能套用原厂同名模型的尺寸。
+MODEL_SIZES: dict[str, tuple[str, ...]] = {
+    DEFAULT_MODEL: tuple(
+        "1024x1024 1536x864 864x1536 2016x864 864x2016 2048x1024 "
+        "1024x2048 2048x1152 1152x2048 2688x1152 1152x2688 2688x1344 "
+        "1344x2688 3840x1648 1648x3840 3840x1920 1920x3840 3840x2160 "
+        "2160x3840".split()
+    ),
+    "senseaudio-image-1.0-260319": tuple(
+        "1664x928 928x1664 1584x1056 1056x1584 1472x1140 1140x1472 1328x1328".split()
+    ),
+    "doubao-seedream-5-0-260128": tuple(
+        "2304x1728 1728x2304 2496x1664 1664x2496 2048x2048 3136x1344 "
+        "2848x1600 1600x2848 3456x2592 2592x3456 2496x3744 3744x2496 "
+        "4096x2304 2304x4096 3072x3072 4704x2016".split()
+    ),
+    "sensenova-u1-fast": tuple(
+        "1664x2496 2496x1664 1760x2368 2368x1760 1824x2272 2272x1824 "
+        "2048x2048 2752x1536 1536x2752 3072x1376 1344x3136".split()
+    ),
+}
+MODEL_RESOLUTIONS = {
+    DEFAULT_MODEL: ("1K", "2K", "4K"),
+    "senseaudio-image-1.0-260319": ("1K",),
+    "doubao-seedream-5-0-260128": ("2K", "4K"),
+    "sensenova-u1-fast": ("2K",),
+}
+MODEL_RATIOS = {
+    DEFAULT_MODEL: ("1:1", "16:9", "9:16", "21:9", "2:1", "1:2"),
+    "senseaudio-image-1.0-260319": ("1:1", "16:9", "9:16", "3:2", "2:3", "4:3", "3:4"),
+    "doubao-seedream-5-0-260128": (
+        "1:1",
+        "4:3",
+        "3:4",
+        "3:2",
+        "2:3",
+        "21:9",
+        "16:9",
+        "9:16",
+    ),
+    "sensenova-u1-fast": (
+        "1:1",
+        "2:3",
+        "3:2",
+        "3:4",
+        "4:3",
+        "4:5",
+        "5:4",
+        "16:9",
+        "9:16",
+        "21:9",
+    ),
+}
+
+
+def _resolve_size(model: str, resolution: str | None, aspect_ratio: str | None) -> str:
+    ratio = 1.0
+    if aspect_ratio:
+        try:
+            width, height = map(float, aspect_ratio.split(":"))
+            if width > 0 and height > 0 and math.isfinite(width / height):
+                ratio = width / height
+        except (ValueError, ZeroDivisionError):
+            pass
+    target = {"1K": 1024, "2K": 2048, "4K": 4096}.get(resolution or "1K", 1024)
+
+    def distance(size: str) -> tuple[float, float]:
+        w, h = map(int, size.split("x"))
+        # 同比例的不同尺寸有像素取整误差，先归入同一比例，再比较长边档位。
+        return round(abs(math.log((w / h) / ratio)), 2), abs(max(w, h) - target)
+
+    return min(MODEL_SIZES[model], key=distance)
+
+
+def _api_base(value: str | None) -> str:
+    base = (value or DEFAULT_API_BASE).strip().rstrip("/")
+    return base[:-3] if base.endswith("/v1") else base
+
+
+class SenseAudioProvider:
+    name = "senseaudio"
+
+    async def build_request(
+        self, *, client: Any, config: ApiRequestConfig, is_retry: bool = False
+    ) -> ProviderRequest:
+        settings = config.provider_settings or {}
+        model = str(config.model or settings.get("model") or DEFAULT_MODEL).strip()
+        if model not in MODEL_SIZES:
+            raise APIError(
+                "SenseAudio 模型不在支持列表中", None, "invalid_model", retryable=False
+            )
+        if not config.api_key:
+            raise APIError(
+                "SenseAudio 缺少 API Key", None, "missing_api_key", retryable=False
+            )
+        prompt = (config.prompt or "").strip()
+        if not prompt:
+            raise APIError(
+                "SenseAudio 需要非空 prompt", None, "empty_prompt", retryable=False
+            )
+        ensure_prompt_length(
+            prompt,
+            max_chars=6000 if model == DEFAULT_MODEL else 2000,
+            provider="SenseAudio",
+        )
+        mode = settings.get("request_mode", "sync")
+        if mode not in ("sync", "async"):
+            raise APIError(
+                "SenseAudio request_mode 必须为 sync 或 async",
+                None,
+                "invalid_request",
+                retryable=False,
+            )
+        payload: dict[str, Any] = {"model": model, "prompt": prompt}
+        if config.reference_images:
+            refs = await resolve_reference_api_values(
+                client,
+                config,
+                config.reference_images,
+                max_count=MAX_REFERENCE_IMAGES_SENSEAUDIO,
+                log_prefix="[senseaudio] ",
+                error_label="senseaudio",
+            )
+            if not refs:
+                raise APIError(
+                    "SenseAudio 未取得有效参考图",
+                    None,
+                    "invalid_reference_image",
+                    retryable=False,
+                )
+            payload["reference"] = refs[0]
+        # 文生图 size 必填；只有参考图请求可让服务端自动适配尺寸。
+        if not (payload.get("reference") and config.suppress_resolution):
+            size = str(settings.get("size") or "").strip()
+            if size and size not in MODEL_SIZES[model]:
+                raise APIError(
+                    "SenseAudio size 不在当前模型的尺寸白名单中",
+                    None,
+                    "invalid_size",
+                    retryable=False,
+                )
+            payload["size"] = size or _resolve_size(
+                model, config.resolution, config.aspect_ratio
+            )
+        seed = config.seed if config.seed is not None else settings.get("seed")
+        if seed is not None and seed != "":
+            try:
+                payload["seed"] = int(seed)
+            except (ValueError, TypeError) as exc:
+                raise APIError(
+                    "SenseAudio seed 必须为整数或留空",
+                    None,
+                    "invalid_request",
+                    retryable=False,
+                ) from exc
+        base = _api_base(config.api_base or settings.get("api_base"))
+        return ProviderRequest(
+            url=f"{base}/v1/image/{mode}",
+            headers={
+                "Authorization": f"Bearer {config.api_key}",
+                "Content-Type": "application/json",
+            },
+            payload=payload,
+        )
+
+    async def parse_response(
+        self,
+        *,
+        client: Any,
+        response_data: dict[str, Any],
+        session: aiohttp.ClientSession,
+        api_base: str | None = None,
+        http_status: int | None = None,
+        request_config: ApiRequestConfig | None = None,
+        is_retry: bool = False,
+    ) -> tuple[list[str], list[str], str | None, str | None]:
+        if http_status is not None and http_status != 200:
+            raise self._error(response_data, http_status)
+        if not isinstance(response_data, dict):
+            raise APIError(
+                "SenseAudio 响应不是对象",
+                http_status,
+                "invalid_response",
+                retryable=False,
+            )
+        settings = getattr(request_config, "provider_settings", None) or {}
+        if settings.get("request_mode", "sync") == "async":
+            task_id = response_data.get("task_id")
+            if not isinstance(task_id, str) or not task_id.strip():
+                raise APIError(
+                    "SenseAudio 响应缺少 task_id",
+                    http_status,
+                    "invalid_response",
+                    retryable=False,
+                )
+            response_data = await self._poll(
+                client=client,
+                session=session,
+                task_id=task_id,
+                base=_api_base(
+                    api_base
+                    or getattr(request_config, "api_base", None)
+                    or settings.get("api_base")
+                ),
+                request_config=request_config,
+                settings=settings,
+            )
+        url = response_data.get("url")
+        if not isinstance(url, str) or not url.startswith(("https://", "http://")):
+            raise APIError(
+                "SenseAudio 响应缺少有效图片 URL",
+                http_status,
+                "no_image",
+                retryable=False,
+            )
+        if client._request_has_proxy(request_config):
+            _, path = await client._download_image(
+                url,
+                session,
+                use_cache=False,
+                proxy=client._request_http_proxy(request_config),
+            )
+            if not path:
+                # 共享下载器失败时返回空路径；不能触发上游重新生成。
+                raise APIError(
+                    "SenseAudio 图片下载失败", None, "download_error", retryable=False
+                )
+            return [path], [path], None, None
+        return [url], [], None, None
+
+    async def _poll(
+        self,
+        *,
+        client: Any,
+        session: aiohttp.ClientSession,
+        task_id: str,
+        base: str,
+        request_config: ApiRequestConfig | None,
+        settings: dict[str, Any],
+    ) -> dict[str, Any]:
+        interval = coerce_float(settings.get("poll_interval"), lo=0.1, hi=30, default=3)
+        timeout = coerce_float(settings.get("poll_timeout"), lo=1, hi=3600, default=100)
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout
+        if request_config and request_config.request_deadline is not None:
+            deadline = min(deadline, request_config.request_deadline)
+        headers = {
+            "Authorization": f"Bearer {getattr(request_config, 'api_key', None)}"
+        }
+        while True:
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                raise APIError(
+                    "SenseAudio 轮询超时；任务可能仍在生成，不再重新提交",
+                    None,
+                    "timeout",
+                    retryable=False,
+                )
+            try:
+                async with session.get(
+                    f"{base}/v1/image/pending",
+                    params={"task_id": task_id},
+                    headers=headers,
+                    proxy=client._request_http_proxy(request_config),
+                    timeout=aiohttp.ClientTimeout(total=min(15, remaining)),
+                ) as response:
+                    status = response.status
+                    body = await response.text()
+            except (aiohttp.ClientError, asyncio.TimeoutError):
+                # 已取得任务 ID，瞬时查询失败只能重查同一任务。
+                logger.warning("[senseaudio] 任务查询连接失败，继续轮询")
+            else:
+                if status == 429 or status >= 500:
+                    logger.warning("[senseaudio] 任务查询 HTTP %s，继续轮询", status)
+                else:
+                    try:
+                        data = json.loads(body)
+                    except json.JSONDecodeError as exc:
+                        raise APIError(
+                            "SenseAudio 查询响应不是 JSON",
+                            status,
+                            "invalid_response",
+                            retryable=False,
+                        ) from exc
+                    if status != 200:
+                        raise self._error(data, status, retryable=False)
+                    if not isinstance(data, dict):
+                        raise APIError(
+                            "SenseAudio 查询响应不是对象",
+                            status,
+                            "invalid_response",
+                            retryable=False,
+                        )
+                    state = data.get("status")
+                    if state == "completed":
+                        return data
+                    if state == "failed":
+                        raise self._error(data, status, retryable=False)
+                    if state != "pending":
+                        raise APIError(
+                            "SenseAudio 返回未知任务状态",
+                            status,
+                            "invalid_response",
+                            retryable=False,
+                        )
+            await asyncio.sleep(min(interval, max(0, deadline - loop.time())))
+
+    @staticmethod
+    def _error(
+        data: Any, status: int | None, retryable: bool | None = None
+    ) -> APIError:
+        message = (
+            (data.get("error_message") or data.get("message"))
+            if isinstance(data, dict)
+            else None
+        )
+        code = (
+            (data.get("ref_code") or data.get("code"))
+            if isinstance(data, dict)
+            else None
+        )
+        return APIError(
+            f"SenseAudio 请求失败: {message or f'HTTP {status}'}",
+            status,
+            "api_error",
+            str(code) if code is not None else None,
+            retryable=retryable,
+        )

--- a/tl/provider_capabilities.py
+++ b/tl/provider_capabilities.py
@@ -359,6 +359,34 @@ def sensenova_capability(candidate: Any) -> dict[str, Any]:
     )
 
 
+def senseaudio_capability(candidate: Any) -> dict[str, Any]:
+    from .api.senseaudio import DEFAULT_MODEL, MODEL_RATIOS, MODEL_RESOLUTIONS
+
+    model = _model(candidate) or DEFAULT_MODEL
+    profile = _profile(
+        candidate,
+        parameters={
+            "resolution": {
+                "type": "string",
+                "enum": list(MODEL_RESOLUTIONS.get(model, ("1K",))),
+                "default_source": "provider_config",
+            },
+            "aspect_ratio": {
+                "type": "string",
+                "enum": list(MODEL_RATIOS.get(model, ("1:1",))),
+                "default_source": "provider_config",
+            },
+            "seed": {"type": "integer", "default_source": "provider_config"},
+        },
+    )
+    if _settings(candidate).get("size"):
+        # 固定尺寸覆盖自动映射，避免工作台继续提供无效的比例/档位覆盖。
+        for name in ("resolution", "aspect_ratio"):
+            profile["parameters"].pop(name)
+        profile["unsupported_settings"] = {"resolution", "aspect_ratio"}
+    return profile
+
+
 def dashscope_capability(candidate: Any) -> dict[str, Any]:
     settings = _settings(candidate)
     model = _model(candidate).lower()
@@ -486,6 +514,7 @@ def candidate_reference_limit(candidate: Any) -> int:
         "openai": limits.MAX_REFERENCE_IMAGES_OPENAI_COMPAT,
         "minimax": limits.MAX_REFERENCE_IMAGES_MINIMAX,
         "sensenova": limits.MAX_REFERENCE_IMAGES_SENSENOVA_U15,
+        "senseaudio": limits.MAX_REFERENCE_IMAGES_SENSEAUDIO,
         "stepfun": 1,
     }.get(api_type, configured)
     if api_type == "xai":

--- a/tl/provider_metadata.py
+++ b/tl/provider_metadata.py
@@ -123,6 +123,14 @@ _PROVIDER_SPECS: Final[tuple[ProviderSpec, ...]] = (
         capability_profile_path="tl.provider_capabilities.sensenova_capability",
     ),
     ProviderSpec(
+        "senseaudio",
+        "tl.api.senseaudio.SenseAudioProvider",
+        capability_profile_path="tl.provider_capabilities.senseaudio_capability",
+        parse_errors_with_provider=True,
+        # 异步轮询使用提交时的 Key，轮换后需要同步 request config。
+        rebuild_on_retry=True,
+    ),
+    ProviderSpec(
         "dashscope",
         "tl.api.dashscope.DashScopeProvider",
         settings_attr="dashscope_settings",


### PR DESCRIPTION
## 改动说明

新增 `senseaudio` 供应商模板，支持 SenseAudio Image 2.0 / Image 1.0、Doubao Seedream 5.0 Lite 和 SenseNova U1 Fast。配置 Key 后默认调用同步图片接口，也可选择异步提交和任务轮询；文生图与单张参考图编辑共用该平台协议。

- 按模型官方尺寸白名单映射比例和分辨率，支持固定尺寸、种子、URL/Data URI 参考图及候选代理。
- 异步查询沿用提交时的 Key，受剩余总预算约束；查询失败或超时不在当前候选内重新提交，保留插件原有下一候选路由。
- 同步 ProviderSpec、配置模板、Studio 能力与参考图上限、文档和相关回归测试。
- 版本号保持 v3.0.1，变更记录写入 Unreleased。

## 改动类型

- [x] 新功能
- [x] 文档更新

## 测试情况

- Ruff 检查与格式检查、Studio JS 语法检查、schema/metadata 解析、diff 检查通过。
- 完整 pytest：1304 通过、1 项既有失败。`test_metadata_only_declares_tested_qq_official_transport` 要求不声明 `qq_official_webhook`，但现有 metadata 已声明；本次未修改该测试和平台元数据。
- Image 2.0 真实同步文生图：通过配置加载 → 候选路由 → 共享 API 客户端 → 响应解析 → 下载链路，生成与下载均 HTTP 200，1024×1024 PNG，约 50.67 秒。
- Image 2.0 真实同步图生图：本地 JPEG 经共享管道转换为 Data URI，成功为参考猫图添加蓝色围巾；生成与下载均 HTTP 200，2048×2048 PNG，约 92.67 秒。
- 异步提交/轮询、错误和超时路径使用 mock 回归覆盖，未调用真实异步接口。未启动完整 AstrBot 或验证消息发送与 LLM 工具触发。

## 补充说明

- 图生图省略 `size` 时由服务端适配，并不保证原始像素尺寸；实测 1024 方图输入返回 2048 方图，配置文档已说明。
- 原 PNG 参考图形成约 2.34 MB 请求时曾连接重置，同尺寸 JPEG 形成约 254 KB 请求后成功，原因尚未确定；没有据此添加未经证实的大小限制或自动压缩规则。

官方协议参考：https://docs.senseaudio.cn/api-reference/endpoint/image/sync

## Sourcery 摘要

接入 SenseAudio 图片生成平台并完善其配置、Studio 能力、异步任务处理和文档支持。

新功能：
- 新增 SenseAudio 图片生成供应商，支持 SenseAudio Image 2.0/Image 1.0、Doubao Seedream 5.0 Lite 和 SenseNova U1 Fast。
- 支持同步生成、异步任务提交与轮询、文生图、单张参考图编辑、种子及模型尺寸适配。

增强功能：
- 将 SenseAudio 能力、模型参数、参考图限制和候选路由集成到 ProviderSpec、Studio 与配置系统中。
- 完善异步任务的超时、查询失败和下载失败处理，避免已提交任务被重复生成。

文档：
- 补充 SenseAudio 配置示例、模型尺寸白名单、协议说明及 README 供应商列表。
- 新增未发布变更记录。

测试：
- 新增 SenseAudio 请求构建、尺寸映射、参考图处理、同步响应、异步轮询及错误路径回归测试。
- 更新供应商目录、配置模板和 Studio 相关测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

接入 SenseAudio 图片生成平台并完善其配置、Studio 能力、异步任务处理和文档支持。

New Features:
- 新增 SenseAudio 图片生成供应商，支持 SenseAudio Image 2.0/Image 1.0、Doubao Seedream 5.0 Lite 和 SenseNova U1 Fast。
- 支持同步生成、异步任务提交与轮询、文生图、单张参考图编辑、种子及模型尺寸适配。

Enhancements:
- 将 SenseAudio 能力、模型参数、参考图限制和候选路由集成到 ProviderSpec、Studio 与配置系统中。
- 完善异步任务的超时、查询失败和下载失败处理，避免已提交任务被重复生成。

Documentation:
- 补充 SenseAudio 配置示例、模型尺寸白名单、协议说明及 README 供应商列表。
- 新增 Unreleased 变更记录。

Tests:
- 新增 SenseAudio 请求构建、尺寸映射、参考图处理、同步响应、异步轮询及错误路径回归测试。
- 更新供应商目录、配置模板和 Studio 相关测试。

</details>